### PR TITLE
internal/cmd/run: support running by index with `--index`

### DIFF
--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -16,6 +16,11 @@ stdout 'Hello, runme!'
 ! stderr .
 
 env SHELL=/bin/bash
+exec runme run --index 0
+stdout 'Hello, runme!'
+! stderr .
+
+env SHELL=/bin/bash
 exec runme run echo-1
 stdout '1\n2\n3\n'
 ! stderr .


### PR DESCRIPTION
Currently, this will overwrite any commands in the arguments. It also does not work in project mode.

This is being introduced to unblock name synchronization on the extension-side.