### PR TITLE
only show file query error when file query is present

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -190,7 +190,7 @@ func (blocks CodeBlocks) LookupWithFile(queryFile string, queryName string) ([]C
 	}
 
 	if len(results) == 0 {
-		if !foundFile {
+		if !foundFile && queryFile != "" {
 			return nil, ErrCodeBlockFileNotFound{queryFile: queryFile}
 		}
 


### PR DESCRIPTION
Currently, if you try to run a script that isn't in the project, you get:

```
unable to find file in project matching regex ""
```

This PR fixes that so that you get a more appropriate error message:

```
unable to find any script named "unknown"
```