### PR TITLE
internal/document: only include intro if from paragraph

### DIFF
--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -269,7 +269,7 @@ func normalizeIntro(s string) string {
 }
 
 func getIntro(node *ast.FencedCodeBlock, source []byte) string {
-	if prevNode := node.PreviousSibling(); prevNode != nil {
+	if prevNode := node.PreviousSibling(); prevNode != nil && prevNode.Kind() == ast.KindParagraph {
 		return normalizeIntro(string(prevNode.Text(source)))
 	}
 	return ""

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -65,6 +65,35 @@ First paragraph.
 	assert.Equal(t, "Item 3\n", string(node.children[3].children[2].children[0].Item().Value()))
 }
 
+func TestDocument_BlockIntro(t *testing.T) {
+	data := bytes.TrimSpace([]byte(`
+---
+key: value
+---
+
+` + "```" + `js { name=echo }
+console.log("hello world!")
+` + "```" + `
+
+This is an intro
+
+` + "```" + `js { name=echo-2 }
+console.log("hello world!")
+` + "```" + `
+
+`,
+	))
+
+	doc := New(data, cmark.Render)
+	node, _, err := doc.Parse()
+	require.NoError(t, err)
+
+	cells := CollectCodeBlocks(node)
+
+	assert.Equal(t, "", cells[0].Intro())
+	assert.Equal(t, "This is an intro", cells[1].Intro())
+}
+
 func TestDocument_FinalLineBreaks(t *testing.T) {
 	data := []byte(`This will test final line breaks`)
 


### PR DESCRIPTION
Fixes #334 

Basically we just need to make sure that the codeblock's `intro` value is coming from a paragraph, and not e.g. the frontmatter block.