### PR TITLE
internal/runner: handle interactive commands in Shell

### DIFF
--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/stateful/runme/internal/document"
+	"go.uber.org/zap"
 )
 
 type Executable interface {
@@ -12,13 +12,15 @@ type Executable interface {
 	Run(context.Context) error
 }
 
-type Base struct {
+type ExecutableConfig struct {
 	Name    string
 	Dir     string
-	Session *Session
+	Tty     bool
 	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
+	Session *Session
+	Logger  *zap.Logger
 }
 
 var supportedExecutables = []string{
@@ -40,7 +42,6 @@ func IsSupported(lang string) bool {
 	return false
 }
 
-func IsShell(block *document.CodeBlock) bool {
-	lang := block.Language()
+func IsShell(lang string) bool {
 	return lang == "sh" || lang == "shell" || lang == "sh-raw"
 }

--- a/internal/runner/go.go
+++ b/internal/runner/go.go
@@ -12,13 +12,13 @@ import (
 )
 
 type Go struct {
-	*Base
+	*ExecutableConfig
 	Source string
 }
 
 var _ Executable = (*Go)(nil)
 
-func (g *Go) DryRun(ctx context.Context, w io.Writer) {
+func (g Go) DryRun(ctx context.Context, w io.Writer) {
 	_, err := exec.LookPath("go")
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "failed to find %q executable: %s\n", "go", err)
@@ -28,7 +28,7 @@ func (g *Go) DryRun(ctx context.Context, w io.Writer) {
 	_, _ = fmt.Fprintf(w, "%s\n", g.Source)
 }
 
-func (g *Go) Run(ctx context.Context) error {
+func (g Go) Run(ctx context.Context) error {
 	executable, err := exec.LookPath("go")
 	if err != nil {
 		return errors.Wrapf(err, "failed to find %q executable", "go")


### PR DESCRIPTION
Assume we have the following README command:

````md
```sh {name=xxx interactive=true}
tr a-z x
```
````

It should be possible to run it with `runme run xxx`. Unfortunately, the current implementation does not work correctly - it does start the command and waits for the input, but it does not produce any output. This PR fixes it by enabling TTY if the code block contains annotation `interactive=true`.

Other changes include small refactoring of structs implementing `runner.Executable` interface as well as more logs and tests for `runner.runnerService.Execute()`.