### PR TITLE
feat: ask to authenticate when GitHub token is invalid

### DIFF
--- a/internal/cmd/api_common.go
+++ b/internal/cmd/api_common.go
@@ -119,10 +119,10 @@ func newAuth() auth.Authorizer {
 	}
 }
 
-func newAPIClient(ctx context.Context) *http.Client {
+func newAPIClient(ctx context.Context, token string) *http.Client {
 	opts := []client.Option{
 		client.WithTokenGetter(func() (string, error) {
-			return newAuth().GetToken(ctx)
+			return token, nil
 		}),
 		client.WithUserAgent(version.BuildVersion),
 	}

--- a/internal/cmd/api_common.go
+++ b/internal/cmd/api_common.go
@@ -119,10 +119,10 @@ func newAuth() auth.Authorizer {
 	}
 }
 
-func newAPIClient(ctx context.Context, token string) *http.Client {
+func newAPIClient(ctx context.Context, auth auth.Authorizer) *http.Client {
 	opts := []client.Option{
 		client.WithTokenGetter(func() (string, error) {
-			return token, nil
+			return auth.GetToken(ctx)
 		}),
 		client.WithUserAgent(version.BuildVersion),
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/auth"
 	"github.com/stateful/runme/internal/tui"
 )
 
@@ -42,7 +43,7 @@ func logoutCmd() *cobra.Command {
 	return cmd
 }
 
-func checkAuthenticated(ctx context.Context, cmd *cobra.Command, refresh bool) error {
+func checkAuthenticated(ctx context.Context, cmd *cobra.Command, auth auth.Authorizer, refresh bool) error {
 	text := "It looks like you're not logged in. Do you want to log in now?"
 	if refresh {
 		text = "It seems that your authentication has expired. Would you like to re-authenticate now?"
@@ -59,7 +60,7 @@ func checkAuthenticated(ctx context.Context, cmd *cobra.Command, refresh bool) e
 	shouldLogIn := finalModel.(tui.StandaloneQuestionModel).Confirmed()
 
 	if shouldLogIn {
-		if loginErr := newAuth().Login(ctx); loginErr != nil {
+		if loginErr := auth.Login(ctx); loginErr != nil {
 			return errors.Wrap(loginErr, "failed to login")
 		}
 	}

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -42,9 +42,13 @@ func logoutCmd() *cobra.Command {
 	return cmd
 }
 
-func checkAuthenticated(ctx context.Context, cmd *cobra.Command) error {
+func checkAuthenticated(ctx context.Context, cmd *cobra.Command, refresh bool) error {
+	text := "It looks like you're not logged in. Do you want to log in now?"
+	if refresh {
+		text = "It seems that your authentication has expired. Would you like to re-authenticate now?"
+	}
 	model := tui.NewStandaloneQuestionModel(
-		"It looks like you're not logged in. Do you want to log in now?",
+		text,
 		tui.MinimalKeyMap,
 		tui.DefaultStyles,
 	)

--- a/internal/cmd/suggest.go
+++ b/internal/cmd/suggest.go
@@ -106,8 +106,7 @@ func runSuggestAndRetry(ctx context.Context, cmd *cobra.Command, runF runFunc) e
 	case errors.Is(err, graphql.ErrNoData):
 		return err
 	case !recoverableWithLogin(err):
-
-		return errors.New("The Runme API is currently unavailable. Please try again later or report the issue at https://discord.com/channels/878764303052865537.")
+		return errors.New("the Runme API is currently unavailable. Please try again later or report the issue at https://discord.com/channels/878764303052865537")
 	default:
 		// continue as it likely was an auth problem
 	}

--- a/internal/cmd/suggest.go
+++ b/internal/cmd/suggest.go
@@ -42,7 +42,7 @@ bad. Please use with discretion.
 			auth := newAuth()
 			_, err := auth.GetToken(cmd.Context())
 			if err != nil {
-				if err := checkAuthenticated(ctx, cmd, !recoverableWithLogin(err)); err != nil {
+				if err := checkAuthenticated(ctx, cmd, auth, !recoverableWithLogin(err)); err != nil {
 					return err
 				}
 			}

--- a/internal/cmd/suggest.go
+++ b/internal/cmd/suggest.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"log"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -38,13 +39,14 @@ bad. Please use with discretion.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := graphql.ContextWithTrackInput(cmd.Context(), trackInputFromCmd(cmd, args))
 
-			token, err := newAuth().GetToken(cmd.Context())
+			auth := newAuth()
+			_, err := auth.GetToken(cmd.Context())
 			if err != nil {
 				if err := checkAuthenticated(ctx, cmd, !recoverableWithLogin(err)); err != nil {
 					return err
 				}
 			}
-			client, err := graphql.New(graphqlEndpoint(), newAPIClient(cmd.Context(), token))
+			client, err := graphql.New(graphqlEndpoint(), newAPIClient(cmd.Context(), auth))
 			if err != nil {
 				return err
 			}
@@ -106,7 +108,8 @@ func runSuggestAndRetry(ctx context.Context, cmd *cobra.Command, runF runFunc) e
 	case errors.Is(err, graphql.ErrNoData):
 		return err
 	case !recoverableWithLogin(err):
-		return errors.New("the Runme API is currently unavailable. Please try again later or report the issue at https://discord.com/channels/878764303052865537")
+		log.Print("Unexpected error occurred. Please try again later or report the issue at https://github.com/stateful/runme or our Discord at https://discord.gg/stateful")
+		return errors.Wrap(err, "failed to run command")
 	default:
 		// continue as it likely was an auth problem
 	}


### PR DESCRIPTION
Doing small changes for https://github.com/stateful/runme/issues/123
- If GitHub token is expired or invalid ask for login again to get a new token. 
- if there is any error on the Runme API display a better message. 