### PR TITLE
internal/runner: disable echoing in shell run

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,13 +14,13 @@
             "host": "127.0.0.1"
         },
         {
-            "name": "Launch runme json",
+            "name": "Launch",
             "type": "go",
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}/main.go",
             "args": [
-                "json"
+                "ls"
             ]
         }
     ]

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/pkg/term v1.1.0
+	github.com/pkg/term v1.2.0-beta.2.0.20211217091447-1a4a3b719465
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20221208044002-44028be4359e
 	golang.org/x/net v0.5.0
 	golang.org/x/oauth2 v0.4.0
+	golang.org/x/sys v0.4.0
 	golang.org/x/term v0.4.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -73,7 +74,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
-	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/tools v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
@@ -94,6 +94,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/term v1.1.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgc
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
+github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -291,6 +293,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgc
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
-github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
+github.com/pkg/term v1.2.0-beta.2.0.20211217091447-1a4a3b719465 h1:J1AQza02ffZ4VP77HnZ5kRyzf6ak1LkjYQutOCdvckI=
+github.com/pkg/term v1.2.0-beta.2.0.20211217091447-1a4a3b719465/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -220,7 +220,7 @@ func (c *command) startWithOpts(ctx context.Context, opts *startOpts) error {
 			if err := termios.Tcgetattr(uintptr(c.tty.Fd()), &attr); err != nil {
 				return errors.Wrap(err, "failed to get tty attr")
 			}
-			attr.Lflag &= ^uint64(unix.ECHO)
+			attr.Lflag &^= unix.ECHO
 			if err := termios.Tcsetattr(c.tty.Fd(), termios.TCSANOW, &attr); err != nil {
 				return errors.Wrap(err, "failed to set tty attr")
 			}

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -14,9 +14,11 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/pkg/errors"
+	"github.com/pkg/term/termios"
 	"github.com/stateful/runme/internal/rbuffer"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 )
 
 type command struct {
@@ -163,7 +165,22 @@ func newCommand(
 	return cmd, nil
 }
 
+type startOpts struct {
+	DisableEcho bool
+}
+
 func (c *command) Start(ctx context.Context) error {
+	return c.StartWithOpts(ctx, nil)
+}
+
+func (c *command) StartWithOpts(ctx context.Context, opts *startOpts) error {
+	if opts == nil {
+		opts = &startOpts{}
+	}
+	return c.startWithOpts(ctx, opts)
+}
+
+func (c *command) startWithOpts(ctx context.Context, opts *startOpts) error {
 	cmd := exec.CommandContext(
 		ctx,
 		c.ProgramPath,
@@ -194,6 +211,22 @@ func (c *command) Start(ctx context.Context) error {
 	}
 
 	if c.tty != nil {
+		if opts.DisableEcho {
+			// Disable echoing. This solves the problem of duplicating entered line in the output.
+			// This is one of the solutions, but there are other methods:
+			//   - removing echoed input from the output
+			//   - removing the entered line using escape codes
+			var attr unix.Termios
+			if err := termios.Tcgetattr(uintptr(c.tty.Fd()), &attr); err != nil {
+				return errors.Wrap(err, "failed to get tty attr")
+			}
+			attr.Lflag &= ^uint64(unix.ECHO)
+			if err := termios.Tcsetattr(c.tty.Fd(), termios.TCSANOW, &attr); err != nil {
+				return errors.Wrap(err, "failed to set tty attr")
+			}
+		}
+
+		// Close tty as not needed anymore.
 		if err := c.tty.Close(); err != nil {
 			c.logger.Info("failed to close tty after starting the command", zap.Error(err))
 		} else {

--- a/internal/runner/command_unix.go
+++ b/internal/runner/command_unix.go
@@ -5,6 +5,10 @@ package runner
 import (
 	"os/exec"
 	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 func setCmdAttrs(cmd *exec.Cmd) {
@@ -13,4 +17,14 @@ func setCmdAttrs(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Setsid = true
 	cmd.SysProcAttr.Setctty = true
+}
+
+func disableEcho(fd uintptr) error {
+	attr, err := termios.Tcgetattr(fd)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tty attr")
+	}
+	attr.Lflag &^= unix.ECHO
+	err = termios.Tcsetattr(fd, termios.TCSANOW, attr)
+	return errors.Wrap(err, "failed to set tty attr")
 }

--- a/internal/runner/command_windows.go
+++ b/internal/runner/command_windows.go
@@ -2,6 +2,14 @@
 
 package runner
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
 
 func setCmdAttrs(cmd *exec.Cmd) {}
+
+func disableEcho(fd uintptr) error {
+	return errors.New("unsupported")
+}

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -43,11 +43,11 @@ func Test_executeCmd(t *testing.T) {
 	exitCode, err := executeCmd(
 		context.Background(),
 		cmd,
+		nil,
 		func(data output) error {
 			results = append(results, data.Clone())
 			return nil
 		},
-		time.Millisecond*250,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
@@ -290,9 +290,8 @@ func Test_runnerService_Execute(t *testing.T) {
 		result := <-execResult
 
 		assert.NoError(t, result.Err)
-		require.Len(t, result.Responses, 2)
-		// result.Responses[0] contains prompt and exit command
-		assert.EqualValues(t, 0, result.Responses[1].ExitCode.Value)
+		require.NotEmpty(t, result.Responses)
+		assert.EqualValues(t, 0, result.Responses[len(result.Responses)-1].ExitCode.Value)
 	})
 
 	// ClientCancel is similar to "Tty" but the client cancels

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -157,7 +157,7 @@ func execSingle(
 	)
 	if err != nil {
 		var exiterr *exec.ExitError
-		// Ignore errors due to INT signal.
+		// Ignore errors caused by SIGINT.
 		if errors.As(err, &exiterr) && exiterr.ProcessState.Sys().(syscall.WaitStatus).Signal() != os.Kill {
 			msg := "failed to run command"
 			if len(name) > 0 {

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -17,7 +17,7 @@ stdout 'Hello, runme!'
 
 env SHELL=/bin/bash
 exec runme run echo-1
-stdout '1\n2\n3'
+stdout '1\r\n2\r\n3\r\n'
 ! stderr .
 
 env SHELL=/bin/bash


### PR DESCRIPTION
This change fixes a problem where input lines were duplicated (echoed) when running `runme run`. After merging https://github.com/stateful/runme/pull/119, `runme run` started using a pseudo-terminal underneath, which caused this problem.

The easiest way to reproduce this is to run (with `runme run`) the following script:
````
```sh { name=input }
cat - | tr a-z A-Z
```
````

The output without this change looks like this:
```
abc
abc
ABC
def
def
DEF
```

With this change it looks as expected:
```
abc
ABC
def
DEF
```