### PR TITLE
Retain trailing new line breaks

### DIFF
--- a/internal/document/constants/constants.go
+++ b/internal/document/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	MaxFinalLineBreaks = 10
+	FinalLineBreaksKey = "finalLineBreaks"
+)

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -117,11 +117,15 @@ func (r *nameResolver) Get(obj interface{}, name string) string {
 }
 
 func CountFinalLineBreaks(source []byte, lineBreak []byte) int {
-	end := len(source)
-	start := end - MaxFinalLineBreaks*len(lineBreak)
-	tail := source[math.Max(start, 0):end]
+	i := len(source) - len(lineBreak)
+	numBreaks := 0
 
-	return bytes.Count(tail, lineBreak)
+	for i >= 0 && bytes.Equal(source[i:i+len(lineBreak)], lineBreak) {
+		i -= len(lineBreak)
+		numBreaks++
+	}
+	
+	return numBreaks
 }
 
 func DetectLineBreak(source []byte) []byte {

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -10,12 +10,7 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
 
-	math "github.com/stateful/runme/internal/math"
-)
-
-const (
-	MaxFinalLineBreaks = 10
-	FinalLineBreaksKey = "finalLineBreaks"
+	"github.com/stateful/runme/internal/document/constants"
 )
 
 type Document struct {
@@ -53,7 +48,7 @@ func (d *Document) Parse() (*Node, ast.Node, error) {
 	}
 
 	finalNewLines := CountFinalLineBreaks(d.source, DetectLineBreak(d.source))
-	d.astNode.SetAttributeString(FinalLineBreaksKey, finalNewLines)
+	d.astNode.SetAttributeString(constants.FinalLineBreaksKey, finalNewLines)
 
 	return d.node, d.astNode, nil
 }
@@ -124,7 +119,7 @@ func CountFinalLineBreaks(source []byte, lineBreak []byte) int {
 		i -= len(lineBreak)
 		numBreaks++
 	}
-	
+
 	return numBreaks
 }
 

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -2,7 +2,6 @@ package document
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/stateful/runme/internal/renderer/cmark"
@@ -67,11 +66,9 @@ First paragraph.
 }
 
 func TestDocument_FinalLineBreaks(t *testing.T) {
-	data := []byte(`## Newline debugging
+	data := []byte(`This will test final line breaks`)
 
-This will test final line breaks`)
-
-	t.Run("No newline", func(t *testing.T) {
+	t.Run("No breaks", func(t *testing.T) {
 		doc := New(data, cmark.Render)
 		_, astNode, err := doc.Parse()
 		require.NoError(t, err)
@@ -81,13 +78,13 @@ This will test final line breaks`)
 
 		assert.Equal(
 			t,
-			string(actual),
 			string(data),
+			string(actual),
 		)
 	})
 
-	t.Run("7 line breaks", func(t *testing.T) {
-		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 7)...)
+	t.Run("1 LF", func(t *testing.T) {
+		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 1)...)
 		doc := New(withLineBreaks, cmark.Render)
 		_, astNode, err := doc.Parse()
 		require.NoError(t, err)
@@ -95,7 +92,37 @@ This will test final line breaks`)
 		actual, err := cmark.Render(astNode, withLineBreaks)
 		require.NoError(t, err)
 
-		fmt.Sprintln(string(withLineBreaks))
+		assert.Equal(
+			t,
+			string(withLineBreaks),
+			string(actual),
+		)
+	})
+
+	t.Run("1 CRLF", func(t *testing.T) {
+		withLineBreaks := append(data, bytes.Repeat([]byte{'\r', '\n'}, 1)...)
+		doc := New(withLineBreaks, cmark.Render)
+		_, astNode, err := doc.Parse()
+		require.NoError(t, err)
+
+		actual, err := cmark.Render(astNode, withLineBreaks)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			string(withLineBreaks),
+			string(actual),
+		)
+	})
+
+	t.Run("7 LFs", func(t *testing.T) {
+		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 7)...)
+		doc := New(withLineBreaks, cmark.Render)
+		_, astNode, err := doc.Parse()
+		require.NoError(t, err)
+
+		actual, err := cmark.Render(astNode, withLineBreaks)
+		require.NoError(t, err)
 
 		assert.Equal(
 			t,

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -1,6 +1,8 @@
 package document
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stateful/runme/internal/renderer/cmark"
@@ -62,4 +64,43 @@ First paragraph.
 	assert.Equal(t, "3. Item 3\n", string(node.children[3].children[2].Item().Value()))
 	assert.Len(t, node.children[3].children[2].children[0].children, 0)
 	assert.Equal(t, "Item 3\n", string(node.children[3].children[2].children[0].Item().Value()))
+}
+
+func TestDocument_FinalLineBreaks(t *testing.T) {
+	data := []byte(`## Newline debugging
+
+This will test final line breaks`)
+
+	t.Run("No newline", func(t *testing.T) {
+		doc := New(data, cmark.Render)
+		_, astNode, err := doc.Parse()
+		require.NoError(t, err)
+
+		actual, err := cmark.Render(astNode, data)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			string(actual),
+			string(data),
+		)
+	})
+
+	t.Run("7 line breaks", func(t *testing.T) {
+		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 7)...)
+		doc := New(withLineBreaks, cmark.Render)
+		_, astNode, err := doc.Parse()
+		require.NoError(t, err)
+
+		actual, err := cmark.Render(astNode, withLineBreaks)
+		require.NoError(t, err)
+
+		fmt.Sprintln(string(withLineBreaks))
+
+		assert.Equal(
+			t,
+			string(actual),
+			string(withLineBreaks),
+		)
+	})
 }

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	internalAttributePrefix = "runme.dev"
-	privateAttributePrefix  = "_"
+	InternalAttributePrefix = "runme.dev"
+	PrivateAttributePrefix  = "_"
 )
 
 type CellKind int
@@ -55,7 +55,7 @@ func (n *Notebook) GetContentOffset() int {
 }
 
 func (n *Notebook) ParsedFrontmatter() (document.Frontmatter, *document.FrontmatterParseInfo) {
-	raw, ok := n.Metadata[FrontmatterKey]
+	raw, ok := n.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)]
 	if n.parsedFrontmatter != nil {
 		return *n.parsedFrontmatter, nil
 	}
@@ -135,7 +135,7 @@ func toCellsRec(
 			// In the future, we will include language detection (#77).
 			if lang := block.Language(); lang == "" || isEditorSupported(lang) {
 				metadata := block.Attributes()
-				metadata[prefixAttributeName(internalAttributePrefix, "name")] = block.Name()
+				metadata[PrefixAttributeName(InternalAttributePrefix, "name")] = block.Name()
 				*cells = append(*cells, &Cell{
 					Kind:       CodeKind,
 					Value:      string(block.Content()),
@@ -202,11 +202,11 @@ func countTrailingNewLines(b []byte) int {
 	return count
 }
 
-func prefixAttributeName(prefix, name string) string {
+func PrefixAttributeName(prefix, name string) string {
 	switch prefix {
-	case internalAttributePrefix:
+	case InternalAttributePrefix:
 		return prefix + "/" + name
-	case privateAttributePrefix:
+	case PrivateAttributePrefix:
 		fallthrough
 	default:
 		return prefix + name
@@ -218,7 +218,7 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 	// A key with a name "index" that comes from VS Code is also filtered out.
 	keys := make([]string, 0, len(cell.Metadata))
 	for k := range cell.Metadata {
-		if k == "index" || strings.HasPrefix(k, privateAttributePrefix) || strings.HasPrefix(k, internalAttributePrefix) {
+		if k == "index" || strings.HasPrefix(k, PrivateAttributePrefix) || strings.HasPrefix(k, InternalAttributePrefix) {
 			continue
 		}
 		keys = append(keys, k)

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -31,7 +31,7 @@ func Deserialize(data []byte) (*Notebook, error) {
 		contentOffset: sections.ContentOffset,
 	}
 
-	finalLinesBreaks := document.CountFinalLineBreaks(data, []byte{'\n'})
+	finalLinesBreaks := document.CountFinalLineBreaks(data, document.DetectLineBreak(data))
 	notebook.Metadata = map[string]string{
 		PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey): fmt.Sprint(finalLinesBreaks),
 	}

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/renderer/cmark"
 
@@ -62,7 +63,7 @@ func Serialize(notebook *Notebook) ([]byte, error) {
 	if lineBreaks, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)]; ok {
 		desired, err := strconv.ParseInt(lineBreaks, 10, 32)
 		if err != nil {
-			panic(err)
+			return nil, errors.WithStack(err)
 		}
 
 		lb := document.DetectLineBreak(result)

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -2,12 +2,16 @@ package editor
 
 import (
 	"bytes"
+	"fmt"
+	"strconv"
 
 	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/renderer/cmark"
+
+	math "github.com/stateful/runme/internal/math"
 )
 
-const FrontmatterKey = "runme.dev/frontmatter"
+const FrontmatterKey = "frontmatter"
 
 func Deserialize(data []byte) (*Notebook, error) {
 	sections, err := document.ParseSections(data)
@@ -27,11 +31,14 @@ func Deserialize(data []byte) (*Notebook, error) {
 		contentOffset: sections.ContentOffset,
 	}
 
+	finalLinesBreaks := document.CountFinalLineBreaks(data, []byte{'\n'})
+	notebook.Metadata = map[string]string{
+		PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey): fmt.Sprint(finalLinesBreaks),
+	}
+
 	// If Front Matter exists, store it in Notebook's metadata.
 	if len(sections.FrontMatter) > 0 {
-		notebook.Metadata = map[string]string{
-			FrontmatterKey: string(sections.FrontMatter),
-		}
+		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)] = string(sections.FrontMatter)
 	}
 
 	return notebook, nil
@@ -40,9 +47,9 @@ func Deserialize(data []byte) (*Notebook, error) {
 func Serialize(notebook *Notebook) ([]byte, error) {
 	var result []byte
 
-	if intro, ok := notebook.Metadata[FrontmatterKey]; ok {
+	if intro, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)]; ok {
 		intro := []byte(intro)
-		lb := detectLineBreak(intro)
+		lb := document.DetectLineBreak(intro)
 		result = append(
 			intro,
 			append(lb, lb...)...,
@@ -51,14 +58,23 @@ func Serialize(notebook *Notebook) ([]byte, error) {
 
 	result = append(result, serializeCells(notebook.Cells)...)
 
-	return result, nil
-}
+	if lineBreaks, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)]; ok {
+		desired, err := strconv.ParseInt(lineBreaks, 10, 32)
+		if err != nil {
+			panic(err)
+		}
 
-func detectLineBreak(source []byte) []byte {
-	crlfCount := bytes.Count(source, []byte{'\r', '\n'})
-	lfCount := bytes.Count(source, []byte{'\n'})
-	if crlfCount == lfCount {
-		return []byte{'\r', '\n'}
+		lb := document.DetectLineBreak(result)
+		actual := document.CountFinalLineBreaks(result, lb)
+		delta := int(desired) - actual
+
+		if delta < 0 {
+			end := len(result) + delta*len(lb)
+			result = result[0:math.Max(0, end)]
+		} else {
+			result = append(result, bytes.Repeat(lb, delta)...)
+		}
 	}
-	return []byte{'\n'}
+
+	return result, nil
 }

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/renderer/cmark"
 
+	"github.com/stateful/runme/internal/document/constants"
 	math "github.com/stateful/runme/internal/math"
 )
 
@@ -33,7 +34,7 @@ func Deserialize(data []byte) (*Notebook, error) {
 
 	finalLinesBreaks := document.CountFinalLineBreaks(data, document.DetectLineBreak(data))
 	notebook.Metadata = map[string]string{
-		PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey): fmt.Sprint(finalLinesBreaks),
+		PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey): fmt.Sprint(finalLinesBreaks),
 	}
 
 	// If Front Matter exists, store it in Notebook's metadata.
@@ -58,7 +59,7 @@ func Serialize(notebook *Notebook) ([]byte, error) {
 
 	result = append(result, serializeCells(notebook.Cells)...)
 
-	if lineBreaks, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)]; ok {
+	if lineBreaks, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)]; ok {
 		desired, err := strconv.ParseInt(lineBreaks, 10, 32)
 		if err != nil {
 			panic(err)

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -52,7 +52,7 @@ func Serialize(notebook *Notebook) ([]byte, error) {
 		lb := document.DetectLineBreak(intro)
 		result = append(
 			intro,
-			append(lb, lb...)...,
+			bytes.Repeat(lb, 2)...,
 		)
 	}
 

--- a/internal/document/editor/editor_test.go
+++ b/internal/document/editor/editor_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stateful/runme/internal/document"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stateful/runme/internal/document/constants"
 )
 
 func TestEditor(t *testing.T) {
@@ -128,7 +128,7 @@ This will test final line breaks`)
 
 		assert.Equal(
 			t,
-			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)],
 			"0",
 		)
 
@@ -149,7 +149,7 @@ This will test final line breaks`)
 
 		assert.Equal(
 			t,
-			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)],
 			"1",
 		)
 
@@ -170,7 +170,7 @@ This will test final line breaks`)
 
 		assert.Equal(
 			t,
-			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)],
 			"7",
 		)
 

--- a/internal/document/editor/editor_test.go
+++ b/internal/document/editor/editor_test.go
@@ -1,7 +1,10 @@
 package editor
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/stateful/runme/internal/document"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +61,7 @@ func TestEditor_CodeBlock(t *testing.T) {
 		cell := notebook.Cells[0]
 		assert.Equal(
 			t,
-			cell.Metadata[prefixAttributeName(internalAttributePrefix, "name")],
+			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "name")],
 			"echo-1",
 		)
 		// "name" is empty because it was not included in the original snippet.
@@ -78,7 +81,7 @@ func TestEditor_CodeBlock(t *testing.T) {
 		cell := notebook.Cells[0]
 		assert.Equal(
 			t,
-			cell.Metadata[prefixAttributeName(internalAttributePrefix, "name")],
+			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "name")],
 			"name1",
 		)
 		// "name" is not nil because it was included in the original snippet.
@@ -112,4 +115,71 @@ A paragraph
 		string(data),
 		string(result),
 	)
+}
+
+func TestEditor_Newlines(t *testing.T) {
+	data := []byte(`## Newline debugging
+
+This will test final line breaks`)
+
+	t.Run("No line breaks", func(t *testing.T) {
+		notebook, err := Deserialize(data)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			"0",
+		)
+
+		actual, err := Serialize(notebook)
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(actual),
+			string(data),
+		)
+	})
+
+	t.Run("Single line break", func(t *testing.T) {
+		withLineBreaks := append(data, byte('\n'))
+
+		notebook, err := Deserialize(withLineBreaks)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			"1",
+		)
+
+		actual, err := Serialize(notebook)
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(actual),
+			string(withLineBreaks),
+		)
+	})
+
+	t.Run("7 line breaks", func(t *testing.T) {
+		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 7)...)
+
+		notebook, err := Deserialize(withLineBreaks)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, document.FinalLineBreaksKey)],
+			"7",
+		)
+
+		actual, err := Serialize(notebook)
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(actual),
+			string(withLineBreaks),
+		)
+	})
 }

--- a/internal/document/editor/editorservice/service_test.go
+++ b/internal/document/editor/editorservice/service_test.go
@@ -82,7 +82,7 @@ Some content
 		assert.Equal(
 			t,
 			frontMatter,
-			dResp.Notebook.Metadata[editor.FrontmatterKey],
+			dResp.Notebook.Metadata[editor.PrefixAttributeName(editor.InternalAttributePrefix, editor.FrontmatterKey)],
 		)
 
 		sResp, err := client.Serialize(

--- a/internal/renderer/cmark/cmark.go
+++ b/internal/renderer/cmark/cmark.go
@@ -22,7 +22,7 @@ func Render(doc ast.Node, source []byte) ([]byte, error) {
 	}
 
 	finalLineBreaks := 1
-	if flb, ok := doc.AttributeString("finalLineBreaks"); ok {
+	if flb, ok := doc.AttributeString(document.FinalLineBreaksKey); ok {
 		val, ok := flb.(int)
 		if !ok {
 			return nil, errors.Errorf("invalid type for %s expected int", "finalLineBreaks")

--- a/internal/renderer/cmark/cmark.go
+++ b/internal/renderer/cmark/cmark.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/yuin/goldmark/ast"
+
+	"github.com/stateful/runme/internal/document/constants"
 )
 
 type NodeSourceProvider func(ast.Node) ([]byte, bool)
@@ -22,10 +24,10 @@ func Render(doc ast.Node, source []byte) ([]byte, error) {
 	}
 
 	finalLineBreaks := 1
-	if flb, ok := doc.AttributeString(document.FinalLineBreaksKey); ok {
+	if flb, ok := doc.AttributeString(constants.FinalLineBreaksKey); ok {
 		val, ok := flb.(int)
 		if !ok {
-			return nil, errors.Errorf("invalid type for %s expected int", document.FinalLineBreaksKey)
+			return nil, errors.Errorf("invalid type for %s expected int", constants.FinalLineBreaksKey)
 		}
 		finalLineBreaks = val
 	}

--- a/internal/renderer/cmark/cmark.go
+++ b/internal/renderer/cmark/cmark.go
@@ -25,7 +25,7 @@ func Render(doc ast.Node, source []byte) ([]byte, error) {
 	if flb, ok := doc.AttributeString(document.FinalLineBreaksKey); ok {
 		val, ok := flb.(int)
 		if !ok {
-			return nil, errors.Errorf("invalid type for %s expected int", "finalLineBreaks")
+			return nil, errors.Errorf("invalid type for %s expected int", document.FinalLineBreaksKey)
 		}
 		finalLineBreaks = val
 	}

--- a/internal/renderer/cmark/cmark.go
+++ b/internal/renderer/cmark/cmark.go
@@ -21,8 +21,18 @@ func Render(doc ast.Node, source []byte) ([]byte, error) {
 		lineBreak = []byte{'\r', '\n'}
 	}
 
+	finalLineBreaks := 1
+	if flb, ok := doc.AttributeString("finalLineBreaks"); ok {
+		val, ok := flb.(int)
+		if !ok {
+			return nil, errors.Errorf("invalid type for %s expected int", "finalLineBreaks")
+		}
+		finalLineBreaks = val
+	}
+
 	r := renderer{
-		lineBreak: lineBreak,
+		lineBreak:       lineBreak,
+		finalLineBreaks: finalLineBreaks,
 	}
 	return r.Render(doc, source)
 }
@@ -33,6 +43,7 @@ type renderer struct {
 	beginLine       bool
 	buf             bytes.Buffer
 	inTightListItem bool
+	finalLineBreaks int
 	needCR          int
 	prefix          []byte
 }
@@ -418,7 +429,7 @@ func (r *renderer) Render(doc ast.Node, source []byte) ([]byte, error) {
 	}
 
 	// Finish writing any remaining characters.
-	r.needCR = 1
+	r.needCR = r.finalLineBreaks
 	err = r.write(nil)
 	return r.buf.Bytes(), errors.WithStack(err)
 }


### PR DESCRIPTION
Another attempt to avoid unnecessary diffs which cause confusion.