### PR TITLE
internal/document/editor: parse frontmatter in yaml,json,toml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/henvic/httpretty v0.1.0
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.7
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/term v1.2.0-beta.2.0.20211217091447-1a4a3b719465

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0/go.mod h1:Bd5NYQ
 github.com/muesli/termenv v0.13.0 h1:wK20DRpJdDX8b7Ek2QfhvqhRQFZ237RGRO0RQ/Iqdy0=
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pelletier/go-toml/v2 v2.0.7 h1:muncTPStnKRos5dpVKULv2FVd4bMOhNePj9CjgDb8Us=
+github.com/pelletier/go-toml/v2 v2.0.7/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pjbgf/sha1cd v0.2.3 h1:uKQP/7QOzNtKYH7UTohZLcjF5/55EnTw0jO/Ru4jZwI=
 github.com/pjbgf/sha1cd v0.2.3/go.mod h1:HOK9QrgzdHpbc2Kzip0Q1yi3M2MFGPADtR6HjG65m5M=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -431,10 +431,6 @@ func Test_notebook_frontmatter(t *testing.T) {
 			require.NoError(t, getErr(&info))
 			require.NoError(t, info.other)
 			assert.Equal(t, "fish", fmtr.Shell)
-
-			// assert.Equal(t, 1, len(notebook.Cells))
-			// assert.Equal(t, MarkupKind, notebook.Cells[0].Kind)
-			// assert.Equal(t, "Test paragraph", notebook.Cells[0].Value)
 		})
 	}
 }


### PR DESCRIPTION
#88 #249

This internally gives the capability to parse frontmatter using the `notebook.ParsedFrontmatter()` method. This is cached for lazy evaluation.

In a follow-up PR, I'd like to expose this property so that the frontmatter is usable in the extension.