### PR TITLE
internal/runner: Pass envs to most recent session only on creation

### DIFF
--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -131,14 +131,20 @@ func (r *RemoteRunner) RunBlock(ctx context.Context, block *document.CodeBlock) 
 
 	tty := block.Interactive()
 
-	err = stream.Send(&runnerv1.ExecuteRequest{
+	req := &runnerv1.ExecuteRequest{
 		ProgramName:     runner.ShellPath(),
 		Directory:       r.dir,
 		Commands:        block.Lines(),
 		Tty:             tty,
 		SessionId:       r.sessionID,
 		SessionStrategy: r.sessionStrategy,
-	})
+	}
+
+	if r.sessionStrategy == runnerv1.SessionStrategy_SESSION_STRATEGY_MOST_RECENT {
+		req.Envs = os.Environ()
+	}
+
+	err = stream.Send(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to send initial request")
 	}


### PR DESCRIPTION
This PR introduces a change in behavior that helps make most recent session behave better in most circumstances:

 - In `recent` mode, Envs in an `Execute` request are passed to the session only on creation
 - In `manual` mode, Envs in an `Execute` request are always passed to the provided session
 - The remote client passes operating system's environment variables down in `recent` mode

This PR is needed for persistent environment vars in CI.