### PR TITLE
Respect frontmatter in text range

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -71,7 +71,7 @@ func run() error {
 			return err
 		}
 
-		fmt.Println(resp.Notebook)
+		_, _ = fmt.Println(resp.Notebook)
 
 		return nil
 	}

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -44,6 +44,12 @@ type Cell struct {
 type Notebook struct {
 	Cells    []*Cell           `json:"cells"`
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	contentOffset int
+}
+
+func (n *Notebook) GetContentOffset() int {
+	return n.contentOffset
 }
 
 func toCells(node *document.Node, source []byte) (result []*Cell) {

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -23,7 +23,8 @@ func Deserialize(data []byte) (*Notebook, error) {
 	}
 
 	notebook := &Notebook{
-		Cells: toCells(node, data),
+		Cells:         toCells(node, data),
+		contentOffset: sections.ContentOffset,
 	}
 
 	// If Front Matter exists, store it in Notebook's metadata.

--- a/internal/document/editor/editorservice/service.go
+++ b/internal/document/editor/editorservice/service.go
@@ -35,8 +35,8 @@ func (s *parserServiceServer) Deserialize(_ context.Context, req *parserv1.Deser
 
 		if cellTextRange != nil {
 			TextRange = &parserv1.TextRange{
-				Start: uint32(cellTextRange.Start),
-				End:   uint32(cellTextRange.End),
+				Start: uint32(cellTextRange.Start + notebook.GetContentOffset()),
+				End:   uint32(cellTextRange.End + notebook.GetContentOffset()),
 			}
 		}
 

--- a/internal/document/parser.go
+++ b/internal/document/parser.go
@@ -9,8 +9,9 @@ import (
 )
 
 type ParsedSections struct {
-	FrontMatter []byte
-	Content     []byte
+	FrontMatter   []byte
+	Content       []byte
+	ContentOffset int
 }
 
 func ParseSections(source []byte) (result ParsedSections, _ error) {
@@ -21,6 +22,7 @@ func ParseSections(source []byte) (result ParsedSections, _ error) {
 		case parsedItemFrontMatter:
 			result.FrontMatter = item.Value(source)
 		case parsedItemContent:
+			result.ContentOffset = item.start
 			result.Content = item.Value(source)
 		case parsedItemError:
 			return result, item.err


### PR DESCRIPTION
Currently, we disregard frontmatter in text ranges. This causes misalignment of codelens in the vscode extension wherever there is frontmatter.

Fixes https://github.com/stateful/vscode-runme/issues/462.