### PR TITLE
Support multi-runner in `run` command

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -185,7 +185,7 @@ func runCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the final command without executing.")
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
-	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run scripts in parallel.")
+	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 
 	getRunnerOpts = setRunnerFlags(&cmd, &serverAddr)
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -35,6 +35,10 @@ func runCmd() *cobra.Command {
 		Args:              cobra.ArbitraryArgs,
 		ValidArgsFunction: validCmdNames,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("must provide at least one command to run")
+			}
+
 			runBlocks := make([]*document.CodeBlock, 0)
 
 			{

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -144,7 +144,7 @@ func runCmd() *cobra.Command {
 			}
 
 			if parallel {
-				multiRunner.StdoutPrefix = "[%[1]s] "
+				multiRunner.StdoutPrefix = fmt.Sprintf("[%s] ", blockColor.Sprint("%s"))
 			}
 
 			defer multiRunner.Cleanup(cmd.Context())

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -124,11 +124,18 @@ func runCmd() *cobra.Command {
 						scriptRunText += "s"
 					}
 
+					extraText := ""
+
+					if parallel {
+						extraText = " in parallel"
+					}
+
 					return fmt.Sprintf(
-						"%s %s %s...\n",
+						"%s %s %s%s...\n",
 						infoMsgPrefix,
 						textColor.Sprint(scriptRunText),
 						strings.Join(blockNames, ", "),
+						textColor.Sprint(extraText),
 					)
 				},
 				PostRunMsg: func(block *document.CodeBlock, exitCode uint) string {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -110,6 +110,8 @@ func runCmd() *cobra.Command {
 			blockColor := color.New(color.Bold, color.FgYellow)
 			playColor := color.New(color.BgHiBlue, color.Bold, color.FgWhite)
 			textColor := color.New()
+			successColor := color.New(color.FgGreen)
+			failureColor := color.New(color.FgRed)
 
 			infoMsgPrefix := playColor.Sprint(" ► ")
 
@@ -143,9 +145,18 @@ func runCmd() *cobra.Command {
 					)
 				},
 				PostRunMsg: func(block *document.CodeBlock, exitCode uint) string {
+					var statusIcon string
+
+					if exitCode == 0 {
+						statusIcon = successColor.Sprint("✓")
+					} else {
+						statusIcon = failureColor.Sprint("𐄂")
+					}
+
 					return textColor.Sprintf(
-						"%s %s %s %s %v\n",
+						"%s %s %s %s %s %v\n",
 						infoMsgPrefix,
+						statusIcon,
 						textColor.Sprint("Script"),
 						blockColor.Sprint(block.Name()),
 						textColor.Sprint("exited with code"),

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -124,7 +124,7 @@ func runCmd() *cobra.Command {
 						blockNames[i] = blockColor.Sprint(blockNames[i])
 					}
 
-					scriptRunText := "Running script"
+					scriptRunText := "Running task"
 
 					if len(blocks) > 1 {
 						scriptRunText += "s"
@@ -157,7 +157,7 @@ func runCmd() *cobra.Command {
 						"%s %s %s %s %s %v\n",
 						infoMsgPrefix,
 						statusIcon,
-						textColor.Sprint("Script"),
+						textColor.Sprint("Task"),
 						blockColor.Sprint(block.Name()),
 						textColor.Sprint("exited with code"),
 						exitCode,

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -144,7 +144,7 @@ func runCmd() *cobra.Command {
 			}
 
 			if parallel {
-				multiRunner.StdoutPrefix = fmt.Sprintf("[%s] ", blockColor.Sprint("%s"))
+				multiRunner.StdoutPrefix = fmt.Sprintf("[%s] ", blockColor.Sprintf("%%s"))
 			}
 
 			defer multiRunner.Cleanup(cmd.Context())

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -28,7 +28,7 @@ func runCmd() *cobra.Command {
 	)
 
 	cmd := cobra.Command{
-		Use:               "run",
+		Use:               "run <commands>",
 		Aliases:           []string{"exec"},
 		Short:             "Run a selected command",
 		Long:              "Run a selected command identified based on its unique parsed name.",

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -23,9 +23,15 @@ type Runner interface {
 
 	setWithinShell() error
 	setDir(dir string) error
+
 	setStdin(stdin io.Reader) error
 	setStdout(stdout io.Writer) error
 	setStderr(stdout io.Writer) error
+
+	getStdin() io.Reader
+	getStdout() io.Writer
+	getStderr() io.Writer
+
 	setLogger(logger *zap.Logger) error
 	setEnableBackgroundProcesses(disableBackground bool) error
 
@@ -35,6 +41,8 @@ type Runner interface {
 	RunBlock(ctx context.Context, block *document.CodeBlock) error
 	DryRunBlock(ctx context.Context, block *document.CodeBlock, w io.Writer, opts ...RunnerOption) error
 	Cleanup(ctx context.Context) error
+
+	Clone() Runner
 }
 
 func WithSession(s *runner.Session) RunnerOption {
@@ -88,6 +96,24 @@ func WithStdout(stdout io.Writer) RunnerOption {
 func WithStderr(stderr io.Writer) RunnerOption {
 	return func(rc Runner) error {
 		return rc.setStderr(stderr)
+	}
+}
+
+func WithStdinTransform(op func(io.Reader) io.Reader) RunnerOption {
+	return func(rc Runner) error {
+		return rc.setStdin(op(rc.getStdin()))
+	}
+}
+
+func WithStdoutTransform(op func(io.Writer) io.Writer) RunnerOption {
+	return func(rc Runner) error {
+		return rc.setStdout(op(rc.getStdout()))
+	}
+}
+
+func WithStderrTransform(op func(io.Writer) io.Writer) RunnerOption {
+	return func(rc Runner) error {
+		return rc.setStderr(op(rc.getStderr()))
 	}
 }
 

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -28,6 +28,21 @@ type LocalRunner struct {
 	logger *zap.Logger
 }
 
+func (r *LocalRunner) Clone() Runner {
+	return &LocalRunner{
+		dir: r.dir,
+
+		stdin:  r.stdin,
+		stdout: r.stdout,
+		stderr: r.stderr,
+
+		shellID: r.shellID,
+		session: r.session,
+
+		logger: r.logger,
+	}
+}
+
 func (r *LocalRunner) setSession(s *runner.Session) error {
 	r.session = s
 	return nil
@@ -72,6 +87,18 @@ func (r *LocalRunner) setStdout(stdout io.Writer) error {
 func (r *LocalRunner) setStderr(stderr io.Writer) error {
 	r.stderr = stderr
 	return nil
+}
+
+func (r *LocalRunner) getStdin() io.Reader {
+	return r.stdin
+}
+
+func (r *LocalRunner) getStdout() io.Writer {
+	return r.stdout
+}
+
+func (r *LocalRunner) getStderr() io.Writer {
+	return r.stderr
 }
 
 func (r *LocalRunner) setLogger(logger *zap.Logger) error {

--- a/internal/runner/client/client_multi.go
+++ b/internal/runner/client/client_multi.go
@@ -1,0 +1,167 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/stateful/runme/internal/document"
+	"github.com/stateful/runme/internal/runner"
+)
+
+type MultiRunner struct {
+	Runner Runner
+
+	StdoutPrefix string
+
+	PreRunMsg  func(blocks []*document.CodeBlock, parallel bool) string
+	PostRunMsg func(block *document.CodeBlock, exitCode uint) string
+}
+
+type prefixWriter struct {
+	w      io.Writer
+	prefix string
+
+	haveWritten bool
+}
+
+func NewPrefixWriter(w io.Writer, prefix string) io.Writer {
+	return prefixWriter{
+		w:      w,
+		prefix: prefix,
+	}
+}
+
+func (w prefixWriter) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+
+	// lines := make([][]byte, 0)
+	// fmt.Println(p)
+
+	// data := make([]byte, 0)
+
+	// for _, line := range bytes.SplitAfter(p, []byte{'\n'}) {
+	// 	newLine := make([]byte, 0)
+
+	// 	// if !w.haveWritten || i != 0 {
+	// 	// 	newLine = append(newLine, []byte(w.prefix)...)
+	// 	// }
+
+	// 	newLine = append(newLine, []byte("[pre] ")...)
+	// 	newLine = append(newLine, line...)
+
+	// 	// lines = append(lines, newLine)
+	// 	data = append(data, newLine...)
+	// }
+
+	// w.haveWritten = true
+
+	// return w.w.Write(data)
+}
+
+func (m MultiRunner) RunBlocks(ctx context.Context, blocks []*document.CodeBlock, parallel bool) error {
+	if m.PreRunMsg != nil && parallel {
+		m.Runner.getStdout().Write([]byte(
+			m.PreRunMsg(blocks, parallel),
+		))
+	}
+
+	errChan := make(chan error, len(blocks))
+	var wg sync.WaitGroup
+
+	for _, block := range blocks {
+		runnerClient := m.Runner.Clone()
+
+		if m.PreRunMsg != nil && !parallel {
+			runnerClient.getStdout().Write([]byte(
+				m.PreRunMsg([]*document.CodeBlock{block}, parallel),
+			))
+		}
+
+		ApplyOptions(
+			runnerClient,
+			WithStdinTransform(func(r io.Reader) io.Reader {
+				if parallel {
+					// TODO: support stdin
+					return bytes.NewReader(nil)
+				}
+
+				return r
+			}),
+			WithStdoutTransform(func(w io.Writer) io.Writer {
+				if m.StdoutPrefix == "" {
+					return w
+				}
+
+				prefix := fmt.Sprintf(
+					m.StdoutPrefix,
+					block.Name(),
+				)
+
+				return NewPrefixWriter(w, prefix)
+			}),
+		)
+
+		run := func(block *document.CodeBlock) error {
+			err := runnerClient.RunBlock(ctx, block)
+
+			code := uint(0)
+
+			{
+				exitErr := (*runner.ExitError)(nil)
+				if errors.As(err, &exitErr) {
+					code = exitErr.Code
+				}
+			}
+
+			if m.PostRunMsg != nil {
+				runnerClient.getStdout().Write([]byte(
+					m.PostRunMsg(block, code),
+				))
+			}
+
+			return err
+		}
+
+		if !parallel {
+			err := run(block)
+			if err != nil {
+				return err
+			}
+		} else {
+			wg.Add(1)
+			go func(block *document.CodeBlock) {
+				defer wg.Done()
+				err := run(block)
+				errChan <- err
+			}(block)
+		}
+	}
+
+	wg.Wait()
+
+	errors := make([]error, 0)
+
+outer:
+	for {
+		select {
+		case err := <-errChan:
+			errors = append(errors, err)
+		default:
+			break outer
+		}
+	}
+
+	if len(errors) > 0 {
+		return errors[0]
+	}
+
+	return nil
+}
+
+func (m MultiRunner) Cleanup(ctx context.Context) error {
+	return m.Runner.Cleanup(ctx)
+}

--- a/internal/runner/client/client_multi.go
+++ b/internal/runner/client/client_multi.go
@@ -110,11 +110,8 @@ func (m MultiRunner) RunBlocks(ctx context.Context, blocks []*document.CodeBlock
 
 			code := uint(0)
 
-			{
-				exitErr := (*runner.ExitError)(nil)
-				if errors.As(err, &exitErr) {
-					code = exitErr.Code
-				}
+			if exitErr := (*runner.ExitError)(nil); errors.As(err, &exitErr) {
+				code = exitErr.Code
 			}
 
 			if m.PostRunMsg != nil {

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -38,6 +38,26 @@ type RemoteRunner struct {
 	enableBackground bool
 }
 
+func (r *RemoteRunner) Clone() Runner {
+	return &RemoteRunner{
+		dir: r.dir,
+
+		stdin:  r.stdin,
+		stdout: r.stdout,
+		stderr: r.stderr,
+
+		client:          nil,
+		sessionID:       r.sessionID,
+		sessionStrategy: r.sessionStrategy,
+		cleanupSession:  r.cleanupSession,
+
+		insecure: r.insecure,
+		tlsDir:   r.tlsDir,
+
+		enableBackground: r.enableBackground,
+	}
+}
+
 func (r *RemoteRunner) setDir(dir string) error {
 	r.dir = dir
 	return nil
@@ -56,6 +76,18 @@ func (r *RemoteRunner) setStdout(stdout io.Writer) error {
 func (r *RemoteRunner) setStderr(stderr io.Writer) error {
 	r.stderr = stderr
 	return nil
+}
+
+func (r *RemoteRunner) getStdin() io.Reader {
+	return r.stdin
+}
+
+func (r *RemoteRunner) getStdout() io.Writer {
+	return r.stdout
+}
+
+func (r *RemoteRunner) getStderr() io.Writer {
+	return r.stderr
 }
 
 func (r *RemoteRunner) setLogger(logger *zap.Logger) error {


### PR DESCRIPTION
Implements #229 

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/16108792/236587149-a49c50e5-8c16-4e4c-b5d0-d3dc0b958179.png">

Implementation is slightly different than the PR description. It runs the provided arguments in the order given, unless `-p` is provided, in which case it runs them in parallel.

@christian-bromann If you could try this out and let me know what issues you run into, that would be great!