### PR TITLE
Opt to use node-grpc client for codegen

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -20,3 +20,8 @@ plugins:
   - plugin: buf.build/bufbuild/es
     out: internal/gen/proto/ts
     opt: target=ts
+
+  # Remote plugin. You can switch to a local one by using "timostamm-protobuf-ts".
+  - plugin: buf.build/community/timostamm-protobuf-ts
+    out: internal/gen/proto/ts
+    opt: client_grpc1,optimize_code_size

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -24,4 +24,4 @@ plugins:
   # Remote plugin. You can switch to a local one by using "timostamm-protobuf-ts".
   - plugin: buf.build/community/timostamm-protobuf-ts
     out: internal/gen/proto/ts
-    opt: client_grpc1,optimize_code_size
+    opt: output_javascript,optimize_code_size,long_type_string,add_pb_suffix,ts_nocheck,eslint_disable


### PR DESCRIPTION
This will generate types and implementation code that are compliant with `node-grpc`.

Chose not to commit the generated code yet. I will let you do that post merge, @adambabik.