### PR TITLE
feat: using new endpoint for runme cli auth

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -511,7 +511,7 @@ func (a *Auth) getAndSaveOAuthToken(ctx context.Context, code string) (Token, er
 	return token, a.Storage.Save(oauthTokenKey, token)
 }
 
-const APIAuthEndpoint = "/auth/cli"
+const APIAuthEndpoint = "/auth/cli/runme"
 
 // TODO(adamb): this is a hack, it temporarily uses an endpoint
 // that is dedicated for the VS Code to exchange the GH access token


### PR DESCRIPTION
Using the new endpoint to authenticate runme from the CLI that will track signup origin 

Don't merge or release until this PR is 100% in prod. 
https://github.com/stateful/baldaquin/pull/539