### PR TITLE
Simplify command normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/charmbracelet/bubbles v0.15.0
 	github.com/elliotchance/orderedmap v1.5.0
 	github.com/go-git/go-git/v5 v5.5.2
+	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/go-git/go-git-fixtures/v4 v4.3.1 h1:y5z6dd3qi8Hl+stezc8p3JxDkoTRqMAlK
 github.com/go-git/go-git-fixtures/v4 v4.3.1/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/go-git/go-git/v5 v5.5.2 h1:v8lgZa5k9ylUw+OR/roJHTxR4QItsNFI5nKtAXFuynw=
 github.com/go-git/go-git/v5 v5.5.2/go.mod h1:BE5hUJ5yaV2YMxhmaP4l6RBQ08kMxKSPD4BlxtH7OjI=
-github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/go-git/go-git/v5 v5.5.2 h1:v8lgZa5k9ylUw+OR/roJHTxR4QItsNFI5nKtAXFuyn
 github.com/go-git/go-git/v5 v5.5.2/go.mod h1:BE5hUJ5yaV2YMxhmaP4l6RBQ08kMxKSPD4BlxtH7OjI=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb8WugfUU=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/jYrnRPArHwAcmLoJZxyho=

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cli/cli/v2/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/shell"
 )
 
 func listCmd() *cobra.Command {
@@ -38,8 +39,8 @@ func listCmd() *cobra.Command {
 				lines := block.Lines()
 
 				table.AddField(block.Name(), nil, nil)
-				table.AddField(lines[0], nil, nil)
-				table.AddField(fmt.Sprintf("%d", len(lines)), nil, nil)
+				table.AddField(shell.TryGetNonCommentLine(lines), nil, nil)
+				table.AddField(fmt.Sprintf("%d", len(shell.StripComments(lines))), nil, nil)
 				table.AddField(block.Intro(), nil, nil)
 				table.EndRow()
 			}

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stateful/runme/internal/shell"
 	"github.com/yuin/goldmark/ast"
 )
 
@@ -249,7 +250,7 @@ func getName(node *ast.FencedCodeBlock, source []byte, nameResolver *nameResolve
 	} else {
 		lines := getLines(node, source)
 		if len(lines) > 0 {
-			name = sanitizeName(lines[0])
+			name = sanitizeName(shell.TryGetNonCommentLine(lines))
 		}
 	}
 	return nameResolver.Get(node, name)

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -250,6 +250,7 @@ func getName(node *ast.FencedCodeBlock, source []byte, nameResolver *nameResolve
 	} else {
 		lines := getLines(node, source)
 		if len(lines) > 0 {
+			// TODO(mxs): only do this in sh-like commands
 			name = sanitizeName(shell.TryGetNonCommentLine(lines))
 		}
 	}

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -116,7 +116,7 @@ func newCommand(cfg *commandConfig) (*command, error) {
 			)
 		} else if cfg.Script != "" {
 			_, _ = script.WriteString(
-				prepareScript(cfg.Script),
+				prepareScript(cfg.Script, ShellFromShellPath(programPath)),
 			)
 		}
 

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -132,7 +132,7 @@ func PrepareScriptFromCommands(cmds []string, shell string) string {
 func prepareScriptFromCommands(cmds []string, shell string) string {
 	var b strings.Builder
 
-	writeShellPrefix(shell, &b)
+	_, _ = b.WriteString(getShellOptions(shell))
 
 	for _, cmd := range cmds {
 		_, _ = b.WriteString(cmd)
@@ -147,21 +147,23 @@ func prepareScriptFromCommands(cmds []string, shell string) string {
 func prepareScript(script string, shell string) string {
 	var b strings.Builder
 
-	writeShellPrefix(shell, &b)
+	_, _ = b.WriteString(getShellOptions(shell))
+
 	_, _ = b.WriteString(script)
 	_, _ = b.WriteRune('\n')
 
 	return b.String()
 }
 
-func writeShellPrefix(shell string, b *strings.Builder) {
+func getShellOptions(shell string) (res string) {
 	// TODO(mxs): powershell, DOS
 	switch shell {
 	case "zsh", "ksh", "bash":
-		_, _ = b.WriteString("set -e -o pipefail")
+		res += "set -e -o pipefail"
 	case "sh":
-		_, _ = b.WriteString("set -e")
+		res += "set -e"
 	}
 
-	_, _ = b.WriteRune('\n')
+	res += "\n"
+	return
 }

--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -135,8 +135,8 @@ func prepareScriptFromCommands(cmds []string, shell string) string {
 	writeShellPrefix(shell, &b)
 
 	for _, cmd := range cmds {
-		b.WriteString(cmd)
-		b.WriteRune('\n')
+		_, _ = b.WriteString(cmd)
+		_, _ = b.WriteRune('\n')
 	}
 
 	_, _ = b.WriteRune('\n')

--- a/internal/runner/shell_test.go
+++ b/internal/runner/shell_test.go
@@ -13,7 +13,7 @@ func TestPrepareScript(t *testing.T) {
 		`brew bundle --no-lock`,
 		`brew upgrade`,
 	}, "bash")
-	assert.Equal(t, "set -e -o pipefail;brew bundle --no-lock;brew upgrade;\n", script)
+	assert.Equal(t, "set -e -o pipefail\n# macOS\nbrew bundle --no-lock\nbrew upgrade\n\n", script)
 
 	script = prepareScriptFromCommands([]string{
 		"deno install \\",
@@ -22,24 +22,24 @@ func TestPrepareScript(t *testing.T) {
 		"--no-check \\",
 		"-r -f https://deno.land/x/deploy/deployctl.ts",
 	}, "bash")
-	assert.Equal(t, "set -e -o pipefail;deno install --allow-read --allow-write --allow-env --allow-net --allow-run --no-check -r -f https://deno.land/x/deploy/deployctl.ts;\n", script)
+	assert.Equal(t, "set -e -o pipefail\ndeno install \\\n--allow-read --allow-write \\\n--allow-env --allow-net --allow-run \\\n--no-check \\\n-r -f https://deno.land/x/deploy/deployctl.ts\n\n", script)
 
 	script = prepareScriptFromCommands([]string{
 		`pipenv run bash -c 'echo "Some message"'`,
 	}, "bash")
-	assert.Equal(t, "set -e -o pipefail;pipenv run bash -c \"echo \\\"Some message\\\"\";\n", script)
+	assert.Equal(t, "set -e -o pipefail\npipenv run bash -c 'echo \"Some message\"'\n\n", script)
 
 	script = prepareScriptFromCommands([]string{
 		`brew bundle --no-lock`,
 		`brew upgrade`,
 	}, "sh")
-	assert.Equal(t, "set -e;brew bundle --no-lock;brew upgrade;\n", script)
+	assert.Equal(t, "set -e\nbrew bundle --no-lock\nbrew upgrade\n\n", script)
 
 	script = prepareScriptFromCommands([]string{
 		`brew bundle --no-lock`,
 		`brew upgrade`,
 	}, "pwsh")
-	assert.Equal(t, "brew bundle --no-lock;brew upgrade;\n", script)
+	assert.Equal(t, "\nbrew bundle --no-lock\nbrew upgrade\n\n", script)
 }
 
 func TestShellFromShellPath(t *testing.T) {

--- a/internal/runner/shellraw.go
+++ b/internal/runner/shellraw.go
@@ -20,7 +20,7 @@ func (s ShellRaw) DryRun(ctx context.Context, w io.Writer) {
 
 	_, _ = b.WriteString(fmt.Sprintf("#!%s\n\n", s.ProgramPath()))
 	_, _ = b.WriteString(fmt.Sprintf("// run in %q\n\n", s.Dir))
-	_, _ = b.WriteString(prepareScript(strings.Join(s.Cmds, "\n")))
+	_, _ = b.WriteString(prepareScript(strings.Join(s.Cmds, "\n"), s.ShellType()))
 
 	_, err := w.Write(b.Bytes())
 	if err != nil {

--- a/internal/shell/format.go
+++ b/internal/shell/format.go
@@ -1,15 +1,23 @@
 package shell
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 func StripComments(lines []string) (ret []string) {
 	for _, l := range lines {
 		l = strings.TrimSpace(l)
 
-		if !strings.HasPrefix(l, "#") {
-			ret = append(ret, l)
+		split := strings.SplitN(l, "#", 2)
+
+		if len(split) == 0 || split[0] == "" {
+			continue
 		}
+
+		ret = append(ret, strings.TrimRightFunc(split[0], unicode.IsSpace))
 	}
+
 	return
 }
 

--- a/internal/shell/format.go
+++ b/internal/shell/format.go
@@ -1,0 +1,28 @@
+package shell
+
+import "strings"
+
+func TryGetNonCommentLine(lines []string) string {
+	var line string
+
+	for _, l := range lines {
+		if l == "" {
+			continue
+		}
+
+		l = strings.TrimSpace(l)
+
+		if strings.HasPrefix(l, "#") {
+			continue
+		}
+
+		line = l
+		break
+	}
+
+	if line == "" && len(lines) > 0 {
+		line = lines[0]
+	}
+
+	return line
+}

--- a/internal/shell/format.go
+++ b/internal/shell/format.go
@@ -2,27 +2,27 @@ package shell
 
 import "strings"
 
-func TryGetNonCommentLine(lines []string) string {
-	var line string
-
+func StripComments(lines []string) (ret []string) {
 	for _, l := range lines {
-		if l == "" {
-			continue
-		}
-
 		l = strings.TrimSpace(l)
 
-		if strings.HasPrefix(l, "#") {
-			continue
+		if !strings.HasPrefix(l, "#") {
+			ret = append(ret, l)
 		}
+	}
+	return
+}
 
-		line = l
-		break
+func TryGetNonCommentLine(lines []string) string {
+	stripped := StripComments(lines)
+
+	if len(stripped) > 0 {
+		return stripped[0]
 	}
 
-	if line == "" && len(lines) > 0 {
-		line = lines[0]
+	if len(lines) > 0 {
+		return lines[0]
 	}
 
-	return line
+	return ""
 }

--- a/internal/shell/format_test.go
+++ b/internal/shell/format_test.go
@@ -1,0 +1,47 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+)
+
+func Test_StripComments(t *testing.T) {
+	cmd := []string{
+		"# Commented line",
+		"# Commented line # with subcomment",
+		"echo Hello World # with comment",
+		"echo Hello World",
+	}
+
+	assert.Equal(t, []string{
+		"echo Hello World",
+		"echo Hello World",
+	}, StripComments(cmd))
+}
+
+func Test_TryGetNonCommentLine(t *testing.T) {
+	assert.Equal(t,
+		"echo Hello World",
+		TryGetNonCommentLine([]string{
+			"# Commented line",
+			"echo Hello World",
+		}),
+	)
+
+	assert.Equal(t,
+		"echo Hello World",
+		TryGetNonCommentLine([]string{
+			"# Commented line",
+			"echo Hello World #with comment",
+		}),
+	)
+
+	assert.Equal(t,
+		"# Commented line",
+		TryGetNonCommentLine([]string{
+			"# Commented line",
+			"# Only Comments",
+		}),
+	)
+}

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -51,6 +51,13 @@ You can omit the language, and `runme` will assume you are in shell:
 $ echo "Hello, runme!"
 ```
 
+Names will automatically be inferred from a script's contents:
+
+```sh
+# This is a pesky comment
+echo Inferred
+```
+
 With `{name=hello}` you can annotate it and give it a nice name:
 
 ```sh {name=echo}
@@ -103,6 +110,7 @@ func main() {
 NAME	FIRST COMMAND	# OF COMMANDS	DESCRIPTION
 echo-hello	echo "Hello, runme!"	1	This is a basic snippet with shell command.
 echo-hello-2	echo "Hello, runme!"	1	You can omit the language, and runme will assume you are in shell.
+echo-inferred	echo Inferred	1	Names will automatically be inferred from a script's contents.
 echo	echo "Hello, runme!"	1	With {name=hello} you can annotate it and give it a nice name.
 echo-1	echo "1"	3	It can contain multiple lines too.
 echo-hello-3	echo "Hello, runme! Again!"	1	Also, the dollar sign is not needed.
@@ -111,6 +119,7 @@ package-main	package main	9	It can also execute a snippet of Go code.
 -- golden-list-disallow-unknown.txt --
 NAME	FIRST COMMAND	# OF COMMANDS	DESCRIPTION
 echo-hello	echo "Hello, runme!"	1	This is a basic snippet with shell command.
+echo-inferred	echo Inferred	1	Names will automatically be inferred from a script's contents.
 echo	echo "Hello, runme!"	1	With {name=hello} you can annotate it and give it a nice name.
 echo-1	echo "1"	3	It can contain multiple lines too.
 echo-hello-3	echo "Hello, runme! Again!"	1	Also, the dollar sign is not needed.

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -115,7 +115,7 @@ echo	echo "Hello, runme!"	1	With {name=hello} you can annotate it and give it a 
 echo-1	echo "1"	3	It can contain multiple lines too.
 echo-hello-3	echo "Hello, runme! Again!"	1	Also, the dollar sign is not needed.
 tempdir	temp_dir=$(mktemp -d -t "runme-XXXXXXX")	7	It works with cd, pushd, and similar because all lines are executed as a single script.
-package-main	package main	9	It can also execute a snippet of Go code.
+package-main	package main	7	It can also execute a snippet of Go code.
 -- golden-list-disallow-unknown.txt --
 NAME	FIRST COMMAND	# OF COMMANDS	DESCRIPTION
 echo-hello	echo "Hello, runme!"	1	This is a basic snippet with shell command.
@@ -124,4 +124,4 @@ echo	echo "Hello, runme!"	1	With {name=hello} you can annotate it and give it a 
 echo-1	echo "1"	3	It can contain multiple lines too.
 echo-hello-3	echo "Hello, runme! Again!"	1	Also, the dollar sign is not needed.
 tempdir	temp_dir=$(mktemp -d -t "runme-XXXXXXX")	7	It works with cd, pushd, and similar because all lines are executed as a single script.
-package-main	package main	9	It can also execute a snippet of Go code.
+package-main	package main	7	It can also execute a snippet of Go code.


### PR DESCRIPTION
 - Removes shlex and essentially all forms of command normalization; commands are joined with new lines rather than semicolons
 - Try to ignore comments when auto-generating name ~~(**needs tests before merge**)~~

The reason for removing command normalization is that it should be handled by bash already. The `Args` field of `exec.Command` can take new lines, and bash will deal with backslashes on its own. Also, new lines appear to act the same as semicolons for most purposes, at least in `bash`.

Attempting to do normalization on our own is causing issues for users, such as #188 

I suppose it might not be handled by some shells like `sh`, but that does not mean that we should attempt to do normalization ourselves.

cc @adambabik 