### PR TITLE
internal/project: ignore node_modules by default

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -109,7 +109,7 @@ func getProject() (proj project.Project, err error) {
 			findNearestRepo = true
 		}
 
-		dirProj, err := project.NewDirectoryProject(projDir, findNearestRepo, fAllowUnknown, fAllowUnnamed)
+		dirProj, err := project.NewDirectoryProject(projDir, findNearestRepo, fAllowUnknown, fAllowUnnamed, fProjectIgnorePatterns)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,14 +11,15 @@ import (
 )
 
 var (
-	fAllowUnknown     bool
-	fAllowUnnamed     bool
-	fChdir            string
-	fFileName         string
-	fFileMode         bool
-	fProject          string
-	fRespectGitignore bool
-	fInsecure         bool
+	fAllowUnknown          bool
+	fAllowUnnamed          bool
+	fChdir                 string
+	fFileName              string
+	fFileMode              bool
+	fProject               string
+	fProjectIgnorePatterns []string
+	fRespectGitignore      bool
+	fInsecure              bool
 )
 
 func Root() *cobra.Command {
@@ -70,6 +71,7 @@ func Root() *cobra.Command {
 
 	pflags.StringVar(&fProject, "project", "", "Root project to find runnable tasks")
 	pflags.BoolVar(&fRespectGitignore, "git-ignore", true, "Whether to respect .gitignore file(s) in project")
+	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules"}, "Patterns to ignore in project mode")
 
 	setAPIFlags(pflags)
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -76,7 +76,7 @@ func Test_directoryGitProject(t *testing.T) {
 	_, err = git.Init(storage, nil)
 	require.NoError(t, err)
 
-	proj, err := NewDirectoryProject(pfs.Root(), true, true, true)
+	proj, err := NewDirectoryProject(pfs.Root(), true, true, true, []string{})
 	require.NoError(t, err)
 	require.NotNil(t, proj.repo)
 
@@ -139,7 +139,7 @@ func Test_directoryGitProject(t *testing.T) {
 }
 
 func Test_directoryBareProject(t *testing.T) {
-	proj, err := NewDirectoryProject(pfs.Root(), false, true, true)
+	proj, err := NewDirectoryProject(pfs.Root(), false, true, true, []string{})
 	require.NoError(t, err)
 
 	t.Run("LoadEnvs", func(t *testing.T) {
@@ -215,7 +215,7 @@ func Test_codeBlockFrontmatter(t *testing.T) {
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 
-	proj, err := NewDirectoryProject(filepath.Join(cwd, "../../", "examples", "frontmatter", "shells"), false, true, true)
+	proj, err := NewDirectoryProject(filepath.Join(cwd, "../../", "examples", "frontmatter", "shells"), false, true, true, []string{})
 	require.NoError(t, err)
 
 	tasks, err := proj.LoadTasks()

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -26,7 +26,7 @@ func Test_ResolveDirectory(t *testing.T) {
 		return filepath.Join(root, filepath.FromSlash(rel))
 	}
 
-	proj, err := project.NewDirectoryProject(projectRoot, false, false, false)
+	proj, err := project.NewDirectoryProject(projectRoot, false, false, false, []string{})
 	require.NoError(t, err)
 
 	tasks, err := proj.LoadTasks()

--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -196,7 +196,7 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 	}
 
 	if req.Project != nil {
-		proj, err := project.NewDirectoryProject(req.Project.Root, false, true, true)
+		proj, err := project.NewDirectoryProject(req.Project.Root, false, true, true, []string{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes stateful/vscode-runme#608

Introduces `--ignore-pattern` which allows specifying custom ignore patterns in project mode. Think like adding extra lines to `gitignore` (or creating it if it doesn't exist). 

By default, this includes `node_modules`.