### PR TITLE
internal/cmd/server: health check endpoint

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -47,8 +47,6 @@ func run() error {
 		return errors.Errorf("service status: %v", resp.Status)
 	}
 
-	log.Printf("service is SERVING")
-
 	client := runnerv1.NewRunnerServiceClient(conn)
 
 	g, ctx := errgroup.WithContext(context.Background())

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -30,8 +30,6 @@ func serverCmd() *cobra.Command {
 	const (
 		defaultSocketAddr = "unix:///var/run/runme.sock"
 		defaultLocalAddr  = "localhost:7890"
-		// Empty string represents the health of the system.
-		system = ""
 	)
 
 	var (
@@ -142,7 +140,7 @@ The kernel is used to run long running processes like shells and interacting wit
 			healthcheck := health.NewServer()
 			healthgrpc.RegisterHealthServer(server, healthcheck)
 			// Setting SERVING for the whole system.
-			healthcheck.SetServingStatus(system, healthgrpc.HealthCheckResponse_SERVING)
+			healthcheck.SetServingStatus("", healthgrpc.HealthCheckResponse_SERVING)
 
 			reflection.Register(server)
 			return server.Serve(lis)

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -21,9 +21,9 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 )
 
 func serverCmd() *cobra.Command {


### PR DESCRIPTION
Adds health check endpoint in gRPC server.

**Issue:**

#163 

**Test:**

- Start the gRPC server `./runme server -a localhost:7890`
- Install [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe#installation)
- Execute command `grpc_health_probe -addr=localhost:7890`

Response will either be `SERVING` or `NOT SERVING`.