### PR TITLE
Better error message when no code blocks were found in project-mode

### DIFF
--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -50,7 +50,7 @@ func tuiCmd() *cobra.Command {
 				if !fAllowUnnamed {
 					return errors.Errorf("no named code blocks, consider adding flag --allow-unnamed")
 				}
-				return errors.Errorf("no named code blocks")
+				return errors.Errorf("no code blocks")
 			}
 
 			if visibleEntries <= 0 {

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -44,7 +44,13 @@ func tuiCmd() *cobra.Command {
 			blocks = sortBlocks(blocks)
 
 			if len(blocks) == 0 {
-				return errors.Errorf("no code blocks in %s", fFileName)
+				if fFileMode {
+					return errors.Errorf("no code blocks in %s", fFileName)
+				}
+				if !fAllowUnnamed {
+					return errors.Errorf("no named code blocks, consider adding flag --allow-unnamed")
+				}
+				return errors.Errorf("no named code blocks")
 			}
 
 			if visibleEntries <= 0 {


### PR DESCRIPTION
Ahead of making UX changes to better support out-of-the-box use cases, such as showing all code blocks if no named code blocks were found.