### PR TITLE
internal/runner/client: fix multirunner cwd

### DIFF
--- a/internal/runner/client/client_multi.go
+++ b/internal/runner/client/client_multi.go
@@ -116,7 +116,7 @@ func (m MultiRunner) RunBlocks(ctx context.Context, blocks []project.FileCodeBlo
 			return err
 		}
 
-		run := func(block *document.CodeBlock) error {
+		run := func(block project.FileCodeBlock) error {
 			err := runnerClient.RunBlock(ctx, block)
 
 			code := uint(0)
@@ -127,7 +127,7 @@ func (m MultiRunner) RunBlocks(ctx context.Context, blocks []project.FileCodeBlo
 
 			if m.PostRunMsg != nil {
 				_, _ = m.Runner.getSettings().stdout.Write([]byte(
-					m.PostRunMsg(block, code),
+					m.PostRunMsg(block.GetBlock(), code),
 				))
 			}
 
@@ -135,17 +135,17 @@ func (m MultiRunner) RunBlocks(ctx context.Context, blocks []project.FileCodeBlo
 		}
 
 		if !parallel {
-			err := run(block)
+			err := run(fileBlock)
 			if err != nil {
 				return err
 			}
 		} else {
 			wg.Add(1)
-			go func(block *document.CodeBlock) {
+			go func(fileBlock project.FileCodeBlock) {
 				defer wg.Done()
 				err := run(block)
 				errChan <- err
-			}(block)
+			}(fileBlock)
 		}
 	}
 

--- a/internal/runner/client/client_multi.go
+++ b/internal/runner/client/client_multi.go
@@ -143,7 +143,7 @@ func (m MultiRunner) RunBlocks(ctx context.Context, blocks []project.FileCodeBlo
 			wg.Add(1)
 			go func(fileBlock project.FileCodeBlock) {
 				defer wg.Done()
-				err := run(block)
+				err := run(fileBlock)
 				errChan <- err
 			}(fileBlock)
 		}


### PR DESCRIPTION
Multi-runner was using the old `document.CodeBlock`, which does not have file information. This prevented scripts run with multi-runner from being aware of their file location, so their cwd would be set relative/same as the parent.

