### PR TITLE
Retain the legacy attribute parsing for upcoming release

### DIFF
--- a/internal/document/attributes.go
+++ b/internal/document/attributes.go
@@ -191,6 +191,14 @@ func (p *failoverAttributeParser) Write(attr Attributes, w io.Writer) error {
 
 var DefaultDocumentParser = newFailoverAttributeParser(
 	[]attributeParser{
+		&babikMLParser{},
+	},
+	&babikMLParser{},
+)
+
+// todo(sebastian): make default in v2
+var FutureDocumentParser = newFailoverAttributeParser(
+	[]attributeParser{
 		&jsonParser{},
 		&babikMLParser{},
 	},

--- a/internal/document/attributes_test.go
+++ b/internal/document/attributes_test.go
@@ -117,7 +117,7 @@ func Test_attributes(t *testing.T) {
 	})
 
 	t.Run("failoverAttributesParser", func(t *testing.T) {
-		parser := DefaultDocumentParser
+		parser := FutureDocumentParser
 
 		// parser handles json
 		{

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -166,6 +166,8 @@ echo 1
 }
 
 func Test_toCells_UnsupportedLang(t *testing.T) {
+	// todo(sebastian): make default in v2
+	document.DefaultDocumentParser = document.FutureDocumentParser
 	data := []byte("```py {\"readonly\":\"true\"}" + `
 def hello():
     print("Hello World")
@@ -323,55 +325,61 @@ pre-commit install
 	)
 }
 
-func Test_serializeCells_attributes_babikml(t *testing.T) {
-	data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
-	expected := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
-	doc := document.New(data, cmark.Render)
-	node, _, err := doc.Parse()
-	require.NoError(t, err)
-	cells := toCells(node, data)
-	assert.Equal(t, string(expected), string(serializeCells(cells)))
-}
+func Test_serializeCells(t *testing.T) {
+	// todo(sebastian): remove for v2
+	document.DefaultDocumentParser = document.FutureDocumentParser
+	t.Run("attributes_babikml", func(t *testing.T) {
+		data := []byte("```sh { name=echo first= second=2 }\necho 1\n```\n")
+		expected := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
+		doc := document.New(data, cmark.Render)
+		node, _, err := doc.Parse()
+		require.NoError(t, err)
+		cells := toCells(node, data)
+		assert.Equal(t, string(expected), string(serializeCells(cells)))
+	})
 
-func Test_serializeCells_attributes(t *testing.T) {
-	data := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
-	doc := document.New(data, cmark.Render)
-	node, _, err := doc.Parse()
-	require.NoError(t, err)
-	cells := toCells(node, data)
-	assert.Equal(t, string(data), string(serializeCells(cells)))
-}
+	t.Run("attributes", func(t *testing.T) {
+		data := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
+		doc := document.New(data, cmark.Render)
+		node, _, err := doc.Parse()
+		require.NoError(t, err)
+		cells := toCells(node, data)
+		assert.Equal(t, string(data), string(serializeCells(cells)))
+	})
 
-func Test_serializeCells_privateFields(t *testing.T) {
-	data := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
-	doc := document.New(data, cmark.Render)
-	node, _, err := doc.Parse()
-	require.NoError(t, err)
+	t.Run("privateFields", func(t *testing.T) {
+		data := []byte("```sh {\"first\":\"\",\"name\":\"echo\",\"second\":\"2\"}\necho 1\n```\n")
+		doc := document.New(data, cmark.Render)
+		node, _, err := doc.Parse()
+		require.NoError(t, err)
 
-	cells := toCells(node, data)
-	// Add private fields whcih will be filtered out durign serialization.
-	cells[0].Metadata["_private"] = "private"
-	cells[0].Metadata["runme.dev/internal"] = "internal"
+		cells := toCells(node, data)
+		// Add private fields whcih will be filtered out durign serialization.
+		cells[0].Metadata["_private"] = "private"
+		cells[0].Metadata["runme.dev/internal"] = "internal"
 
-	assert.Equal(t, string(data), string(serializeCells(cells)))
-}
+		assert.Equal(t, string(data), string(serializeCells(cells)))
+	})
 
-func Test_serializeCells_UnsupportedLang(t *testing.T) {
-	data := []byte(`## Non-Supported Languages
+	t.Run("UnsupportedLang", func(t *testing.T) {
+		data := []byte(`## Non-Supported Languages
 
 ` + "```py {\"readonly\":\"true\"}" + `
 def hello():
-    print("Hello World")
+	print("Hello World")
 ` + "```" + `
 `)
-	doc := document.New(data, cmark.Render)
-	node, _, err := doc.Parse()
-	require.NoError(t, err)
-	cells := toCells(node, data)
-	assert.Equal(t, string(data), string(serializeCells(cells)))
+		doc := document.New(data, cmark.Render)
+		node, _, err := doc.Parse()
+		require.NoError(t, err)
+		cells := toCells(node, data)
+		assert.Equal(t, string(data), string(serializeCells(cells)))
+	})
 }
 
 func Test_serializeFencedCodeAttributes(t *testing.T) {
+	// todo(sebastian): remove for v2
+	document.DefaultDocumentParser = document.FutureDocumentParser
 	t.Run("NoMetadata", func(t *testing.T) {
 		var buf bytes.Buffer
 		serializeFencedCodeAttributes(&buf, &Cell{


### PR DESCRIPTION
Decided it makes more sense to switch attribute formats for v2 (more straightforward to explain). For the pending release of project mode, we want to continue using BabikML.

This is a stop-gap PR to get the release out and then "revert this commit" for the upcoming v2. Obviously, it's not great to have tests against JSON attributes, whereas the app logic uses BabikML. However, there's little value in rewriting the tests for a 1-2 weeks lifetime.