### PR TITLE
Fix TUI error when no scripts in readme with simple error

### DIFF
--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mgutz/ansi"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/math"
@@ -194,6 +195,10 @@ func tuiCmd() *cobra.Command {
 			blocks, err := getCodeBlocks()
 			if err != nil {
 				return err
+			}
+
+			if len(blocks) == 0 {
+				return errors.New("no scripts in README.md")
 			}
 
 			version := "???"

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -198,7 +198,7 @@ func tuiCmd() *cobra.Command {
 			}
 
 			if len(blocks) == 0 {
-				return errors.New("no scripts in README.md")
+				return errors.Errorf("no scripts in %s", fFileName)
 			}
 
 			version := "???"


### PR DESCRIPTION
Fixes #109 

This takes the simplest solution, which just prints an error message to prevent the TUI from running.