### PR TITLE
Remove splitting executed commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,4 @@ repos:
   - id: go-revive-repo-mod
   - id: go-staticcheck-mod
   - id: go-sec-repo-mod
-    args: ["-exclude=G204,G104", "-exclude-generated"]
+    args: ["-exclude=G204,G304", "-exclude-generated"]

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -42,9 +42,7 @@ func listCmd() *cobra.Command {
 				table.EndRow()
 			}
 
-			table.Render()
-
-			return nil
+			return errors.Wrap(table.Render(), "failed to render")
 		},
 	}
 	return &cmd

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stateful/rdme/internal/parser"
 )
 
 var (
@@ -30,4 +35,13 @@ func Root() *cobra.Command {
 	cmd.AddCommand(tasksCmd())
 
 	return &cmd
+}
+
+func newParser() (*parser.Parser, error) {
+	source, err := os.ReadFile(filepath.Join(chdir, fileName))
+	if err != nil {
+		return nil, errors.Wrap(err, "fail to read README file")
+	}
+
+	return parser.New(source), nil
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -6,14 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 
-	"github.com/google/shlex"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/stateful/rdme/internal/parser"
 )
 
 func runCmd() *cobra.Command {
@@ -41,11 +38,6 @@ func runCmd() *cobra.Command {
 			return filtered, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO: like can omit because Args should do the validation.
-			if len(args) != 1 {
-				return cmd.Help()
-			}
-
 			p, err := newParser()
 			if err != nil {
 				return errors.Wrap(err, "fail to read README file")
@@ -53,7 +45,7 @@ func runCmd() *cobra.Command {
 
 			snippets := p.Snippets()
 
-			snippet, found := p.Snippets().Lookup(args[0])
+			snippet, found := snippets.Lookup(args[0])
 			if !found {
 				return errors.Errorf("command %q not found; known command names: %s", args[0], snippets.Names())
 			}
@@ -76,10 +68,6 @@ func runCmd() *cobra.Command {
 			stdin := cmd.InOrStdin()
 			stdout, stderr := cmd.OutOrStdout(), cmd.ErrOrStderr()
 
-			if len(snippet.Cmds()) == 1 {
-				return execSingle(ctx, sh, snippet.FirstCmd(), stdin, stdout, stderr)
-			}
-
 			for _, cmd := range snippet.Cmds() {
 				if err := execSingle(ctx, sh, cmd, stdin, stdout, stderr); err != nil {
 					return err
@@ -94,25 +82,11 @@ func runCmd() *cobra.Command {
 }
 
 func execSingle(ctx context.Context, sh, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
-	fragments, err := shlex.Split(cmd)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse command %q", cmd)
-	}
-
-	c := exec.CommandContext(ctx, sh, []string{"-c", strings.Join(fragments, " ")}...)
+	c := exec.CommandContext(ctx, sh, []string{"-c", cmd}...)
 	c.Dir = chdir
 	c.Stderr = stderr
 	c.Stdout = stdout
 	c.Stdin = stdin
 
-	return errors.Wrapf(c.Run(), "failed to run command %s", cmd)
-}
-
-func newParser() (*parser.Parser, error) {
-	source, err := os.ReadFile(filepath.Join(chdir, fileName))
-	if err != nil {
-		return nil, errors.Wrap(err, "fail to read README file")
-	}
-
-	return parser.New(source), nil
+	return errors.Wrapf(c.Run(), "failed to run command %q", cmd)
 }

--- a/internal/parser/parse_snippets_test.go
+++ b/internal/parser/parse_snippets_test.go
@@ -53,4 +53,16 @@ go run main.go
 	snippets4 := p4.Snippets()
 	assert.Len(t, snippets4, 1)
 	assert.EqualValues(t, []string{"run"}, snippets4.Names())
+
+	p5 := New([]byte(`
+Feedback can be patched:
+` + "```sh { name=patch-feedback }" + `
+$ curl -X PATCH -H "Content-Type: application/json" localhost:8080/feedback/a02b6b5f-46c4-40ff-8160-ff7d55b8ca6f/ -d '{"message": "Modified!"}'
+{"id":"a02b6b5f-46c4-40ff-8160-ff7d55b8ca6f"}
+` + "```"))
+	snippets5 := p5.Snippets()
+	assert.Len(t, snippets5, 1)
+	assert.EqualValues(t, []string{"patch-feedback"}, snippets5.Names())
+	p5Snippet, _ := snippets5.Lookup("patch-feedback")
+	assert.Equal(t, []string{`curl -X PATCH -H "Content-Type: application/json" localhost:8080/feedback/a02b6b5f-46c4-40ff-8160-ff7d55b8ca6f/ -d '{"message": "Modified!"}'`}, p5Snippet.Cmds())
 }


### PR DESCRIPTION
It removes usage of https://github.com/google/shlex as rdme executes found commands as strings using `$SHELL -c`. Parsing and joining them will remove quotes and possibly escapes.

Closes https://github.com/stateful/rdme/issues/6