### PR TITLE
internal/runner: remove `DisableEcho`

### DIFF
--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -201,7 +201,7 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 		cmdCtx = context.Background()
 	}
 
-	if err := cmd.StartWithOpts(cmdCtx, &startOpts{DisableEcho: req.Tty}); err != nil {
+	if err := cmd.StartWithOpts(cmdCtx, &startOpts{}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Seems we manually disable tty echo by default in the runner.

This is causing issues for commands like `ssh git@gitlab.com`, which normally echo the output back, but now will not (since the default behavior is to echo, but we have overridden that).

@adambabik Could really use your insight here - why did you do this? I'm not able to replicate the "double input" issue in any of my tests - do you remember what kinds of scripts were leading to this?