### PR TITLE
fix commands hanging in linux

### DIFF
--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/muesli/cancelreader"
 	"github.com/pkg/errors"
 	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/env"
@@ -145,8 +146,8 @@ func (r *LocalRunner) RunBlock(ctx context.Context, fileBlock project.FileCodeBl
 		go func() {
 			for {
 				if executable.ExitCode() > -1 {
-					if closer, ok := r.stdin.(io.ReadCloser); ok {
-						_ = closer.Close()
+					if canceler, ok := r.stdin.(cancelreader.CancelReader); ok {
+						_ = canceler.Cancel()
 					}
 
 					return

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/muesli/cancelreader"
 	"github.com/pkg/errors"
 	runnerv1 "github.com/stateful/runme/internal/gen/proto/go/runme/runner/v1"
 	"github.com/stateful/runme/internal/project"
@@ -160,8 +161,8 @@ func (r *RemoteRunner) RunBlock(ctx context.Context, fileBlock project.FileCodeB
 
 	g.Go(func() error {
 		defer func() {
-			if closer, ok := r.stdin.(io.ReadCloser); ok {
-				_ = closer.Close()
+			if canceler, ok := r.stdin.(cancelreader.CancelReader); ok {
+				_ = canceler.Cancel()
 			}
 		}()
 		return r.recvLoop(stream, background)


### PR DESCRIPTION
Interactive scripts would hang on Linux until user input was provided.

Struggled for a long time on this, but it turns out `Cancel` is very much different than `Close`.