### PR TITLE
allow copying from tui with "y" or "c"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Microsoft/go-winio v0.6.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/bufbuild/connect-go v1.4.1
 	github.com/bufbuild/connect-grpchealth-go v1.0.0
 	github.com/bufbuild/connect-grpcreflect-go v1.0.0
@@ -38,7 +39,6 @@ require (
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
 	github.com/briandowns/spinner v1.18.1 // indirect
 	github.com/cli/go-gh v1.0.0 // indirect

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/atotto/clipboard"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mgutz/ansi"
 	"github.com/muesli/cancelreader"
@@ -313,6 +314,10 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.expanded[m.cursor] = struct{}{}
 			}
+
+		case "y", "c":
+			command := strings.Join(m.blocks[m.cursor].Lines(), "\n")
+			_ = clipboard.WriteAll(command)
 
 		case "enter", "l":
 			m.result = tuiResult{


### PR DESCRIPTION
Use "y" or "c" to copy command contents to clipboard.

Maybe we should escape new lines with `\`?