### PR TITLE
internal/cmd/run: run in raw mode

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -122,7 +122,7 @@ func runCmd() *cobra.Command {
 
 				err = runner.RunBlock(ctx, block)
 
-				current.Reset()
+				_ = current.Reset()
 			}
 
 			if err != nil {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containerd/console"
 	"github.com/pkg/errors"
 	"github.com/rwtodd/Go.Sed/sed"
 	"github.com/spf13/cobra"
@@ -115,7 +116,15 @@ func runCmd() *cobra.Command {
 				return runner.DryRunBlock(ctx, block, cmd.ErrOrStderr())
 			}
 
-			err = runner.RunBlock(ctx, block)
+			{
+				current := console.Current()
+				_ = current.SetRaw()
+
+				err = runner.RunBlock(ctx, block)
+
+				current.Reset()
+			}
+
 			if err != nil {
 				if err != nil && errors.Is(err, io.ErrClosedPipe) {
 					err = nil

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/containerd/console"
 	"github.com/mgutz/ansi"
 	"github.com/muesli/cancelreader"
 	"github.com/pkg/errors"
@@ -112,10 +111,7 @@ func tuiCmd() *cobra.Command {
 
 				ctx, cancel := ctxWithSigCancel(cmd.Context())
 
-				{
-					current := console.Current()
-					_ = current.SetRaw()
-
+				err = inRawMode(func() error {
 					stdin, _ := cancelreader.NewReader(cmd.InOrStdin())
 
 					if err := client.ApplyOptions(
@@ -127,8 +123,8 @@ func tuiCmd() *cobra.Command {
 
 					err = runnerClient.RunBlock(ctx, result.block)
 
-					_ = current.Reset()
-				}
+					return err
+				})
 
 				cancel()
 


### PR DESCRIPTION
Should run in terminal raw mode when using `runme run`, similar to how TUI is currently handled.