### PR TITLE
Use absolute path for markdown not found error

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -29,7 +29,13 @@ func readMarkdownFile(args []string) ([]byte, error) {
 		if err != nil {
 			var pathError *os.PathError
 			if errors.As(err, &pathError) {
-				return nil, errors.Errorf("failed to %s markdown file %s: %s", pathError.Op, pathError.Path, pathError.Err.Error())
+				mdPath := pathError.Path
+
+				if absolutePath, err := filepath.Abs(mdPath); err == nil {
+					mdPath = absolutePath
+				}
+
+				return nil, errors.Errorf("failed to %s markdown file %s: %s", pathError.Op, mdPath, pathError.Err.Error())
 			}
 
 			return nil, errors.Wrapf(err, "failed to read %s", filepath.Join(fChdir, fFileName))


### PR DESCRIPTION
On my system, the path returned from path error is relative rather than absolute ¯\\\_(ツ)_/¯ this breaks the tests

Figure absolute is clearer.