### PR TITLE
Fix executing nested shell scripts

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -97,21 +97,19 @@ func replace(block *document.CodeBlock, scripts []string) error {
 		return nil
 	}
 
-	content := block.Content()
-
 	for _, script := range scripts {
 		engine, err := sed.New(strings.NewReader(script))
 		if err != nil {
 			return errors.Wrapf(err, "failed to compile sed script %q", script)
 		}
 
-		content, err = engine.RunString(content)
+		err = block.MapLines(func(s string) (string, error) {
+			return engine.RunString(s)
+		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to run sed script %q", script)
 		}
 	}
-
-	block.SetContent(content)
 
 	return nil
 }

--- a/internal/document/block_test.go
+++ b/internal/document/block_test.go
@@ -2,6 +2,7 @@ package document
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,9 +39,6 @@ $ echo "Hello, runme!"
 	source := NewSource(data)
 	block := source.Parse().CodeBlocks()[0]
 	assert.Equal(t, "$ echo \"Hello, runme!\"\n", block.Content())
-
-	block.SetContent("reset")
-	assert.Equal(t, "reset", block.Content())
 }
 
 func TestCodeBlock_Executable(t *testing.T) {
@@ -75,6 +73,21 @@ func TestCodeBlock_Lines(t *testing.T) {
 		"echo \"2\"",
 		"echo \"3\"",
 	}, blocks[2].Lines())
+}
+
+func TestCodeBlock_MapLines(t *testing.T) {
+	data := []byte("```" + `sh
+echo 1
+echo 2
+echo 3
+` + "```")
+	source := NewSource(data)
+	block := source.Parse().CodeBlocks()[0]
+	err := block.MapLines(func(s string) (string, error) {
+		return strings.Split(s, " ")[1], nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "2", "3"}, block.Lines())
 }
 
 func TestCodeBlock_Name(t *testing.T) {

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/google/shlex"
@@ -77,7 +78,11 @@ func prepareScript(cmds []string) string {
 				detectedWord = true
 			}
 
-			_, _ = b.WriteString(word)
+			if strings.Contains(word, " ") {
+				_, _ = b.WriteString(strconv.Quote(word))
+			} else {
+				_, _ = b.WriteString(word)
+			}
 		}
 	}
 

--- a/internal/runner/shell_test.go
+++ b/internal/runner/shell_test.go
@@ -22,4 +22,9 @@ func TestPrepareScript(t *testing.T) {
 		"-r -f https://deno.land/x/deploy/deployctl.ts",
 	})
 	assert.Equal(t, "set -e -o pipefail;deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts;\n", script)
+
+	script = prepareScript([]string{
+		`pipenv run bash -c 'echo "Some message"'`,
+	})
+	assert.Equal(t, "set -e -o pipefail;pipenv run bash -c \"echo \\\"Some message\\\"\";\n", script)
 }


### PR DESCRIPTION
This is a fix of a regression and makes it possible to execute snippets like `pipenv run bash -c "echo 1"` again.