### PR TITLE
internal/runner: limit env store size

### DIFF
--- a/internal/runner/env_store.go
+++ b/internal/runner/env_store.go
@@ -42,10 +42,9 @@ func (s *envStore) Set(k string, v string) (*envStore, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	newSize := 0
+	newSize := getEnvSizeContribution(k, v)
 	for key, value := range s.values {
 		if key == k {
-			newSize += getEnvSizeContribution(k, v)
 			continue
 		}
 

--- a/internal/runner/env_store_test.go
+++ b/internal/runner/env_store_test.go
@@ -1,3 +1,54 @@
 package runner
 
-// TODO: add unit tests
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: add more unit tests
+
+func Test_maxEnvSize(t *testing.T) {
+	{
+		session := newEnvStore()
+
+		_, err := session.Set("key", strings.Repeat("a", maxEnvSize))
+		assert.Error(t, err)
+	}
+
+	{
+		session := newEnvStore()
+
+		_, err := session.Set("key", "value")
+		assert.NoError(t, err)
+	}
+
+	{
+		session := newEnvStore()
+
+		{
+			_, err := session.Set("key", strings.Repeat("a", maxEnvSize/2+1))
+			assert.NoError(t, err)
+		}
+
+		{
+			_, err := session.Set("key", strings.Repeat("a", (maxEnvSize/2)+1))
+			assert.NoError(t, err)
+		}
+	}
+
+	{
+		session := newEnvStore()
+
+		{
+			_, err := session.Set("key", strings.Repeat("a", maxEnvSize/2+1))
+			assert.NoError(t, err)
+		}
+
+		{
+			_, err := session.Set("key2", strings.Repeat("a", (maxEnvSize/2)+1))
+			assert.Error(t, err)
+		}
+	}
+}


### PR DESCRIPTION
Limits env store size to 32760 (the lowest env store size of the main platforms).

This fixes a bug where scripts that have very very large outputs would cause the notebook terminal to refuse to run a script.