### PR TITLE
(release): add download-url to brew update step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,5 +70,6 @@ jobs:
         if: ${{ !contains(github.ref, '-') }}
         with:
           formula-name: runme
+          download-url: https://github.com/stateful/runme.git
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Looking at other examples, e.g. https://github.com/Homebrew/homebrew-core/pull/136419/files this seems to be the way to force the action to update the git tag and sha rather than the url.