### PR TITLE
internal/cmd: implement insecure mode

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -202,6 +202,8 @@ func getDefaultConfigHome() string {
 
 type runFunc func(context.Context) error
 
+const tlsFileMode = os.FileMode(int(0o700))
+
 func generateTLS(tlsDir string, logger *zap.Logger) (*tls.Config, error) {
 	if info, err := os.Stat(tlsDir); err != nil {
 		if err := os.MkdirAll(tlsDir, tlsFileMode); err != nil {

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"strings"
 
@@ -31,6 +32,10 @@ func environmentDumpCmd() *cobra.Command {
 		Short: "Dump environment variables to stdout",
 		Long:  "Dumps all environment variables to stdout as a list of K=V separated by null terminators",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !fInsecure {
+				return errors.New("must be run in insecure mode; enable by running with --insecure flag")
+			}
+
 			dumped := getDumpedEnvironment()
 
 			_, _ = cmd.OutOrStdout().Write([]byte(dumped))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	fAllowUnknown bool
 	fChdir        string
 	fFileName     string
+	fInsecure     bool
 )
 
 func Root() *cobra.Command {
@@ -48,6 +49,7 @@ func Root() *cobra.Command {
 	pflags.BoolVar(&fAllowUnknown, "allow-unknown", true, "Display snippets without known executor")
 	pflags.StringVar(&fChdir, "chdir", getCwd(), "Switch to a different working directory before executing the command")
 	pflags.StringVar(&fFileName, "filename", "README.md", "Name of the README file")
+	pflags.BoolVar(&fInsecure, "insecure", false, "Run command in insecure-mode")
 
 	setAPIFlags(pflags)
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -26,8 +27,6 @@ import (
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
-
-const tlsFileMode = os.FileMode(int(0o700))
 
 func serverCmd() *cobra.Command {
 	const (
@@ -70,7 +69,7 @@ The kernel is used to run long running processes like shells and interacting wit
 
 			var tlsConfig *tls.Config
 
-			if tlsDir != "" {
+			if !fInsecure {
 				tlsConfig, err = generateTLS(tlsDir, logger)
 
 				if err != nil {
@@ -179,7 +178,7 @@ The kernel is used to run long running processes like shells and interacting wit
 	cmd.Flags().BoolVar(&useConnectProtocol, "connect-protocol", false, "Use Connect Protocol (https://connect.build/)")
 	cmd.Flags().BoolVar(&devMode, "dev", false, "Enable development mode")
 	cmd.Flags().BoolVar(&enableRunner, "runner", false, "Enable runner service")
-	cmd.Flags().StringVar(&tlsDir, "tls", "", "Directory in which to generate TLS certificates & use for all incoming and outgoing messages")
+	cmd.Flags().StringVar(&tlsDir, "tls", filepath.Join(os.TempDir(), "runme", "tls"), "Directory in which to generate TLS certificates & use for all incoming and outgoing messages")
 
 	return &cmd
 }

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -436,5 +436,5 @@ func (c *command) setWinsize(winsize *pty.Winsize) {
 
 func getDumpCmd() string {
 	path, _ := os.Executable()
-	return strings.Join([]string{path, "env", "dump"}, " ")
+	return strings.Join([]string{path, "env", "dump", "--insecure"}, " ")
 }


### PR DESCRIPTION
Closes #198 

- Introduces persistent `--insecure` flag which enables "insecure mode"
- `runme server` runs in TLS unless in insecure mode, in which case it is plain-text
- `runme env dump` requires insecure mode to run