### PR TITLE
docs: update install script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ brew update
 Install runme:
 
 ```sh { name=install-runme }
-$ brew install stateful/tap/runme
+$ brew install runme
 ```
 
 or via NPM:


### PR DESCRIPTION
Update README as this can now be installed with `brew install runme` by https://github.com/Homebrew/homebrew-core/pull/135992 .
Created PR without creating an issue because of the minor changes.