### PR TITLE
internal/runner: use `cmd.StdinPipe()`

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -207,11 +207,12 @@ func (c *command) StartWithOpts(ctx context.Context, opts *startOpts) error {
 		if c.Stdin != nil {
 			c.cmd.Stdin = c.Stdin
 		} else {
-			if writer, err := c.cmd.StdinPipe(); err != nil {
+			writer, err := c.cmd.StdinPipe()
+			if err != nil {
 				return err
-			} else {
-				c.StdinWriter = &writer
 			}
+
+			c.StdinWriter = &writer
 		}
 
 		// Set the process group ID of the program.

--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -203,7 +203,7 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 	logger.Debug("command config", zap.Any("cfg", cfg))
 	cmd, err := newCommand(cfg)
 	if cmd.StdinWriter != nil {
-		stdinWriter.Close()
+		_ = stdinWriter.Close()
 		stdinWriter = *cmd.StdinWriter
 	}
 	if err != nil {


### PR DESCRIPTION
This PR uses `StdinPipe` instead of setting the `Stdin` field for non-TTY processes. This automatically closes the `stdin` stream when the program exits.

In particular, this PR reverts the closing `stdinWriter` early for non-TTY processes, and should allow for non-TTY processes to accept stdin without hanging execution.