### PR TITLE
internal/document/editor: send code blocks without supported languages

### DIFF
--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -305,20 +305,3 @@ func trimRightNewLine(s []byte) []byte {
 	s = bytes.TrimRight(s, "\r\n")
 	return bytes.TrimRight(s, "\n")
 }
-
-var supportedExecutables = []string{
-	"bash",
-	"bat", // fallback to sh
-	"sh",
-	"shell",
-	"zsh",
-}
-
-func isEditorSupported(lang string) bool {
-	for _, item := range supportedExecutables {
-		if item == lang {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -130,28 +130,19 @@ func toCellsRec(
 		case *document.CodeBlock:
 			textRange := block.TextRange()
 
-			// If the lang is unknown (empty) or supported then return a code cell.
-			// Otherwise, return a markup cell (#85).
 			// In the future, we will include language detection (#77).
-			if lang := block.Language(); lang == "" || isEditorSupported(lang) {
-				metadata := block.Attributes()
-				metadata[PrefixAttributeName(InternalAttributePrefix, "name")] = block.Name()
-				*cells = append(*cells, &Cell{
-					Kind:       CodeKind,
-					Value:      string(block.Content()),
-					LanguageID: block.Language(),
-					Metadata:   metadata,
-					TextRange: &TextRange{
-						Start: textRange.Start,
-						End:   textRange.End,
-					},
-				})
-			} else {
-				*cells = append(*cells, &Cell{
-					Kind:  MarkupKind,
-					Value: fmtValue(block.Value()),
-				})
-			}
+			metadata := block.Attributes()
+			metadata[PrefixAttributeName(InternalAttributePrefix, "name")] = block.Name()
+			*cells = append(*cells, &Cell{
+				Kind:       CodeKind,
+				Value:      string(block.Content()),
+				LanguageID: block.Language(),
+				Metadata:   metadata,
+				TextRange: &TextRange{
+					Start: textRange.Start,
+					End:   textRange.End,
+				},
+			})
 
 		case *document.MarkdownBlock:
 			value := block.Value()

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -177,8 +177,10 @@ def hello():
 	cells := toCells(node, data)
 	assert.Len(t, cells, 1)
 	cell := cells[0]
-	assert.Equal(t, MarkupKind, cell.Kind)
-	assert.Equal(t, "```py { readonly=true }\ndef hello():\n    print(\"Hello World\")\n```", cell.Value)
+	assert.Equal(t, CodeKind, cell.Kind)
+	assert.Equal(t, "py", cell.LanguageID)
+	assert.Equal(t, "true", cell.Metadata["readonly"])
+	assert.Equal(t, "def hello():\n    print(\"Hello World\")", cell.Value)
 }
 
 func Test_serializeCells_Edited(t *testing.T) {


### PR DESCRIPTION
Currently, the editor service doesn't send code blocks as code blocks if the language is unsupported.

This removes this guardrail, creating code blocks from the editor service regardless of block language.