### PR TITLE
internal/cmd/run, internal/cmd/tui: resolve fChdir

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -65,9 +66,11 @@ func runCmd() *cobra.Command {
 				stdin = bytes.NewReader(nil)
 			}
 
+			dir, _ := filepath.Abs(fChdir)
+
 			runOpts := []client.RunnerOption{
 				client.WithinShellMaybe(),
-				client.WithDir(fChdir),
+				client.WithDir(dir),
 				client.WithStdin(stdin),
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -52,8 +53,10 @@ func tuiCmd() *cobra.Command {
 				}
 			}()
 
+			dir, _ := filepath.Abs(fChdir)
+
 			opts := []client.RunnerOption{
-				client.WithDir(fChdir),
+				client.WithDir(dir),
 				client.WithStdin(cmd.InOrStdin()),
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),


### PR DESCRIPTION
Uses absolute path instead of relative.

Using relative paths introduces bugs around locating executables.