### PR TITLE
bump to go1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: ">=1.19"
+          go-version: ">=1.20"
       - name: Install dependencies
         run: make install/dev
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19"]
+        go: ["1.20"]
     name: Lint with Go ${{ matrix.go }}
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ["1.19"]
+        go: ["1.20"]
         os: [ubuntu-latest, windows-latest]
     name: Build and test with Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,3 +178,11 @@ The requisite tools can be installed with:
 ```sh { interactive=false }
 make install/goreleaser
 ```
+
+## Upgrading to go 1.20
+
+After upgrading go to version 1.20, you'll need to make sure to reinstall dev packages, as some may be outdated:
+
+```sh
+make install/dev
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,6 @@ make install/goreleaser
 
 After upgrading go to version 1.20, you'll need to make sure to reinstall dev packages, as some may be outdated:
 
-```sh
+```sh { name=upgrade-go-120 }
 make install/dev
 ```

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ lint:
 .PHONY: install/dev
 install/dev:
 	go install github.com/mgechev/revive@v1.2.3
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.12.0
-	go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.16.0
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 	go install mvdan.cc/gofumpt@v0.3.1
 
 .PHONY: install/goreleaser

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stateful/runme
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/internal/rbuffer/ring_buffer_test.go
+++ b/internal/rbuffer/ring_buffer_test.go
@@ -2,8 +2,9 @@ package rbuffer
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io"
-	"math/rand"
+	mathRand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,7 +66,7 @@ func TestRingBuffer(t *testing.T) {
 			unwritten := int64((64 << 10) << 10) // 64 MiB
 
 			for unwritten > 0 {
-				c := rand.Intn(cap(token))
+				c := mathRand.Intn(cap(token))
 				if c > int(unwritten) {
 					c = int(unwritten)
 				}


### PR DESCRIPTION
Bumps required packages not currently supporting v1.20. Fixes lint issues related.

I added some lines to `CONTRIBUTING.md` to cover this case. Developers can run the following to get up-to-date:

```sh
runme run upgrade-go-120 --filename CONTRIBUTING.md
```