### PR TITLE
Write sigint character to pty process

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -308,6 +308,10 @@ func (c *command) stop(sig os.Signal) error {
 	}
 
 	if c.pty != nil {
+		if sig == os.Interrupt {
+			_, _ = c.pty.Write([]byte{0x3})
+		}
+
 		if err := c.pty.Close(); err != nil {
 			c.logger.Info("failed to close pty; continuing")
 		}


### PR DESCRIPTION
Fixes problem where processes in interactive mode (spawned in `-i` mode) won't end on SIGINT.

This is a work-around for that problem. Eventually we may want a better solution.