### PR TITLE
fix: Adding required header on cloud to generate tokens

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -538,6 +538,8 @@ func (a *Auth) getAPIToken(ctx context.Context, accessToken string) (string, err
 		return "", err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	resp, err := a.getHTTPClient().Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Adding header required on cloud-backend to generate tokens