### PR TITLE
internal/runner: sanitize last command output

### DIFF
--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -342,7 +343,9 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 			}
 
 			if storeStdout {
-				stdoutMem = append(stdoutMem, data.Stdout...)
+				// sanitize for environment variable
+				sanitized := bytes.ReplaceAll(data.Stdout, []byte{'\000'}, []byte{})
+				stdoutMem = append(stdoutMem, sanitized...)
 			}
 		}
 		return nil


### PR DESCRIPTION
Removes null bytes from last command output. Prevents errors in notebook if command output contains null bytes.

You can repro this error on main by using `echo "\0"` - things will break after the first command if a session is used.