### PR TITLE
file/annotation specific cwd

### DIFF
--- a/examples/frontmatter/cwd/ABSOLUTE.md
+++ b/examples/frontmatter/cwd/ABSOLUTE.md
@@ -1,0 +1,15 @@
+---
+cwd: /tmp
+---
+
+```sh { name=absolute-pwd }
+pwd
+```
+
+```sh { name=absolute-rel-pwd cwd=../}
+pwd
+```
+
+```sh { name=absolute-abs-pwd cwd=/opt}
+pwd
+```

--- a/examples/frontmatter/cwd/NONE.md
+++ b/examples/frontmatter/cwd/NONE.md
@@ -1,0 +1,11 @@
+```sh { name=none-pwd }
+pwd
+```
+
+```sh { name=none-rel-pwd cwd=../}
+pwd
+```
+
+```sh { name=none-abs-pwd cwd=/opt}
+pwd
+```

--- a/examples/frontmatter/cwd/RELATIVE.md
+++ b/examples/frontmatter/cwd/RELATIVE.md
@@ -1,0 +1,15 @@
+---
+cwd: ../../../
+---
+
+```sh { name=relative-pwd }
+pwd
+```
+
+```sh { name=relative-rel-pwd cwd=../}
+pwd
+```
+
+```sh { name=relative-abs-pwd cwd=/opt}
+pwd
+```

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -410,3 +410,7 @@ func (b *CodeBlock) GetBlock() *CodeBlock {
 func (b *CodeBlock) GetFile() string {
 	return ""
 }
+
+func (b *CodeBlock) GetFrontmatter() *Frontmatter {
+	return &Frontmatter{}
+}

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -169,6 +169,10 @@ func (b *CodeBlock) Category() string {
 	return b.Attributes()["category"]
 }
 
+func (b *CodeBlock) Cwd() string {
+	return b.Attributes()["cwd"]
+}
+
 func (b *CodeBlock) PromptEnv() bool {
 	val, err := strconv.ParseBool(b.Attributes()["promptEnv"])
 	if err != nil {

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -411,6 +411,10 @@ func (b *CodeBlock) GetBlock() *CodeBlock {
 	return b
 }
 
+func (b *CodeBlock) GetFileRel() string {
+	return ""
+}
+
 func (b *CodeBlock) GetFile() string {
 	return ""
 }

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -411,6 +411,6 @@ func (b *CodeBlock) GetFile() string {
 	return ""
 }
 
-func (b *CodeBlock) GetFrontmatter() *Frontmatter {
-	return &Frontmatter{}
+func (b *CodeBlock) GetFrontmatter() Frontmatter {
+	return Frontmatter{}
 }

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -2,18 +2,14 @@ package editor
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 
-	"github.com/pelletier/go-toml/v2"
 	"github.com/stateful/runme/internal/document"
 	"github.com/yuin/goldmark/ast"
 	"golang.org/x/exp/slices"
-	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -31,10 +27,6 @@ const (
 type TextRange struct {
 	Start int `json:"start"`
 	End   int `json:"end"`
-}
-
-type Frontmatter struct {
-	Shell string
 }
 
 // Cell resembles NotebookCellData from VS Code.
@@ -55,76 +47,23 @@ type Notebook struct {
 
 	contentOffset int
 
-	parsedFrontmatter *Frontmatter
+	parsedFrontmatter *document.Frontmatter
 }
 
 func (n *Notebook) GetContentOffset() int {
 	return n.contentOffset
 }
 
-type FrontmatterParseInfo struct {
-	yaml error
-	json error
-	toml error
-
-	other error
-}
-
-func (fpi FrontmatterParseInfo) Error() error {
-	if fpi.other != nil {
-		return fpi.other
-	}
-
-	if fpi.yaml != nil {
-		return fpi.yaml
-	}
-
-	if fpi.json != nil {
-		return fpi.json
-	}
-
-	if fpi.toml != nil {
-		return fpi.toml
-	}
-
-	return nil
-}
-
-func (n *Notebook) ParsedFrontmatter() (f Frontmatter, info FrontmatterParseInfo) {
+func (n *Notebook) ParsedFrontmatter() (document.Frontmatter, *document.FrontmatterParseInfo) {
 	raw, ok := n.Metadata[FrontmatterKey]
-
 	if n.parsedFrontmatter != nil || !ok {
-		return *n.parsedFrontmatter, FrontmatterParseInfo{}
+		return *n.parsedFrontmatter, nil
 	}
 
-	defer func() {
-		n.parsedFrontmatter = &f
-	}()
+	f, pi := document.ParseFrontmatter(raw)
+	n.parsedFrontmatter = &f
 
-	lines := strings.Split(raw, "\n")
-
-	if len(lines) < 1 || strings.TrimSpace(lines[0]) != strings.TrimSpace(lines[len(lines)-1]) {
-		info.other = errors.New("invalid frontmatter")
-		return
-	}
-
-	raw = strings.Join(lines[1:len(lines)-1], "\n")
-
-	bytes := []byte(raw)
-
-	if info.yaml = yaml.Unmarshal(bytes, &f); info.yaml == nil {
-		return
-	}
-
-	if info.json = json.Unmarshal(bytes, &f); info.json == nil {
-		return
-	}
-
-	if info.toml = toml.Unmarshal(bytes, &f); info.toml == nil {
-		return
-	}
-
-	return
+	return f, &pi
 }
 
 func toCells(node *document.Node, source []byte) (result []*Cell) {

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -398,24 +398,24 @@ func Test_notebook_frontmatter(t *testing.T) {
 	type fmtrExample struct {
 		file   []byte
 		kind   string
-		getErr func(info *FrontmatterParseInfo) error
+		getErr func(info *document.FrontmatterParseInfo) error
 	}
 
 	for _, ex := range []fmtrExample{
 		{
 			file:   testDataFrontmatterYAML,
 			kind:   "YAML",
-			getErr: func(info *FrontmatterParseInfo) error { return info.yaml },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.YamlError() },
 		},
 		{
 			file:   testDataFrontmatterJSON,
 			kind:   "JSON",
-			getErr: func(info *FrontmatterParseInfo) error { return info.json },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.JsonError() },
 		},
 		{
 			file:   testDataFrontmatterTOML,
 			kind:   "TOML",
-			getErr: func(info *FrontmatterParseInfo) error { return info.toml },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.TomlError() },
 		},
 	} {
 		file := ex.file
@@ -428,8 +428,8 @@ func Test_notebook_frontmatter(t *testing.T) {
 			require.NoError(t, err)
 
 			fmtr, info := notebook.ParsedFrontmatter()
-			require.NoError(t, getErr(&info))
-			require.NoError(t, info.other)
+			require.NoError(t, getErr(info))
+			require.NoError(t, info.Error())
 			assert.Equal(t, "fish", fmtr.Shell)
 		})
 	}

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -405,17 +405,17 @@ func Test_notebook_frontmatter(t *testing.T) {
 		{
 			file:   testDataFrontmatterYAML,
 			kind:   "YAML",
-			getErr: func(info *document.FrontmatterParseInfo) error { return info.YamlError() },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.YAMLError() },
 		},
 		{
 			file:   testDataFrontmatterJSON,
 			kind:   "JSON",
-			getErr: func(info *document.FrontmatterParseInfo) error { return info.JsonError() },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.JSONError() },
 		},
 		{
 			file:   testDataFrontmatterTOML,
 			kind:   "TOML",
-			getErr: func(info *document.FrontmatterParseInfo) error { return info.TomlError() },
+			getErr: func(info *document.FrontmatterParseInfo) error { return info.TOMLError() },
 		},
 	} {
 		file := ex.file

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -40,7 +40,7 @@ func (fpi FrontmatterParseInfo) Error() error {
 func ParseFrontmatter(raw string) (f Frontmatter, info FrontmatterParseInfo) {
 	lines := strings.Split(raw, "\n")
 
-	if len(lines) < 1 || strings.TrimSpace(lines[0]) != strings.TrimSpace(lines[len(lines)-1]) {
+	if len(lines) < 2 || strings.TrimSpace(lines[0]) != strings.TrimSpace(lines[len(lines)-1]) {
 		info.other = errors.New("invalid frontmatter")
 		return
 	}

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -1,0 +1,65 @@
+package document
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"gopkg.in/yaml.v3"
+)
+
+type Frontmatter struct {
+	Shell string
+}
+
+type FrontmatterParseInfo struct {
+	yaml error
+	json error
+	toml error
+
+	other error
+}
+
+func (fpi FrontmatterParseInfo) YamlError() error {
+	return fpi.yaml
+}
+
+func (fpi FrontmatterParseInfo) JsonError() error {
+	return fpi.json
+}
+
+func (fpi FrontmatterParseInfo) TomlError() error {
+	return fpi.toml
+}
+
+func (fpi FrontmatterParseInfo) Error() error {
+	return fpi.other
+}
+
+func ParseFrontmatter(raw string) (f Frontmatter, info FrontmatterParseInfo) {
+	lines := strings.Split(raw, "\n")
+
+	if len(lines) < 1 || strings.TrimSpace(lines[0]) != strings.TrimSpace(lines[len(lines)-1]) {
+		info.other = errors.New("invalid frontmatter")
+		return
+	}
+
+	raw = strings.Join(lines[1:len(lines)-1], "\n")
+
+	bytes := []byte(raw)
+
+	if info.yaml = yaml.Unmarshal(bytes, &f); info.yaml == nil {
+		return
+	}
+
+	if info.json = json.Unmarshal(bytes, &f); info.json == nil {
+		return
+	}
+
+	if info.toml = toml.Unmarshal(bytes, &f); info.toml == nil {
+		return
+	}
+
+	return
+}

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -21,15 +21,15 @@ type FrontmatterParseInfo struct {
 	other error
 }
 
-func (fpi FrontmatterParseInfo) YamlError() error {
+func (fpi FrontmatterParseInfo) YAMLError() error {
 	return fpi.yaml
 }
 
-func (fpi FrontmatterParseInfo) JsonError() error {
+func (fpi FrontmatterParseInfo) JSONError() error {
 	return fpi.json
 }
 
-func (fpi FrontmatterParseInfo) TomlError() error {
+func (fpi FrontmatterParseInfo) TOMLError() error {
 	return fpi.toml
 }
 

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -11,6 +11,7 @@ import (
 
 type Frontmatter struct {
 	Shell string
+	Cwd   string
 }
 
 type FrontmatterParseInfo struct {

--- a/internal/project/document.go
+++ b/internal/project/document.go
@@ -75,8 +75,15 @@ func parseDocumentForCodeBlocks(filepath string, allowUnknown bool, allowUnnamed
 	return filtered, fmtr, nil
 }
 
-func GetCodeBlocksAndParseFrontmatter(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) (document.CodeBlocks, *document.Frontmatter, error) {
-	return parseDocumentForCodeBlocks(filepath, allowUnknown, allowUnnamed, fs, true)
+func GetCodeBlocksAndParseFrontmatter(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) (document.CodeBlocks, document.Frontmatter, error) {
+	blocks, fmtr, err := parseDocumentForCodeBlocks(filepath, allowUnknown, allowUnnamed, fs, true)
+
+	var f document.Frontmatter
+	if fmtr != nil {
+		f = *fmtr
+	}
+
+	return blocks, f, err
 }
 
 func GetCodeBlocks(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) (document.CodeBlocks, error) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -21,7 +21,7 @@ import (
 type CodeBlock struct {
 	Block       *document.CodeBlock
 	File        string
-	Frontmatter *document.Frontmatter
+	Frontmatter document.Frontmatter
 }
 
 func (b CodeBlock) GetBlock() *document.CodeBlock {
@@ -30,7 +30,7 @@ func (b CodeBlock) GetBlock() *document.CodeBlock {
 
 func (b CodeBlock) Clone() *CodeBlock {
 	block := b.Block.Clone()
-	return &CodeBlock{Block: block, File: b.File}
+	return &CodeBlock{Block: block, File: b.File, Frontmatter: b.Frontmatter}
 }
 
 func (b CodeBlock) GetFile() string {
@@ -41,14 +41,14 @@ func (b CodeBlock) GetID() string {
 	return fmt.Sprintf("%s:%s", b.File, b.Block.Name())
 }
 
-func (b CodeBlock) GetFrontmatter() *document.Frontmatter {
+func (b CodeBlock) GetFrontmatter() document.Frontmatter {
 	return b.Frontmatter
 }
 
 type FileCodeBlock interface {
 	GetBlock() *document.CodeBlock
 	GetFile() string
-	GetFrontmatter() *document.Frontmatter
+	GetFrontmatter() document.Frontmatter
 }
 
 type CodeBlocks []CodeBlock

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -19,8 +19,9 @@ import (
 )
 
 type CodeBlock struct {
-	Block *document.CodeBlock
-	File  string
+	Block       *document.CodeBlock
+	File        string
+	Frontmatter *document.Frontmatter
 }
 
 func (b CodeBlock) GetBlock() *document.CodeBlock {
@@ -40,9 +41,14 @@ func (b CodeBlock) GetID() string {
 	return fmt.Sprintf("%s:%s", b.File, b.Block.Name())
 }
 
+func (b CodeBlock) GetFrontmatter() *document.Frontmatter {
+	return b.Frontmatter
+}
+
 type FileCodeBlock interface {
 	GetBlock() *document.CodeBlock
 	GetFile() string
+	GetFrontmatter() *document.Frontmatter
 }
 
 type CodeBlocks []CodeBlock
@@ -403,7 +409,7 @@ func (p *SingleFileProject) Dir() string {
 }
 
 func getFileCodeBlocks(file string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) ([]CodeBlock, error) {
-	blocks, err := GetCodeBlocks(file, allowUnknown, allowUnnamed, fs)
+	blocks, fmtr, err := GetCodeBlocksAndParseFrontmatter(file, allowUnknown, allowUnnamed, fs)
 	if err != nil {
 		return nil, err
 	}
@@ -412,8 +418,9 @@ func getFileCodeBlocks(file string, allowUnknown bool, allowUnnamed bool, fs bil
 
 	for i, block := range blocks {
 		fileBlocks[i] = CodeBlock{
-			File:  file,
-			Block: block,
+			File:        file,
+			Block:       block,
+			Frontmatter: fmtr,
 		}
 	}
 

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
 
+	"github.com/go-git/go-billy/v5/osfs"
 	runnerv1 "github.com/stateful/runme/internal/gen/proto/go/runme/runner/v1"
 	"github.com/stateful/runme/internal/project"
 	"github.com/stateful/runme/internal/runner"
@@ -184,4 +186,36 @@ func ApplyOptions(rc Runner, opts ...RunnerOption) error {
 	}
 
 	return nil
+}
+
+func ResolveDirectory(parentDir string, fileBlock project.FileCodeBlock) string {
+	for _, dir := range []string{
+		fileBlock.GetFile(),
+		fileBlock.GetFrontmatter().Cwd,
+		fileBlock.GetBlock().Cwd(),
+	} {
+		newDir := resolveOrAbsolute(parentDir, dir)
+
+		if stat, err := osfs.Default.Stat(newDir); err == nil && stat.IsDir() {
+			parentDir = newDir
+		}
+	}
+
+	return parentDir
+}
+
+func resolveOrAbsolute(parent string, child string) string {
+	if child == "" {
+		return parent
+	}
+
+	if filepath.IsAbs(child) {
+		return child
+	}
+
+	if parent != "" {
+		return filepath.Join(parent, child)
+	}
+
+	return child
 }

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -190,10 +190,9 @@ func ApplyOptions(rc Runner, opts ...RunnerOption) error {
 
 func ResolveDirectory(parentDir string, fileBlock project.FileCodeBlock) string {
 	for _, dir := range []string{
-		// filepath.Join(projDir, filepath.Dir(fileBlock.GetFile())),
 		filepath.Dir(fileBlock.GetFile()),
-		fileBlock.GetFrontmatter().Cwd,
-		fileBlock.GetBlock().Cwd(),
+		filepath.FromSlash(fileBlock.GetFrontmatter().Cwd),
+		filepath.FromSlash(fileBlock.GetBlock().Cwd()),
 	} {
 		newDir := resolveOrAbsolute(parentDir, dir)
 

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -190,7 +190,8 @@ func ApplyOptions(rc Runner, opts ...RunnerOption) error {
 
 func ResolveDirectory(parentDir string, fileBlock project.FileCodeBlock) string {
 	for _, dir := range []string{
-		fileBlock.GetFile(),
+		// filepath.Join(projDir, filepath.Dir(fileBlock.GetFile())),
+		filepath.Dir(fileBlock.GetFile()),
 		fileBlock.GetFrontmatter().Cwd,
 		fileBlock.GetBlock().Cwd(),
 	} {

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -85,10 +84,7 @@ func (r *LocalRunner) newExecutable(fileBlock project.FileCodeBlock) (runner.Exe
 		cfg.PreEnv = env.ConvertMapEnv(projEnvs)
 	}
 
-	mdFile := fileBlock.GetFile()
-	if mdFile != "" {
-		cfg.Dir = filepath.Join(r.dir, filepath.Dir(mdFile))
-	}
+	cfg.Dir = ResolveDirectory(cfg.Dir, fileBlock)
 
 	if block.Interactive() {
 		cfg.Stdin = r.stdin

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	runnerv1 "github.com/stateful/runme/internal/gen/proto/go/runme/runner/v1"
@@ -130,10 +129,7 @@ func (r *RemoteRunner) RunBlock(ctx context.Context, fileBlock project.FileCodeB
 		}
 	}
 
-	mdFile := fileBlock.GetFile()
-	if mdFile != "" {
-		req.Directory = filepath.Join(r.dir, filepath.Dir(mdFile))
-	}
+	req.Directory = ResolveDirectory(req.Directory, fileBlock)
 
 	if r.sessionStrategy == runnerv1.SessionStrategy_SESSION_STRATEGY_MOST_RECENT {
 		req.Envs = os.Environ()

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -39,17 +39,22 @@ func Test_ResolveDirectory(t *testing.T) {
 		taskMap[task.Block.Name()] = resolved
 	}
 
-	assert.Equal(t, map[string]string{
-		"absolute-pwd":     "/tmp",
-		"absolute-rel-pwd": "/",
-		"absolute-abs-pwd": "/opt",
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, rp("examples\\frontmatter\\cwd"), taskMap["none-pwd"])
+		assert.Equal(t, rp("examples\\frontmatter"), taskMap["none-rel-pwd"])
+	} else {
+		assert.Equal(t, map[string]string{
+			"absolute-pwd":     "/tmp",
+			"absolute-rel-pwd": "/",
+			"absolute-abs-pwd": "/opt",
 
-		"none-pwd":     rp("examples/frontmatter/cwd"),
-		"none-rel-pwd": rp("examples/frontmatter"),
-		"none-abs-pwd": "/opt",
+			"none-pwd":     rp("examples/frontmatter/cwd"),
+			"none-rel-pwd": rp("examples/frontmatter"),
+			"none-abs-pwd": "/opt",
 
-		"relative-pwd":     root,
-		"relative-rel-pwd": rp("../"),
-		"relative-abs-pwd": "/opt",
-	}, taskMap)
+			"relative-pwd":     root,
+			"relative-rel-pwd": rp("../"),
+			"relative-abs-pwd": "/opt",
+		}, taskMap)
+	}
 }

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stateful/runme/internal/project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResolveDirectory(t *testing.T) {
+	_, b, _, _ := runtime.Caller(0)
+	root := filepath.Clean(
+		filepath.Join(
+			filepath.Dir(b),
+			"../../../",
+		),
+	)
+
+	projectRoot := filepath.Join(root, "examples/frontmatter/cwd")
+
+	// repo path
+	rp := func(rel string) string {
+		return filepath.Join(root, rel)
+	}
+
+	proj, err := project.NewDirectoryProject(projectRoot, false, false, false)
+	require.NoError(t, err)
+
+	tasks, err := proj.LoadTasks()
+	require.NoError(t, err)
+
+	taskMap := make(map[string]string)
+
+	for _, task := range tasks {
+		resolved := ResolveDirectory(root, task)
+		taskMap[task.Block.Name()] = resolved
+	}
+
+	assert.Equal(t, map[string]string{
+		"absolute-pwd":     "/tmp",
+		"absolute-rel-pwd": "/",
+		"absolute-abs-pwd": "/opt",
+
+		"none-pwd":     rp("examples/frontmatter/cwd"),
+		"none-rel-pwd": rp("examples/frontmatter"),
+		"none-abs-pwd": "/opt",
+
+		"relative-pwd":     root,
+		"relative-rel-pwd": rp("../"),
+		"relative-abs-pwd": "/opt",
+	}, taskMap)
+}

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -15,7 +15,7 @@ func Test_ResolveDirectory(t *testing.T) {
 	root := filepath.Clean(
 		filepath.Join(
 			filepath.Dir(b),
-			"../../../",
+			filepath.FromSlash("../../../"),
 		),
 	)
 
@@ -23,7 +23,7 @@ func Test_ResolveDirectory(t *testing.T) {
 
 	// repo path
 	rp := func(rel string) string {
-		return filepath.Join(root, rel)
+		return filepath.Join(root, filepath.FromSlash(rel))
 	}
 
 	proj, err := project.NewDirectoryProject(projectRoot, false, false, false)
@@ -42,6 +42,9 @@ func Test_ResolveDirectory(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		assert.Equal(t, rp("examples\\frontmatter\\cwd"), taskMap["none-pwd"])
 		assert.Equal(t, rp("examples\\frontmatter"), taskMap["none-rel-pwd"])
+
+		assert.Equal(t, root, taskMap["relative-pwd"])
+		assert.Equal(t, rp("../"), taskMap["relative-rel-pwd"])
 	} else {
 		assert.Equal(t, map[string]string{
 			"absolute-pwd":     "/tmp",


### PR DESCRIPTION
Implementation is about what you'd expect, though there is an ambiguity around absolute paths. One option is to resolve absolute paths relative to the project, and the other is to resolve them as absolute paths.

I decided to resolve absolute paths as system-absolute paths, because the "project" directory is currently not really stable.

Resolution order goes as follows:

 - Current cwd
 - Markdown file folder
 - Frontmatter `cwd`
 - Annotation `cwd`