### PR TITLE
Improve run error message

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -44,7 +44,7 @@ Sometimes, shell scripts fail:
 
 ```sh
 echo ok
-false
+exit 1
 ```
 
 ## Go

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,13 @@ popd
 pwd
 ```
 
+Sometimes, shell scripts fail:
+
+```sh
+echo ok
+false
+```
+
 ## Go
 
 It can also execute a snippet of Go code:

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -90,6 +90,7 @@ func newExecutable(cmd *cobra.Command, block *document.CodeBlock) (runner.Execut
 		Stdin:  cmd.InOrStdin(),
 		Stdout: cmd.OutOrStdout(),
 		Stderr: cmd.ErrOrStderr(),
+		Name:   block.Name(),
 	}
 
 	switch block.Language() {

--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -17,6 +17,7 @@ type Base struct {
 	Stdin  io.Reader
 	Stdout io.Writer
 	Stderr io.Writer
+	Name   string
 }
 
 var supportedExecutables = []string{

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -45,7 +45,7 @@ func (s *Shell) Run(ctx context.Context) error {
 		sh = "/bin/sh"
 	}
 
-	return execSingle(ctx, sh, s.Dir, prepareScript(s.Cmds), s.Stdin, s.Stdout, s.Stderr)
+	return execSingle(ctx, sh, s.Dir, prepareScript(s.Cmds), s.Name, s.Stdin, s.Stdout, s.Stderr)
 }
 
 func PrepareScript(cmds []string) string {
@@ -95,12 +95,18 @@ func prepareScript(cmds []string) string {
 	return b.String()
 }
 
-func execSingle(ctx context.Context, sh, dir, cmd string, stdin io.Reader, stdout, stderr io.Writer) error {
+func execSingle(ctx context.Context, sh, dir, cmd string, name string, stdin io.Reader, stdout, stderr io.Writer) error {
 	c := exec.CommandContext(ctx, sh, []string{"-c", cmd}...)
 	c.Dir = dir
 	c.Stderr = stderr
 	c.Stdout = stdout
 	c.Stdin = stdin
 
-	return errors.Wrapf(c.Run(), "failed to run command")
+	err := c.Run()
+
+	if len(name) == 0 {
+		return errors.Wrapf(err, "failed to run command")
+	}
+
+	return errors.Wrapf(err, "failed to run command %q", name)
 }

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -102,5 +102,5 @@ func execSingle(ctx context.Context, sh, dir, cmd string, stdin io.Reader, stdou
 	c.Stdout = stdout
 	c.Stdin = stdin
 
-	return errors.Wrapf(c.Run(), "failed to run command %q", cmd)
+	return errors.Wrapf(c.Run(), "failed to run command")
 }

--- a/internal/runner/shellraw.go
+++ b/internal/runner/shellraw.go
@@ -40,5 +40,5 @@ func (s *ShellRaw) Run(ctx context.Context) error {
 		sh = "/bin/sh"
 	}
 
-	return execSingle(ctx, sh, s.Dir, strings.Join(s.Cmds, "\n"), s.Stdin, s.Stdout, s.Stderr)
+	return execSingle(ctx, sh, s.Dir, strings.Join(s.Cmds, "\n"), s.Name, s.Stdin, s.Stdout, s.Stderr)
 }


### PR DESCRIPTION
Solves #106 

I added the command name to the error message. If we'd rather just drop any info about the command, we can revert to b9c88e6e0c741d2e05076f466cc46a3a7b9d23d3.

For a simple example script, run `go run . run echo-ok --chdir ./examples`