### PR TITLE
async task loader

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -434,6 +434,10 @@ func loadTasks(proj project.Project, w io.Writer, r io.Reader) (project.CodeBloc
 
 		resultModel = result.(loadTasksModel)
 	} else {
+		if strings.ToLower(os.Getenv("RUNME_VERBOSE")) != "true" {
+			w = io.Discard
+		}
+
 		fmt.Fprintln(w, "Initializing...")
 
 	outer:

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -393,7 +393,6 @@ type loadTasksModel struct {
 
 	tasks project.CodeBlocks
 
-	// channel chan interface{}
 	nextTaskMsg tea.Cmd
 }
 

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -438,7 +438,7 @@ func loadTasks(proj project.Project, w io.Writer, r io.Reader) (project.CodeBloc
 			w = io.Discard
 		}
 
-		fmt.Fprintln(w, "Initializing...")
+		_, _ = fmt.Fprintln(w, "Initializing...")
 
 	outer:
 		for {
@@ -448,15 +448,15 @@ func loadTasks(proj project.Project, w io.Writer, r io.Reader) (project.CodeBloc
 
 			switch msg := nextTaskMsg().(type) {
 			case loadTaskFinished:
-				fmt.Fprintln(w, "")
+				_, _ = fmt.Fprintln(w, "")
 				break outer
 			case project.LoadTaskStatusSearchingFiles:
-				fmt.Fprintln(w, "Searching for files...")
+				_, _ = fmt.Fprintln(w, "Searching for files...")
 			case project.LoadTaskStatusParsingFiles:
-				fmt.Fprintln(w, "Parsing files...")
+				_, _ = fmt.Fprintln(w, "Parsing files...")
 			default:
-				if new, ok := resultModel.TaskUpdate(msg).(loadTasksModel); ok {
-					resultModel = new
+				if newModel, ok := resultModel.TaskUpdate(msg).(loadTasksModel); ok {
+					resultModel = newModel
 				}
 			}
 		}
@@ -493,7 +493,7 @@ func (m loadTasksModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c":
+		case "ctrl+c", "crtl+d":
 			m.err = errors.New("aborted")
 			return m, tea.Quit
 		}

--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -42,7 +42,7 @@ func fmtCmd() *cobra.Command {
 			files := args
 
 			if len(files) == 0 {
-				projectFiles, err := proj.LoadFiles()
+				projectFiles, err := loadFiles(proj, cmd.OutOrStdout(), cmd.InOrStdin())
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -31,7 +31,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 
-			allBlocks, err := loadTasks(proj)
+			allBlocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -31,7 +31,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 
-			allBlocks, err := proj.LoadTasks()
+			allBlocks, err := project.LoadProjectTasks(proj)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -31,7 +31,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 
-			allBlocks, err := project.LoadProjectTasks(proj)
+			allBlocks, err := loadTasks(proj)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/project"
 )
 
 func printCmd() *cobra.Command {
@@ -20,7 +21,7 @@ func printCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := proj.LoadTasks()
+			blocks, err := project.LoadProjectTasks(proj)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/stateful/runme/internal/project"
 )
 
 func printCmd() *cobra.Command {
@@ -21,7 +20,7 @@ func printCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := project.LoadProjectTasks(proj)
+			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -71,7 +71,7 @@ func runCmd() *cobra.Command {
 			runBlocks := make([]project.FileCodeBlock, 0)
 
 			{
-				blocks, err := project.LoadProjectTasks(proj)
+				blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -71,7 +71,7 @@ func runCmd() *cobra.Command {
 			runBlocks := make([]project.FileCodeBlock, 0)
 
 			{
-				blocks, err := proj.LoadTasks()
+				blocks, err := project.LoadProjectTasks(proj)
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -36,7 +36,7 @@ func tuiCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := proj.LoadTasks()
+			blocks, err := project.LoadProjectTasks(proj)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -36,7 +36,7 @@ func tuiCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := project.LoadProjectTasks(proj)
+			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
 			if err != nil {
 				return err
 			}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -478,7 +478,7 @@ func (p *SingleFileProject) LoadTasks(filesOnly bool, channel chan<- interface{}
 	channel <- LoadTaskStatusSearchingFiles{}
 
 	fs := osfs.New(p.Dir())
-	channel <- LoadTaskSearchingFolder{Folder: fs.Root()}
+	channel <- LoadTaskSearchingFolder{Folder: "."}
 
 	relFile, err := filepath.Rel(fs.Root(), p.file)
 	if err != nil {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -205,8 +205,10 @@ func (blocks CodeBlocks) Names() []string {
 	return nil
 }
 
-type LoadTaskStatusSearchingFiles struct{}
-type LoadTaskStatusParsingFiles struct{}
+type (
+	LoadTaskStatusSearchingFiles struct{}
+	LoadTaskStatusParsingFiles   struct{}
+)
 
 type LoadTaskSearchingFolder struct {
 	Folder string
@@ -403,8 +405,6 @@ func (p *DirectoryProject) LoadTasks(filesOnly bool, channel chan<- interface{})
 		return
 	}
 
-	result := make(CodeBlocks, 0)
-
 	channel <- LoadTaskStatusParsingFiles{}
 
 	for _, mdFile := range markdownFiles {
@@ -418,8 +418,6 @@ func (p *DirectoryProject) LoadTasks(filesOnly bool, channel chan<- interface{})
 		for _, block := range blocks {
 			channel <- LoadTaskFoundTask{Task: block}
 		}
-
-		result = append(result, blocks...)
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -212,6 +212,10 @@ type LoadTaskSearchingFolder struct {
 	Folder string
 }
 
+type LoadTaskParsingFile struct {
+	Filename string
+}
+
 type LoadTaskFoundFile struct {
 	Filename string
 }
@@ -404,6 +408,7 @@ func (p *DirectoryProject) LoadTasks(filesOnly bool, channel chan<- interface{})
 	channel <- LoadTaskStatusParsingFiles{}
 
 	for _, mdFile := range markdownFiles {
+		channel <- LoadTaskParsingFile{Filename: mdFile}
 		blocks, err := getFileCodeBlocks(mdFile, p.allowUnknown, p.allowUnnamed, p.fs)
 		if err != nil {
 			channel <- LoadTaskError{Err: err}
@@ -486,6 +491,7 @@ func (p *SingleFileProject) LoadTasks(filesOnly bool, channel chan<- interface{}
 
 	channel <- LoadTaskStatusParsingFiles{}
 
+	channel <- LoadTaskParsingFile{Filename: relFile}
 	blocks, err := getFileCodeBlocks(relFile, p.allowUnknown, p.allowUnnamed, fs)
 	if err != nil {
 		channel <- LoadTaskError{Err: err}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -554,3 +554,23 @@ func LoadProjectTasks(proj Project) (CodeBlocks, error) {
 
 	return blocks, err
 }
+
+// Load files, blocking until all projects are loaded
+func LoadProjectFiles(proj Project) ([]string, error) {
+	channel := make(chan interface{})
+	go proj.LoadTasks(true, channel)
+
+	files := make([]string, 0)
+	var err error
+
+	for raw := range channel {
+		switch msg := raw.(type) {
+		case LoadTaskError:
+			err = msg.Err
+		case LoadTaskFoundFile:
+			files = append(files, msg.Filename)
+		}
+	}
+
+	return files, err
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -100,8 +100,9 @@ func Test_directoryGitProject(t *testing.T) {
 		}, envs)
 	})
 
-	t.Run("LoadTasks", func(t *testing.T) {
-		tasks, err := proj.LoadTasks()
+	// TODO(mxs): test LoadTasks directly
+	t.Run("LoadProjectTasks", func(t *testing.T) {
+		tasks, err := LoadProjectTasks(proj)
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(tasks))
@@ -155,8 +156,9 @@ func Test_directoryBareProject(t *testing.T) {
 		}, envs)
 	})
 
-	t.Run("LoadTasks", func(t *testing.T) {
-		tasks, err := proj.LoadTasks()
+	// TODO(mxs): test LoadTasks directly
+	t.Run("LoadProjectTasks", func(t *testing.T) {
+		tasks, err := LoadProjectTasks(proj)
 		require.NoError(t, err)
 
 		assert.Equal(t, 4, len(tasks))
@@ -202,8 +204,9 @@ func Test_singleFileProject(t *testing.T) {
 		assert.Nil(t, envs)
 	})
 
-	t.Run("LoadTasks", func(t *testing.T) {
-		tasks, err := proj.LoadTasks()
+	// TODO(mxs): test LoadTasks directly
+	t.Run("LoadProjectTasks", func(t *testing.T) {
+		tasks, err := LoadProjectTasks(proj)
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, len(tasks))
@@ -218,7 +221,7 @@ func Test_codeBlockFrontmatter(t *testing.T) {
 	proj, err := NewDirectoryProject(filepath.Join(cwd, "../../", "examples", "frontmatter", "shells"), false, true, true, []string{})
 	require.NoError(t, err)
 
-	tasks, err := proj.LoadTasks()
+	tasks, err := LoadProjectTasks(proj)
 	require.NoError(t, err)
 
 	t.Log(tasks)

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -29,7 +29,7 @@ func Test_ResolveDirectory(t *testing.T) {
 	proj, err := project.NewDirectoryProject(projectRoot, false, false, false, []string{})
 	require.NoError(t, err)
 
-	tasks, err := proj.LoadTasks()
+	tasks, err := project.LoadProjectTasks(proj)
 	require.NoError(t, err)
 
 	taskMap := make(map[string]string)


### PR DESCRIPTION
Moves the task loader to an asynchronous model, so that loading information can be "streamed" and consumed by e.g. TUI loaders.

Includes a bubbletea model that all the `internal/cmd` should use:

![2023-06-22 16-43-57](https://github.com/stateful/runme/assets/16108792/8b44aac6-6e64-4a0b-a59a-18d997c4a484)
