### PR TITLE
feat: allowing token dir override

### DIFF
--- a/cmd/gqltool/main.go
+++ b/cmd/gqltool/main.go
@@ -40,7 +40,6 @@ func main() {
 }
 
 func getDefaultConfigHome() string {
-	// TODO(adamb): switch to os.UserConfigDir()
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)

--- a/cmd/gqltool/main.go
+++ b/cmd/gqltool/main.go
@@ -40,9 +40,16 @@ func main() {
 }
 
 func getDefaultConfigHome() string {
-	dir, err := os.UserHomeDir()
+	dir, err := os.UserConfigDir()
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(dir, ".config", "stateful")
+	_, fErr := os.Stat(dir)
+	if os.IsNotExist(fErr) {
+		mkdErr := os.MkdirAll(dir, os.ModePerm)
+		if mkdErr != nil {
+			dir = os.TempDir()
+		}
+	}
+	return filepath.Join(dir, "stateful")
 }

--- a/cmd/gqltool/main.go
+++ b/cmd/gqltool/main.go
@@ -6,17 +6,17 @@ import (
 	"fmt"
 	"log" // revive:disable-line
 	"os"
-	"path/filepath"
 
 	"github.com/stateful/runme/internal/auth"
 	"github.com/stateful/runme/internal/client"
 	"github.com/stateful/runme/internal/client/graphql"
+	"github.com/stateful/runme/internal/cmd"
 	"golang.org/x/oauth2"
 )
 
 var (
 	apiURL   = flag.String("api-url", "https://api.stateful.com", "The API base address")
-	tokenDir = flag.String("token-dir", getDefaultConfigHome(), "The directory with tokens")
+	tokenDir = flag.String("token-dir", cmd.GetDefaultConfigHome(), "The directory with tokens")
 )
 
 func init() {
@@ -37,19 +37,4 @@ func main() {
 		log.Fatal(err)
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "%s", result)
-}
-
-func getDefaultConfigHome() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		panic(err)
-	}
-	_, fErr := os.Stat(dir)
-	if os.IsNotExist(fErr) {
-		mkdErr := os.MkdirAll(dir, os.ModePerm)
-		if mkdErr != nil {
-			dir = os.TempDir()
-		}
-	}
-	return filepath.Join(dir, "stateful")
 }

--- a/internal/cmd/api_common.go
+++ b/internal/cmd/api_common.go
@@ -29,7 +29,7 @@ const (
 	traceAllF    = "trace-all"
 	enableChaosF = "enable-chaos"
 	apiTokenF    = "api-token"
-	tokenDirF    = "token-dir"
+	configDirF   = "config-dir"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 	traceAll    bool
 	enableChaos bool
 	apiToken    string
-	tokenDir    string
+	configDir   string
 )
 
 // TODO(adamb): temporarily we authorize using Github as IdP.
@@ -58,13 +58,13 @@ func getTrace() bool       { return trace || traceAll }
 func getTraceAll() bool    { return traceAll }
 func getEnableChaos() bool { return enableChaos }
 func getAPIToken() string  { return apiToken }
-func getTokenDir() string  { return tokenDir }
+func getConfigDir() string { return configDir }
 
 func setAPIFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&authBaseURL, authURLF, defaultAuthURL, "Backend URL to authorize you")
 	flagSet.StringVar(&apiBaseURL, apiURLF, "https://api.stateful.com", "Backend URL with API")
 	flagSet.StringVar(&apiToken, apiTokenF, "", "API token")
-	flagSet.StringVar(&tokenDir, tokenDirF, getDefaultConfigHome(), "Location dir where token will be save")
+	flagSet.StringVar(&configDir, configDirF, GetDefaultConfigHome(), "Location where token will be saved")
 	flagSet.BoolVar(&trace, traceF, false, "Trace HTTP calls")
 	flagSet.BoolVar(&traceAll, traceAllF, false, "Trace all HTTP calls including authentication (it might leak sensitive data to output)")
 	flagSet.BoolVar(&enableChaos, enableChaosF, false, "Enable Chaos Monkey mode for GraphQL requests")
@@ -81,7 +81,7 @@ func setAPIFlags(flagSet *pflag.FlagSet) {
 	mustMarkHidden(traceF)
 	mustMarkHidden(traceAllF)
 	mustMarkHidden(enableChaosF)
-	mustMarkHidden(tokenDirF)
+	mustMarkHidden(configDirF)
 }
 
 var (
@@ -104,7 +104,7 @@ func (a *authorizerWithEnv) GetToken(ctx context.Context) (string, error) {
 }
 
 func newAuth() auth.Authorizer {
-	tokenStorage.Location = getTokenDir()
+	tokenStorage.Location = getConfigDir()
 	if authAuthorizer != nil {
 		return authAuthorizer
 	}

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -183,14 +183,14 @@ func printfInfo(msg string, args ...any) {
 	_, _ = os.Stderr.Write(buf.Bytes())
 }
 
-func getDefaultConfigHome() string {
+func GetDefaultConfigHome() string {
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		dir = os.TempDir()
 	}
 	_, fErr := os.Stat(dir)
 	if os.IsNotExist(fErr) {
-		mkdErr := os.MkdirAll(dir, os.ModePerm)
+		mkdErr := os.MkdirAll(dir, 0o700)
 		if mkdErr != nil {
 			dir = os.TempDir()
 		}
@@ -257,4 +257,4 @@ type runFunc func(context.Context) error
 
 const tlsFileMode = os.FileMode(int(0o700))
 
-var defaultTLSDir = filepath.Join(getDefaultConfigHome(), "tls")
+var defaultTLSDir = filepath.Join(GetDefaultConfigHome(), "tls")

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -184,7 +184,6 @@ func printfInfo(msg string, args ...any) {
 }
 
 func getDefaultConfigHome() string {
-	// TODO(adamb): switch to os.UserConfigDir()
 	dir, err := os.UserHomeDir()
 	if err != nil {
 		dir = os.TempDir()

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -184,11 +184,18 @@ func printfInfo(msg string, args ...any) {
 }
 
 func getDefaultConfigHome() string {
-	dir, err := os.UserHomeDir()
+	dir, err := os.UserConfigDir()
 	if err != nil {
 		dir = os.TempDir()
 	}
-	return filepath.Join(dir, ".config", "stateful")
+	_, fErr := os.Stat(dir)
+	if os.IsNotExist(fErr) {
+		mkdErr := os.MkdirAll(dir, os.ModePerm)
+		if mkdErr != nil {
+			dir = os.TempDir()
+		}
+	}
+	return filepath.Join(dir, "stateful")
 }
 
 func setRunnerFlags(cmd *cobra.Command, serverAddr *string) func() ([]client.RunnerOption, error) {


### PR DESCRIPTION
Adding a new flag to override `getDefaultConfigHome()`

How to use it 
```
--config-dir /Users/username/custom-folder
```

Now we are using `os.UserConfigDir()` 

Address request in this issue https://github.com/stateful/runme/issues/123