### PR TITLE
internal/document: improve attrs processing

### DIFF
--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -60,10 +60,8 @@ func newCodeBlock(
 	source []byte,
 	render Renderer,
 ) (*CodeBlock, error) {
-	name := getName(node, source, nameResolver)
-
 	attributes := getAttributes(node, source)
-	attributes["name"] = name
+	name := getName(node, source, nameResolver)
 
 	value, err := render(node, source)
 	if err != nil {

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -45,3 +45,17 @@ First paragraph.
 	assert.Equal(t, "2. Item 2\n", string(node.children[3].children[1].Item().Value()))
 	assert.Equal(t, "3. Item 3\n", string(node.children[3].children[2].Item().Value()))
 }
+
+func TestDocument_Parse_UnsupportedLang(t *testing.T) {
+	data := []byte(`## Non-Supported Languages
+
+` + "```py { readonly=true }" + `
+def hello():
+    print("Hello World")
+` + "```" + `
+`)
+	doc := New(data, cmark.Render)
+	node, _, err := doc.Parse()
+	require.NoError(t, err)
+	assert.Equal(t, string(data), node.String())
+}

--- a/internal/document/edit/cell.go
+++ b/internal/document/edit/cell.go
@@ -153,7 +153,7 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 		return
 	}
 
-	_, _ = w.Write([]byte{' ', '{'})
+	_, _ = w.Write([]byte{' ', '{', ' '})
 
 	// Sort attributes by key, however, keep the element
 	// with the key "name" in front.
@@ -181,7 +181,7 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 		}
 	}
 
-	_, _ = w.Write([]byte{'}'})
+	_, _ = w.Write([]byte{' ', '}'})
 }
 
 func serializeCells(cells []*Cell) []byte {

--- a/internal/document/edit/cell.go
+++ b/internal/document/edit/cell.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/stateful/runme/internal/document"
 	"github.com/yuin/goldmark/ast"
@@ -155,12 +156,16 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 
 	_, _ = w.Write([]byte{' ', '{', ' '})
 
-	// Sort attributes by key, however, keep the element
-	// with the key "name" in front.
+	// Filter out private keys, i.e. starting with "_" or "runme.dev/".
 	keys := make([]string, 0, len(cell.Metadata))
 	for k := range cell.Metadata {
+		if strings.HasPrefix(k, "_") || strings.HasPrefix(k, "runme.dev/") {
+			continue
+		}
 		keys = append(keys, k)
 	}
+	// Sort attributes by key, however, keep the element
+	// with the key "name" in front.
 	slices.SortFunc(keys, func(a, b string) bool {
 		if a == "name" {
 			return true
@@ -176,7 +181,7 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 		v := cell.Metadata[k]
 		_, _ = w.Write([]byte(fmt.Sprintf("%s=%v", k, v)))
 		i++
-		if i < len(cell.Metadata) {
+		if i < len(keys) {
 			_, _ = w.Write([]byte{' '})
 		}
 	}

--- a/internal/document/edit/cell_test.go
+++ b/internal/document/edit/cell_test.go
@@ -248,6 +248,29 @@ pre-commit install
 	)
 }
 
+func Test_serializeCells_attributes(t *testing.T) {
+	data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
+	doc := document.New(data, cmark.Render)
+	node, _, err := doc.Parse()
+	require.NoError(t, err)
+	cells := toCells(node, data)
+	assert.Equal(t, string(data), string(serializeCells(cells)))
+}
+
+func Test_serializeCells_privateFields(t *testing.T) {
+	data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
+	doc := document.New(data, cmark.Render)
+	node, _, err := doc.Parse()
+	require.NoError(t, err)
+
+	cells := toCells(node, data)
+	// Add private fields whcih will be filtered out durign serialization.
+	cells[0].Metadata["_private"] = "private"
+	cells[0].Metadata["runme.dev/internal"] = "internal"
+
+	assert.Equal(t, string(data), string(serializeCells(cells)))
+}
+
 func Test_serializeCells_unknownLang(t *testing.T) {
 	data := []byte(`## Non-Supported Languages
 
@@ -256,15 +279,6 @@ def hello():
     print("Hello World")
 ` + "```" + `
 `)
-	doc := document.New(data, cmark.Render)
-	node, _, err := doc.Parse()
-	require.NoError(t, err)
-	cells := toCells(node, data)
-	assert.Equal(t, string(data), string(serializeCells(cells)))
-}
-
-func Test_serializeCells_attributes(t *testing.T) {
-	data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
 	doc := document.New(data, cmark.Render)
 	node, _, err := doc.Parse()
 	require.NoError(t, err)

--- a/internal/document/edit/cell_test.go
+++ b/internal/document/edit/cell_test.go
@@ -27,7 +27,7 @@ $ echo "Hello, runme!"
 
 1. Item 1
 
-   ` + "```" + `sh {name=echo first= second=2}
+   ` + "```" + `sh {name=echo-2 first= second=2}
    $ echo "Hello, runme!"
    ` + "```" + `
 
@@ -43,7 +43,7 @@ $ echo "Hello, runme!"
 
 It can have an annotation with a name:
 
-` + "```" + `sh {name=echo first= second=2}
+` + "```" + `sh { name=echo first= second=2 }
 $ echo "Hello, runme!"
 ` + "```" + `
 
@@ -56,7 +56,7 @@ $ echo "Hello, runme!"
 
 1. Item 1
 
-` + "```" + `sh {name=echo-2 first= second=2}
+` + "```" + `sh { name=echo-2 first= second=2 }
 $ echo "Hello, runme!"
 ` + "```" + `
 
@@ -234,13 +234,13 @@ func Test_serializeCells_nestedCode(t *testing.T) {
 
 2. Install MacOS dependencies
 
-`+"```"+`sh {name=brew-bundle}
+`+"```"+`sh
 brew bundle --no-lock
 `+"```"+`
 
 3. Setup pre-commit
 
-`+"```"+`sh {name=precommit-install}
+`+"```"+`sh
 pre-commit install
 `+"```"+`
 `,
@@ -248,8 +248,23 @@ pre-commit install
 	)
 }
 
+func Test_serializeCells_unknownLang(t *testing.T) {
+	data := []byte(`## Non-Supported Languages
+
+` + "```py { readonly=true }" + `
+def hello():
+    print("Hello World")
+` + "```" + `
+`)
+	doc := document.New(data, cmark.Render)
+	node, _, err := doc.Parse()
+	require.NoError(t, err)
+	cells := toCells(node, data)
+	assert.Equal(t, string(data), string(serializeCells(cells)))
+}
+
 func Test_serializeCells_attributes(t *testing.T) {
-	data := []byte("```sh {name=echo first= second=2}\necho 1\n```\n")
+	data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
 	doc := document.New(data, cmark.Render)
 	node, _, err := doc.Parse()
 	require.NoError(t, err)


### PR DESCRIPTION
Highlights:
- Remove serializing the `name` attribute if it was not present in the source.
- Add spaces between `{ ... }`.