### PR TITLE
internal/cmd: set max msg size for gRPC server

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"io"
+	"log"
+	"os"
+
+	"github.com/pkg/errors"
+	runnerv1 "github.com/stateful/runme/internal/gen/proto/go/runme/runner/v1"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var (
+	addr       = flag.String("addr", "127.0.0.1:7890", "the address to connect to")
+	file       = flag.String("file", "", "file with content to upper case")
+	resultFile = flag.String("write-result", "-", "path to a result file (default: stdout)")
+)
+
+func main() {
+	flag.Parse()
+
+	if err := run(); err != nil {
+		log.Fatalf("error: %v", err)
+	}
+}
+
+func run() error {
+	conn, err := grpc.Dial(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return errors.Wrap(err, "failed to connect")
+	}
+	defer conn.Close()
+
+	client := runnerv1.NewRunnerServiceClient(conn)
+
+	stream, err := client.Execute(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "failed to call Execute()")
+	}
+
+	var g errgroup.Group
+
+	g.Go(func() error {
+		source, err := os.Open(*file)
+		if err != nil {
+			return errors.Wrap(err, "failed to open source file")
+		}
+		defer func() { _ = source.Close() }()
+
+		buf := make([]byte, 32*1024)
+
+		for readNext := true; readNext; {
+			n, err := source.Read(buf)
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					return errors.Wrap(err, "failed to read from source")
+				}
+
+				buf[0] = 4 // EOT
+				n = 1
+				readNext = false
+			}
+			err = stream.Send(&runnerv1.ExecuteRequest{
+				InputData: buf[:n],
+			})
+			if err != nil {
+				return errors.Wrap(err, "failed to send msg")
+			}
+		}
+
+		return nil
+	})
+
+	g.Go(func() error {
+		var result io.Writer
+
+		if *resultFile == "-" {
+			result = os.Stdout
+		} else {
+			f, err := os.OpenFile(*resultFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+			if err != nil {
+				return errors.Wrap(err, "failed to open result file")
+			}
+			defer func() { _ = f.Close() }()
+			result = f
+		}
+
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				return errors.Wrap(err, "failed to recv msg")
+			}
+
+			_, err = result.Write(msg.StdoutData)
+			if err != nil {
+				return errors.Wrap(err, "failed to write data")
+			}
+
+			if len(msg.StderrData) > 0 {
+				log.Printf("stderr: %s", msg.StderrData)
+			}
+
+			if msg.ExitCode != nil {
+				var err error
+				if code := msg.ExitCode.Value; code > 0 {
+					err = errors.Errorf("command failed with code %d", code)
+				}
+				return err
+			}
+		}
+	})
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrap(err, "failed to get cwd")
+	}
+
+	err = stream.Send(&runnerv1.ExecuteRequest{
+		ProgramName: "bash",
+		Directory:   cwd,
+		Tty:         true,
+		Commands:    []string{"tr a-z A-Z"},
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to send initial request")
+	}
+
+	return g.Wait()
+}

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -44,8 +44,6 @@ func run() error {
 		return errors.Wrap(err, "failed to call Execute()")
 	}
 
-	var g errgroup.Group
-
 	g.Go(func() error {
 		source, err := os.Open(*file)
 		if err != nil {

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -37,7 +37,9 @@ func run() error {
 
 	client := runnerv1.NewRunnerServiceClient(conn)
 
-	stream, err := client.Execute(context.Background())
+	g, ctx := errgroup.WithContext(context.Background())
+
+	stream, err := client.Execute(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to call Execute()")
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -134,7 +134,7 @@ func ctxWithSigCancel(ctx context.Context) (context.Context, context.CancelFunc)
 	ctx, cancel := context.WithCancel(ctx)
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	go func() {
 		<-sigs

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -123,8 +123,10 @@ The kernel is used to run long running processes like shells and interacting wit
 
 			logger.Info("started listening", zap.String("addr", lis.Addr().String()))
 
-			var opts []grpc.ServerOption
-			server := grpc.NewServer(opts...)
+			server := grpc.NewServer(
+				grpc.MaxRecvMsgSize(runner.MaxMsgSize),
+				grpc.MaxSendMsgSize(runner.MaxMsgSize),
+			)
 			parserv1.RegisterParserServiceServer(server, editorservice.NewParserServiceServer(logger))
 			runnerv1.RegisterRunnerServiceServer(server, runner.NewRunnerService(logger))
 			reflection.Register(server)

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -217,6 +218,65 @@ func Test_runnerService(t *testing.T) {
 		assert.Equal(t, "xxx\r\n", string(result.Responses[0].StdoutData))
 		assert.EqualValues(t, 0, result.Responses[1].ExitCode.Value)
 	})
+
+	// The longest accepted line must not have more than 1024 bytes on macOS,
+	// including the new line character at the end. Any line longer results in ^G (BELL).
+	// It is possible to send more data, but it must be divided in 1024-byte chunks
+	// separated by the new line character (\n).
+	// On Linux, the limit is 4096 which is described on the termios man page.
+	// More: https://man7.org/linux/man-pages/man3/termios.3.html
+	// TODO(adamb): sort out the root cause of this limitation.
+	if runtime.GOOS == "linux" {
+		t.Run("LargeInput", func(t *testing.T) {
+			t.Parallel()
+
+			stream, err := client.Execute(context.Background())
+			require.NoError(t, err)
+
+			execResult := make(chan executeResult)
+			go getExecuteResult(stream, execResult)
+
+			err = stream.Send(&runnerv1.ExecuteRequest{
+				ProgramName: "bash",
+				Tty:         true,
+				Commands:    []string{"tr a-z x"},
+			})
+			require.NoError(t, err)
+
+			errc := make(chan error)
+			go func() {
+				defer close(errc)
+
+				data := make([]byte, 4096)
+				for i := 0; i < len(data); i++ {
+					data[i] = 'a'
+				}
+				data[len(data)-1] = '\n'
+
+				time.Sleep(time.Second)
+				err := stream.Send(&runnerv1.ExecuteRequest{
+					InputData: data,
+				})
+				errc <- err
+				time.Sleep(time.Second)
+				err = stream.Send(&runnerv1.ExecuteRequest{
+					InputData: []byte{4},
+				})
+				errc <- err
+			}()
+			for err := range errc {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, stream.CloseSend())
+
+			result := <-execResult
+
+			assert.NoError(t, result.Err)
+			require.Len(t, result.Responses, 2)
+			assert.Len(t, string(result.Responses[0].StdoutData), 4097) // \n => \r\n
+			assert.EqualValues(t, 0, result.Responses[1].ExitCode.Value)
+		})
+	}
 
 	t.Run("EnvsPersistence", func(t *testing.T) {
 		t.Parallel()

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -223,9 +223,9 @@ func Test_runnerService(t *testing.T) {
 	// including the new line character at the end. Any line longer results in ^G (BELL).
 	// It is possible to send more data, but it must be divided in 1024-byte chunks
 	// separated by the new line character (\n).
+	// More: https://man.freebsd.org/cgi/man.cgi?query=termios&sektion=4
 	// On Linux, the limit is 4096 which is described on the termios man page.
 	// More: https://man7.org/linux/man-pages/man3/termios.3.html
-	// TODO(adamb): sort out the root cause of this limitation.
 	if runtime.GOOS == "linux" {
 		t.Run("LargeInput", func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Highlights:
- explicitly define the max message size
- add a test case for the large input
- add an example with Go client