### PR TITLE
internal/cmd: clean up texts and visible cmds

### DIFF
--- a/cmd/gqltool/main.go
+++ b/cmd/gqltool/main.go
@@ -41,7 +41,6 @@ func main() {
 
 func getDefaultConfigHome() string {
 	// TODO(adamb): switch to os.UserConfigDir()
-	// TODO(mxs): ditto
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)

--- a/internal/cmd/api_common.go
+++ b/internal/cmd/api_common.go
@@ -42,7 +42,6 @@ var (
 
 // TODO(adamb): temporarily we authorize using Github as IdP.
 // In the future, we will likely change this to Stateful being IdP.
-// TODO(mxs): ditto
 var defaultAuthURL = func() string {
 	ghURL, err := url.Parse(github.Endpoint.AuthURL)
 	if err != nil {
@@ -59,12 +58,25 @@ func getEnableChaos() bool { return enableChaos }
 func getAPIToken() string  { return apiToken }
 
 func setAPIFlags(flagSet *pflag.FlagSet) {
-	flagSet.StringVar(&authBaseURL, authURLF, defaultAuthURL, "backend URL to authorize you")
-	flagSet.StringVar(&apiBaseURL, apiURLF, "https://api.stateful.com", "backend URL with API")
-	flagSet.StringVar(&apiToken, apiTokenF, "", "api token")
-	flagSet.BoolVar(&trace, traceF, false, "trace HTTP calls")
-	flagSet.BoolVar(&traceAll, traceAllF, false, "trace all HTTP calls including authentication (it might leak sensitive data to output)")
-	flagSet.BoolVar(&enableChaos, enableChaosF, false, "enable Chaos Monkey mode for GraphQL requests")
+	flagSet.StringVar(&authBaseURL, authURLF, defaultAuthURL, "Backend URL to authorize you")
+	flagSet.StringVar(&apiBaseURL, apiURLF, "https://api.stateful.com", "Backend URL with API")
+	flagSet.StringVar(&apiToken, apiTokenF, "", "API token")
+	flagSet.BoolVar(&trace, traceF, false, "Trace HTTP calls")
+	flagSet.BoolVar(&traceAll, traceAllF, false, "Trace all HTTP calls including authentication (it might leak sensitive data to output)")
+	flagSet.BoolVar(&enableChaos, enableChaosF, false, "Enable Chaos Monkey mode for GraphQL requests")
+
+	mustMarkHidden := func(name string) {
+		if err := flagSet.MarkHidden(name); err != nil {
+			panic(err)
+		}
+	}
+
+	mustMarkHidden(authURLF)
+	mustMarkHidden(apiURLF)
+	mustMarkHidden(apiTokenF)
+	mustMarkHidden(traceF)
+	mustMarkHidden(traceAllF)
+	mustMarkHidden(enableChaosF)
 }
 
 var (

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
 	"github.com/stateful/runme/internal/tui"
 )
 
-//lint:file-ignore U1000 hiding this cmd for now
 func authCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "auth",
-		Short: "Log in and out of your Stateful",
+		Hidden: true,
+		Use:    "auth",
+		Short:  "Log in and out of your Stateful",
 	}
 
 	cmd.AddCommand(loginCmd())

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -158,7 +158,6 @@ func setDefaultFlags(cmd *cobra.Command) {
 	} else {
 		usage += "this command"
 	}
-	usage += "."
 	cmd.Flags().BoolP("help", "h", false, usage)
 
 	// For the root command, set up the --version flag.
@@ -169,7 +168,6 @@ func setDefaultFlags(cmd *cobra.Command) {
 		} else {
 			usage += "this command"
 		}
-		usage += "."
 		cmd.Flags().BoolP("version", "v", false, usage)
 	}
 }
@@ -185,7 +183,6 @@ func printfInfo(msg string, args ...any) {
 
 func getDefaultConfigHome() string {
 	// TODO(adamb): switch to os.UserConfigDir()
-	// TODO(mxs): ditto
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)

--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -20,7 +20,7 @@ func fmtCmd() *cobra.Command {
 
 	cmd := cobra.Command{
 		Use:   "fmt",
-		Short: "Format a Markdown file into canonical format.",
+		Short: "Format a Markdown file into canonical format",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if formatJSON {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -14,7 +14,7 @@ func listCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List available commands.",
+		Short:   "List available commands",
 		Long:    "Displays list of parsed command blocks, their name, number of commands in a block, and description from a given markdown file, such as README.md.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			blocks, err := getCodeBlocks()

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -10,7 +10,7 @@ import (
 func printCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:               "print",
-		Short:             "Print a selected snippet.",
+		Short:             "Print a selected snippet",
 		Long:              "Print will display the details of the corresponding command block based on its name.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: validCmdNames,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -45,9 +45,9 @@ func Root() *cobra.Command {
 
 	pflags := cmd.PersistentFlags()
 
-	pflags.BoolVar(&fAllowUnknown, "allow-unknown", false, "Display snippets without known executor.")
-	pflags.StringVar(&fChdir, "chdir", getCwd(), "Switch to a different working directory before executing the command.")
-	pflags.StringVar(&fFileName, "filename", "README.md", "A name of the README file.")
+	pflags.BoolVar(&fAllowUnknown, "allow-unknown", false, "Display snippets without known executor")
+	pflags.StringVar(&fChdir, "chdir", getCwd(), "Switch to a different working directory before executing the command")
+	pflags.StringVar(&fFileName, "filename", "README.md", "Name of the README file")
 
 	setAPIFlags(pflags)
 
@@ -63,7 +63,6 @@ func Root() *cobra.Command {
 
 	branchCmd := branchCmd()
 	suggestCmd := suggestCmd()
-
 	suggestCmd.AddCommand(branchCmd)
 
 	cmd.AddCommand(tuiCmd)
@@ -74,6 +73,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(fmtCmd())
 	cmd.AddCommand(serverCmd())
 	cmd.AddCommand(shellCmd())
+	cmd.AddCommand(authCmd())
 	cmd.AddCommand(suggestCmd)
 	cmd.AddCommand(branchCmd)
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/stateful/runme/internal/document"
-
 	"github.com/pkg/errors"
 	"github.com/rwtodd/Go.Sed/sed"
 	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/runner"
 )
 
@@ -28,7 +27,7 @@ func runCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:               "run",
 		Aliases:           []string{"exec"},
-		Short:             "Run a selected command.",
+		Short:             "Run a selected command",
 		Long:              "Run a selected command identified based on its unique parsed name.",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: validCmdNames,

--- a/internal/cmd/suggest.go
+++ b/internal/cmd/suggest.go
@@ -11,9 +11,9 @@ import (
 
 func suggestCmd() *cobra.Command {
 	cmd := &cobra.Command{
+		Hidden: true,
 		Use:    "suggest",
 		Short:  "Use our suggestion engine to give contextual advice",
-		Hidden: true,
 	}
 
 	return cmd
@@ -23,9 +23,10 @@ func branchCmd() *cobra.Command {
 	var repoUser string
 
 	cmd := &cobra.Command{
-		Use:   "branch DESCRIPTION",
-		Short: "Suggest a branchname.",
-		Long: `Suggest a branchname for a description.
+		Hidden: true,
+		Use:    "branch DESCRIPTION",
+		Short:  "Suggest a branchname",
+		Long: `Suggest a branch name for a description.
 
 Remember to wrap the DESCRIPTION in double quotes as otherwise
 it will be interpreted as multiple arguments.

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -193,7 +193,7 @@ func tuiCmd() *cobra.Command {
 
 	cmd := cobra.Command{
 		Use:   "tui",
-		Short: "Run the interactive TUI.",
+		Short: "Run the interactive TUI",
 		Long:  "Run a command from a descriptive list given by an interactive TUI.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			blocks, err := getCodeBlocks()
@@ -261,8 +261,8 @@ func tuiCmd() *cobra.Command {
 
 	setDefaultFlags(&cmd)
 
-	cmd.Flags().BoolVar(&exitAfterRun, "exit", false, "Exit runme TUI after running a command.")
-	cmd.Flags().IntVar(&numEntries, "entries", defaultNumEntries, "Number of entries to show in TUI.")
+	cmd.Flags().BoolVar(&exitAfterRun, "exit", false, "Exit TUI after running a command")
+	cmd.Flags().IntVar(&numEntries, "entries", defaultNumEntries, "Number of entries to show in TUI")
 
 	return &cmd
 }


### PR DESCRIPTION
Highlights:
- Commands' short description starts with an upper case and does not end with a point. The same goes for flags' description.
- Removed unnecessary TODO comments.
- Hid flags and commands that should not be exposed.