### PR TITLE
internal/cmd/run: Integrate with gRPC runner

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -44,7 +44,7 @@ func run() error {
 		resp, err := client.CreateSession(context.Background(), &runnerv1.CreateSessionRequest{
 			Envs: os.Environ(),
 		})
-		if err != nil || resp.Session == nil {
+		if err != nil {
 			return err
 		}
 

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -63,7 +63,7 @@ func run() error {
 			return err
 		}
 
-		_, _ = fmt.Printf("Successfully deleted session \"%s\"", id)
+		_, _ = fmt.Printf("Successfully deleted session %q", id)
 
 		return nil
 	}

--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -48,7 +48,7 @@ func run() error {
 			return err
 		}
 
-		fmt.Println(resp.Session.Id)
+		_, _ = fmt.Println(resp.Session.Id)
 
 		return nil
 	}
@@ -63,7 +63,7 @@ func run() error {
 			return err
 		}
 
-		fmt.Printf("Successfully deleted session \"%s\"", id)
+		_, _ = fmt.Printf("Successfully deleted session \"%s\"", id)
 
 		return nil
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -18,6 +18,8 @@ import (
 type runCmdOpts struct {
 	DryRun         bool
 	ReplaceScripts []string
+	ServerAddr     string
+	SessionID      string
 }
 
 func runCmd() *cobra.Command {
@@ -60,15 +62,35 @@ func runCmd() *cobra.Command {
 				stdin = bytes.NewReader(nil)
 			}
 
-			runner, err := client.NewLocalRunner(
+			runOpts := []client.RunnerOption{
 				client.WithinShellMaybe(),
 				client.WithDir(fChdir),
 				client.WithStdin(stdin),
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),
-			)
-			if err != nil {
-				return err
+				client.WithSessionID(opts.SessionID),
+			}
+
+			var runner client.Runner
+
+			if opts.ServerAddr == "" {
+				localRunner, err := client.NewLocalRunner(runOpts...)
+				if err != nil {
+					return err
+				}
+
+				runner = localRunner
+			} else {
+				remoteRunner, err := client.NewRemoteRunner(
+					cmd.Context(),
+					opts.ServerAddr,
+					runOpts...,
+				)
+				if err != nil {
+					return err
+				}
+
+				runner = remoteRunner
 			}
 
 			if opts.DryRun {
@@ -89,6 +111,10 @@ func runCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Print the final command without executing.")
 	cmd.Flags().StringArrayVarP(&opts.ReplaceScripts, "replace", "r", nil, "Replace instructions using sed.")
+	cmd.Flags().StringVarP(&opts.ServerAddr, "server", "s", "", "Server address to connect runner to")
+	cmd.Flags().StringVar(&opts.SessionID, "session", "", "Session id to run commands in runner inside of")
+
+	opts.SessionID = os.Getenv("RUNME_SESSION")
 
 	return &cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -69,6 +69,7 @@ func runCmd() *cobra.Command {
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),
 				client.WithSessionID(opts.SessionID),
+				client.WithCleanupSession(opts.SessionID == ""),
 			}
 
 			var runner client.Runner
@@ -114,9 +115,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Print the final command without executing.")
 	cmd.Flags().StringArrayVarP(&opts.ReplaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().StringVarP(&opts.ServerAddr, "server", "s", "", "Server address to connect runner to")
-	cmd.Flags().StringVar(&opts.SessionID, "session", "", "Session id to run commands in runner inside of")
-
-	opts.SessionID = os.Getenv("RUNME_SESSION")
+	cmd.Flags().StringVar(&opts.SessionID, "session", os.Getenv("RUNME_SESSION"), "Session id to run commands in runner inside of")
 
 	return &cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -116,6 +116,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.ReplaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().StringVarP(&opts.ServerAddr, "server", "s", "", "Server address to connect runner to")
 	cmd.Flags().StringVar(&opts.SessionID, "session", os.Getenv("RUNME_SESSION"), "Session id to run commands in runner inside of")
+	cmd.Flags().MarkHidden("session")
 
 	return &cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -116,7 +116,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.ReplaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().StringVarP(&opts.ServerAddr, "server", "s", "", "Server address to connect runner to")
 	cmd.Flags().StringVar(&opts.SessionID, "session", os.Getenv("RUNME_SESSION"), "Session id to run commands in runner inside of")
-	cmd.Flags().MarkHidden("session")
+	_ = cmd.Flags().MarkHidden("session")
 
 	return &cmd
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -93,6 +93,8 @@ func runCmd() *cobra.Command {
 				runner = remoteRunner
 			}
 
+			defer runner.Cleanup(cmd.Context())
+
 			if opts.DryRun {
 				return runner.DryRunBlock(ctx, block, cmd.ErrOrStderr())
 			}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -153,7 +153,7 @@ func tuiCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&runOnce, "exit", false, "Exit TUI after running a command")
 	cmd.Flags().IntVar(&visibleEntries, "entries", defaultVisibleEntries, "Number of entries to show in TUI")
-	cmd.Flags().StringVar(&serverAddr, "server", "", "Server address to conenct TUI to")
+	cmd.Flags().StringVar(&serverAddr, "server", "", "Server address to connect TUI to")
 
 	return &cmd
 }

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -16,6 +16,7 @@ var ErrRunnerClientUnimplemented = fmt.Errorf("method unimplemented")
 
 type Runner interface {
 	setSession(s *runner.Session) error
+	setSessionID(id string) error
 	setWithinShell() error
 	setDir(dir string) error
 	setStdin(stdin io.Reader) error
@@ -31,6 +32,12 @@ type Runner interface {
 func WithSession(s *runner.Session) RunnerOption {
 	return func(rc Runner) error {
 		return rc.setSession(s)
+	}
+}
+
+func WithSessionID(id string) RunnerOption {
+	return func(rc Runner) error {
+		return rc.setSessionID(id)
 	}
 }
 

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -17,6 +17,7 @@ var ErrRunnerClientUnimplemented = fmt.Errorf("method unimplemented")
 type Runner interface {
 	setSession(s *runner.Session) error
 	setSessionID(id string) error
+	setCleanupSession(cleanup bool) error
 	setWithinShell() error
 	setDir(dir string) error
 	setStdin(stdin io.Reader) error
@@ -38,6 +39,12 @@ func WithSession(s *runner.Session) RunnerOption {
 func WithSessionID(id string) RunnerOption {
 	return func(rc Runner) error {
 		return rc.setSessionID(id)
+	}
+}
+
+func WithCleanupSession(cleanup bool) RunnerOption {
+	return func(rc Runner) error {
+		return rc.setCleanupSession(cleanup)
 	}
 }
 

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -36,6 +36,10 @@ func (r *LocalRunner) setSessionID(sessionID string) error {
 	return nil
 }
 
+func (r *LocalRunner) setCleanupSession(cleanup bool) error {
+	return nil
+}
+
 func (r *LocalRunner) setWithinShell() error {
 	id, ok := shellID()
 	if !ok {

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -32,6 +32,10 @@ func (r *LocalRunner) setSession(s *runner.Session) error {
 	return nil
 }
 
+func (r *LocalRunner) setSessionID(sessionID string) error {
+	return nil
+}
+
 func (r *LocalRunner) setWithinShell() error {
 	id, ok := shellID()
 	if !ok {

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -56,6 +56,11 @@ func (r *RemoteRunner) setSession(session *runner.Session) error {
 	return nil
 }
 
+func (r *RemoteRunner) setSessionID(sessionID string) error {
+	r.sessionID = sessionID
+	return nil
+}
+
 func (r *RemoteRunner) setWithinShell() error {
 	return nil
 }

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -23,8 +23,9 @@ type RemoteRunner struct {
 	stdout io.Writer
 	stderr io.Writer
 
-	client    runnerv1.RunnerServiceClient
-	sessionID string
+	client         runnerv1.RunnerServiceClient
+	sessionID      string
+	cleanupSession bool
 }
 
 func (r *RemoteRunner) setDir(dir string) error {
@@ -61,6 +62,11 @@ func (r *RemoteRunner) setSessionID(sessionID string) error {
 	return nil
 }
 
+func (r *RemoteRunner) setCleanupSession(cleanup bool) error {
+	r.cleanupSession = cleanup
+	return nil
+}
+
 func (r *RemoteRunner) setWithinShell() error {
 	return nil
 }
@@ -86,6 +92,10 @@ func NewRemoteRunner(ctx context.Context, addr string, opts ...RunnerOption) (*R
 }
 
 func (r *RemoteRunner) setupSession(ctx context.Context) error {
+	if r.sessionID != "" {
+		return nil
+	}
+
 	resp, err := r.client.CreateSession(ctx, &runnerv1.CreateSessionRequest{
 		Envs: os.Environ(),
 	})
@@ -149,7 +159,13 @@ func (r *RemoteRunner) DryRunBlock(ctx context.Context, block *document.CodeBloc
 }
 
 func (r *RemoteRunner) Cleanup(ctx context.Context) error {
-	return r.deleteSession(ctx)
+	if r.cleanupSession {
+		if err := r.deleteSession(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *RemoteRunner) sendLoop(stream runnerv1.RunnerService_ExecuteClient, stdin io.Reader) error {


### PR DESCRIPTION
Implements the following for the `run` command:

 - `--server` flag, which when provided uses the gRPC runner at the given address
 - `--session` flag, which when provided uses the given session ID. If this flag is provided, the session will not be removed on program exit.