### PR TITLE
Allow successive cancelations for non-zero exit codes

### DIFF
--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -201,11 +201,10 @@ func WithTempSettings(rc Runner, opts []RunnerOption, cb func() error) error {
 	}
 
 	err = cb()
+	rc.setSettings(oldSettings)
 	if err != nil {
 		return err
 	}
-
-	rc.setSettings(oldSettings)
 
 	return nil
 }


### PR DESCRIPTION
Without this change, the subsequent use of CTRL+C when running from the `tui` will only work when the process exits with error code 0. We want it to work irrespective of the error code.