### PR TITLE
Fix version in `goreleaser` build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.BuildDate={{ .CommitDate }} -X main.BuildVersion={{.Version}} -X main.Commit={{.Commit}}
+      - -s -w
+        -X 'github.com/stateful/runme/internal/version.BuildDate={{ .CommitDate }}'
+        -X 'github.com/stateful/runme/internal/version.BuildVersion={{.Version}}'
+        -X 'github.com/stateful/runme/internal/version.Commit={{.Commit}}'
   - id: wasm
     main: ./web
     goos:
@@ -30,7 +33,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.BuildDate={{ .CommitDate }} -X main.BuildVersion={{.Version}} -X main.Commit={{.Commit}}
+      - -s -w
+        -X 'github.com/stateful/runme/internal/version.BuildDate={{ .CommitDate }}'
+        -X 'github.com/stateful/runme/internal/version.BuildVersion={{.Version}}'
+        -X 'github.com/stateful/runme/internal/version.Commit={{.Commit}}'
 
 release:
   prerelease: auto


### PR DESCRIPTION
Tested locally with `goreleaser build` and had no issues:

```
runme version 0.6.5-rc.0 (6ed81fab5de236c6e8cd00d5d9fee5d5e44fdc81) on 2023-03-09T15:40:05Z
```