### PR TITLE
internal/runner: set command options only in supported shells

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -112,7 +112,7 @@ func newCommand(cfg *commandConfig) (*command, error) {
 
 		if len(cfg.Commands) > 0 {
 			_, _ = script.WriteString(
-				prepareScriptFromCommands(cfg.Commands),
+				prepareScriptFromCommands(cfg.Commands, ShellFromShellPath(programPath)),
 			)
 		} else if cfg.Script != "" {
 			_, _ = script.WriteString(

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -122,8 +122,8 @@ func ShellPath() string {
 // TODO(mxs): this method for determining shell is not strong, since shells can
 // be aliased. we should probably run the shell to get this information
 func ShellFromShellPath(programPath string) string {
-	programFile := path.Base(programPath)
-	return programFile[:len(programFile)-len(path.Ext(programFile))]
+	programFile := filepath.Base(programPath)
+	return programFile[:len(programFile)-len(filepath.Ext(programFile))]
 }
 
 func PrepareScriptFromCommands(cmds []string, shell string) string {

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
@@ -28,12 +29,16 @@ func (s Shell) ProgramPath() string {
 	return ShellPath()
 }
 
+func (s Shell) ShellType() string {
+	return ShellFromShellPath(s.ProgramPath())
+}
+
 func (s Shell) DryRun(ctx context.Context, w io.Writer) {
 	var b bytes.Buffer
 
 	_, _ = b.WriteString(fmt.Sprintf("#!%s\n\n", s.ProgramPath()))
 	_, _ = b.WriteString(fmt.Sprintf("// run in %q\n\n", s.Dir))
-	_, _ = b.WriteString(prepareScriptFromCommands(s.Cmds))
+	_, _ = b.WriteString(prepareScriptFromCommands(s.Cmds, s.ShellType()))
 
 	_, err := w.Write(b.Bytes())
 	if err != nil {
@@ -114,14 +119,27 @@ func ShellPath() string {
 	return "/bin/sh"
 }
 
-func PrepareScriptFromCommands(cmds []string) string {
-	return prepareScriptFromCommands(cmds)
+// TODO(mxs): this method for determining shell is not strong, since shells can
+// be aliased. we should probably run the shell to get this information
+func ShellFromShellPath(programPath string) string {
+	programFile := path.Base(programPath)
+	return programFile[:len(programFile)-len(path.Ext(programFile))]
 }
 
-func prepareScriptFromCommands(cmds []string) string {
+func PrepareScriptFromCommands(cmds []string, shell string) string {
+	return prepareScriptFromCommands(cmds, shell)
+}
+
+func prepareScriptFromCommands(cmds []string, shell string) string {
 	var b strings.Builder
 
-	_, _ = b.WriteString("set -e -o pipefail;")
+	// TODO(mxs): powershell
+	switch shell {
+	case "zsh", "ksh", "bash":
+		_, _ = b.WriteString("set -e -o pipefail;")
+	case "sh":
+		_, _ = b.WriteString("set -e;")
+	}
 
 	for _, cmd := range cmds {
 		detectedWord := false

--- a/internal/runner/shell_test.go
+++ b/internal/runner/shell_test.go
@@ -11,7 +11,7 @@ func TestPrepareScript(t *testing.T) {
 		`# macOS`,
 		`brew bundle --no-lock`,
 		`brew upgrade`,
-	})
+	}, "bash")
 	assert.Equal(t, "set -e -o pipefail;brew bundle --no-lock;brew upgrade;\n", script)
 
 	script = prepareScriptFromCommands([]string{
@@ -20,11 +20,23 @@ func TestPrepareScript(t *testing.T) {
 		"--allow-env --allow-net --allow-run \\",
 		"--no-check \\",
 		"-r -f https://deno.land/x/deploy/deployctl.ts",
-	})
+	}, "bash")
 	assert.Equal(t, "set -e -o pipefail;deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts;\n", script)
 
 	script = prepareScriptFromCommands([]string{
 		`pipenv run bash -c 'echo "Some message"'`,
-	})
+	}, "bash")
 	assert.Equal(t, "set -e -o pipefail;pipenv run bash -c \"echo \\\"Some message\\\"\";\n", script)
+
+	script = prepareScriptFromCommands([]string{
+		`brew bundle --no-lock`,
+		`brew upgrade`,
+	}, "sh")
+	assert.Equal(t, "set -e;brew bundle --no-lock;brew upgrade;\n", script)
+
+	script = prepareScriptFromCommands([]string{
+		`brew bundle --no-lock`,
+		`brew upgrade`,
+	}, "pwsh")
+	assert.Equal(t, "brew bundle --no-lock;brew upgrade;\n", script)
 }

--- a/internal/runner/shell_test.go
+++ b/internal/runner/shell_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,4 +40,28 @@ func TestPrepareScript(t *testing.T) {
 		`brew upgrade`,
 	}, "pwsh")
 	assert.Equal(t, "brew bundle --no-lock;brew upgrade;\n", script)
+}
+
+func TestShellFromShellPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.Equal(t,
+			"pwsh",
+			ShellFromShellPath("c:\\System32\\pwsh.exe"),
+		)
+	} else {
+		assert.Equal(t,
+			"sh",
+			ShellFromShellPath("/bin/sh"),
+		)
+
+		assert.Equal(t,
+			"bash",
+			ShellFromShellPath("/bin/bash"),
+		)
+
+		assert.Equal(t,
+			"zsh",
+			ShellFromShellPath("/bin/zsh"),
+		)
+	}
 }


### PR DESCRIPTION
Solves #159 

~~Would like write tests for `ShellFromShellPath` function before merge~~