### PR TITLE
internal/runner: remove bufs reuse in readLoop

### DIFF
--- a/internal/runner/command_test.go
+++ b/internal/runner/command_test.go
@@ -264,10 +264,6 @@ func Test_command(t *testing.T) {
 		}
 
 		assert.ErrorContains(t, cmd.Wait(), "exit status 130")
-		data, err := io.ReadAll(stdout)
-		assert.NoError(t, err)
-		assert.Contains(t, string(data), "sleep 30")
-		assert.Contains(t, string(data), "exit")
 	})
 
 	t.Run("Env", func(t *testing.T) {

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -565,27 +565,6 @@ func Test_runnerService(t *testing.T) {
 		assert.EqualValues(t, 130, result.ExitCode)
 	})
 
-	t.Run("ExecuteCurl", func(t *testing.T) {
-		t.Parallel()
-
-		stream, err := client.Execute(context.Background())
-		require.NoError(t, err)
-
-		execResult := make(chan executeResult)
-		go getExecuteResult(stream, execResult)
-
-		err = stream.Send(&runnerv1.ExecuteRequest{
-			ProgramName: "bash",
-			Script:      "curl -s https://lever-client-logos.s3.us-west-2.amazonaws.com/a8ff9b1f-f313-4632-b90f-1f7ae7ee807f-1638388150933.png >/dev/null",
-		})
-		assert.NoError(t, err)
-
-		result := <-execResult
-
-		assert.NoError(t, result.Err)
-		assert.EqualValues(t, 0, result.ExitCode)
-	})
-
 	t.Run("ExecuteLicenseCat", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
gRPC server must not modify message after calling SendMsg. More: https://github.com/grpc/grpc-go/issues/5857.

Closes https://github.com/stateful/runme/issues/144