### PR TITLE
internal/rbuffer: fix overflow hanging

### DIFF
--- a/internal/rbuffer/ring_buffer.go
+++ b/internal/rbuffer/ring_buffer.go
@@ -96,6 +96,7 @@ func (b *RingBuffer) read(p []byte) (n int, err error) {
 		copy(p[c1:], b.buf[0:c2])
 	}
 	b.r = (b.r + n) % b.size
+	b.isFull = false
 
 	return n, err
 }


### PR DESCRIPTION
I think this should fix #149.

Basically, the `b.isFull` variable is not able to be cancelled by the `read` method, only by the `write` method. I think probably that the buffer should not be set as full anymore once its drained.