### PR TITLE
Add raw shell executable to keep newlines

### DIFF
--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -27,6 +27,11 @@ func New(block *document.CodeBlock, base *Base) (Executable, error) {
 			Cmds: block.Lines(),
 			Base: base,
 		}, nil
+	case "sh-raw":
+		return &ShellRaw{
+			Cmds: block.Lines(),
+			Base: base,
+		}, nil
 	case "go":
 		return &Go{
 			Source: block.Content(),

--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -42,7 +42,7 @@ func New(block *document.CodeBlock, base *Base) (Executable, error) {
 	}
 }
 
-var supportedExecutables = map[string]struct{}{"sh": {}, "shell": {}, "go": {}}
+var supportedExecutables = map[string]struct{}{"sh": {}, "shell": {}, "sh-raw": {}, "go": {}}
 
 func IsSupported(block *document.CodeBlock) bool {
 	_, ok := supportedExecutables[block.Executable()]

--- a/internal/runner/shellraw.go
+++ b/internal/runner/shellraw.go
@@ -1,0 +1,44 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+type ShellRaw struct {
+	*Base
+	Cmds []string
+}
+
+var _ Executable = (*Shell)(nil)
+
+func (s *ShellRaw) DryRun(ctx context.Context, w io.Writer) {
+	sh, ok := os.LookupEnv("SHELL")
+	if !ok {
+		sh = "/bin/sh"
+	}
+
+	var b strings.Builder
+
+	_, _ = b.WriteString(fmt.Sprintf("#!%s\n\n", sh))
+	_, _ = b.WriteString(fmt.Sprintf("// run in %q\n\n", s.Dir))
+	_, _ = b.WriteString(strings.Join(s.Cmds, "\n"))
+
+	_, err := w.Write([]byte(b.String()))
+	if err != nil {
+		log.Fatalf("failed to write: %s", err)
+	}
+}
+
+func (s *ShellRaw) Run(ctx context.Context) error {
+	sh, ok := os.LookupEnv("SHELL")
+	if !ok {
+		sh = "/bin/sh"
+	}
+
+	return execSingle(ctx, sh, s.Dir, strings.Join(s.Cmds, "\n"), s.Stdin, s.Stdout, s.Stderr)
+}


### PR DESCRIPTION
runme automatically "minifies" code block, by putting multiple commands into a single line separated by `;` 
I run into 2 issues listed below. Which can be fixed with the introduction of a new Executor called `shell-raw`.

## Multiline for cycle formatted incorrectly

Consider the following example, where its already written in a single line:
```sh {name=1-oneliner}
for i in a b c ; do echo === $i; done
```

now the same for loop but in multiple lines:
```sh {name=2-multiline}
$ for i in a b c ; do
  echo === $i
done
```

the second on will fail, with syntax error:
```
line 1: `set -e -o pipefail;for i in a b c ; do;echo === $i;done;'
```
you can see that the `;` after `do` is not needed. I think you can have the same issue with `if/then`.

## Heredoc

The bash heredoc feature is quite often used in documentations to create a file from bash.
Something like this:
```sh-raw {name=4-heredoc}
cat > Dockerfile <<EOF
FROM alpine
RUN apk add curl
EOF
```
