### PR TITLE
Have a more verbose error message for Windows environment

### DIFF
--- a/internal/runner/command_windows.go
+++ b/internal/runner/command_windows.go
@@ -14,7 +14,10 @@ func setSysProcAttrCtty(cmd *exec.Cmd) {}
 func setSysProcAttrPgid(cmd *exec.Cmd) {}
 
 func disableEcho(fd uintptr) error {
-	return errors.New("unsupported")
+	return errors.New("Error: Environtment not supported! " +
+		"Runme currently doesn't support Window shells. " +
+		"Please go to https://github.com/stateful/runme/issues/173 to follow progress on this " +
+		"and join our Discord server at https://discord.gg/runme if you have further questions!")
 }
 
 func signalPgid(pid int, sig os.Signal) error { return errors.New("unsupported") }


### PR DESCRIPTION
As mentioned in #173 we currently do not support Windows environments. Let's be more clear about this to our user and have a more verbose error message, pointing them to some resources to follow up on.