### PR TITLE
ensure script filtering is aware of `--allow-unnamed`

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -132,8 +132,6 @@ func getProject() (proj project.Project, err error) {
 func getCodeBlocks() (document.CodeBlocks, error) {
 	return project.GetCodeBlocks(
 		filepath.Join(fChdir, fFileName),
-		fAllowUnknown,
-		fAllowUnnamed,
 		nil,
 	)
 }
@@ -434,13 +432,24 @@ func loadFiles(proj project.Project, w io.Writer, r io.Reader) ([]string, error)
 	return m.files, nil
 }
 
-func loadTasks(proj project.Project, w io.Writer, r io.Reader) (project.CodeBlocks, error) {
+func loadTasks(proj project.Project, w io.Writer, r io.Reader, filter bool) (project.CodeBlocks, error) {
 	m, err := runTasksModel(proj, false, w, r)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.tasks, nil
+	tasks := m.tasks
+
+	if filter {
+		tasks = project.FilterCodeBlocks[project.CodeBlock](m.tasks, fAllowUnknown, fAllowUnnamed)
+
+		if len(tasks) == 0 {
+			// try again without filtering unnamed
+			tasks = project.FilterCodeBlocks[project.CodeBlock](m.tasks, fAllowUnknown, true)
+		}
+	}
+
+	return tasks, nil
 }
 
 func runTasksModel(proj project.Project, filesOnly bool, w io.Writer, r io.Reader) (*loadTasksModel, error) {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -136,14 +136,6 @@ func getCodeBlocks() (document.CodeBlocks, error) {
 	)
 }
 
-func lookupCodeBlock(blocks document.CodeBlocks, name string) (*document.CodeBlock, error) {
-	block := blocks.Lookup(name)
-	if block == nil {
-		return nil, errors.Errorf("command %q not found; known command names: %s", name, blocks.Names())
-	}
-	return block, nil
-}
-
 func validCmdNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	blocks, err := getCodeBlocks()
 	if err != nil {

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -31,7 +31,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 
-			allBlocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
+			allBlocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin(), true)
 			if err != nil {
 				return err
 			}
@@ -41,7 +41,7 @@ func listCmd() *cobra.Command {
 				return err
 			}
 
-			if len(blocks) < 1 && !fAllowUnnamed {
+			if len(blocks) <= 0 && !fAllowUnnamed {
 				return errors.Errorf("no named code blocks, consider adding flag --allow-unnamed")
 			}
 
@@ -57,6 +57,7 @@ func listCmd() *cobra.Command {
 			table.AddField(strings.ToUpper("File"), nil, nil)
 			table.AddField(strings.ToUpper("First Command"), nil, nil)
 			table.AddField(strings.ToUpper("Description"), nil, nil)
+			table.AddField(strings.ToUpper("Named"), nil, nil)
 			table.EndRow()
 
 			for _, fileBlock := range blocks {
@@ -64,10 +65,16 @@ func listCmd() *cobra.Command {
 
 				lines := block.Lines()
 
+				isNamedField := "True"
+				if block.IsUnnamed() {
+					isNamedField = "False"
+				}
+
 				table.AddField(block.Name(), nil, nil)
 				table.AddField(fileBlock.File, nil, nil)
 				table.AddField(shell.TryGetNonCommentLine(lines), nil, nil)
 				table.AddField(block.Intro(), nil, nil)
+				table.AddField(isNamedField, nil, nil)
 				table.EndRow()
 			}
 

--- a/internal/cmd/print.go
+++ b/internal/cmd/print.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/project"
 )
 
 func printCmd() *cobra.Command {
@@ -20,13 +21,19 @@ func printCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
+		generateBlocks:
+			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin(), true)
 			if err != nil {
 				return err
 			}
 
 			fileBlock, err := lookupCodeBlockWithPrompt(cmd, args[0], blocks)
 			if err != nil {
+				if project.IsCodeBlockNotFoundError(err) && !fAllowUnnamed {
+					fAllowUnnamed = true
+					goto generateBlocks
+				}
+
 				return err
 			}
 

--- a/internal/cmd/tasks.go
+++ b/internal/cmd/tasks.go
@@ -23,6 +23,9 @@ func tasksCmd() *cobra.Command {
 
 		generateBlocks:
 			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin(), true)
+			if err != nil {
+				return err
+			}
 
 			block, err := lookupCodeBlockWithPrompt(cmd, args[0], blocks)
 			if err != nil {

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -366,8 +366,8 @@ func (m tuiModel) View() string {
 				"Choose ↑↓←→",
 				"Run [Enter]",
 				"Expand [Space]",
-				"Quit [q]",
 				fmt.Sprintf("%s Unnamed [u]", unnamedVerb),
+				"Quit [q]",
 			},
 			tab,
 		)

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -37,9 +37,18 @@ func tuiCmd() *cobra.Command {
 				return err
 			}
 
-			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin())
+			blocks, err := loadTasks(proj, cmd.OutOrStdout(), cmd.InOrStdin(), false)
 			if err != nil {
 				return err
+			}
+
+			defaultAllowUnnamed := fAllowUnnamed
+
+			if !defaultAllowUnnamed {
+				newBlocks := project.FilterCodeBlocks(blocks, fAllowUnknown, false)
+				if len(newBlocks) == 0 {
+					defaultAllowUnnamed = true
+				}
 			}
 
 			blocks = sortBlocks(blocks)
@@ -102,7 +111,7 @@ func tuiCmd() *cobra.Command {
 			}
 
 			model := tuiModel{
-				blocks: blocks,
+				unfilteredBlocks: blocks,
 				header: fmt.Sprintf(
 					"%s %s\n\n",
 					ansi.Color("runme", "57+b"),
@@ -110,7 +119,12 @@ func tuiCmd() *cobra.Command {
 				),
 				visibleEntries: visibleEntries,
 				expanded:       make(map[int]struct{}),
+
+				allowUnnamed: defaultAllowUnnamed,
+				allowUnknown: fAllowUnknown,
 			}
+
+			model.filterCodeBlocks()
 
 			sessionEnvs, err := runnerClient.GetEnvs(context.Background())
 			if err != nil {
@@ -188,13 +202,16 @@ func tuiCmd() *cobra.Command {
 }
 
 type tuiModel struct {
-	blocks         project.CodeBlocks
-	header         string
-	visibleEntries int
-	expanded       map[int]struct{}
-	cursor         int
-	scroll         int
-	result         tuiResult
+	unfilteredBlocks project.CodeBlocks
+	blocks           project.CodeBlocks
+	header           string
+	visibleEntries   int
+	expanded         map[int]struct{}
+	cursor           int
+	scroll           int
+	result           tuiResult
+	allowUnnamed     bool
+	allowUnknown     bool
 }
 
 type tuiResult struct {
@@ -215,6 +232,40 @@ func (m *tuiModel) scrollBy(delta int) {
 		m.scroll+delta,
 		0, m.maxScroll(),
 	)
+}
+
+func (m *tuiModel) filterCodeBlocks() {
+	hasInitialized := m.blocks != nil
+
+	var oldSelection project.CodeBlock
+	if hasInitialized {
+		oldSelection = m.blocks[m.cursor]
+	}
+
+	m.blocks = project.FilterCodeBlocks(m.unfilteredBlocks, m.allowUnknown, m.allowUnnamed)
+
+	if !hasInitialized {
+		return
+	}
+
+	foundOldSelection := false
+	for i, block := range m.blocks {
+		if block == oldSelection {
+			m.moveCursorTo(i)
+			foundOldSelection = true
+			break
+		}
+	}
+
+	if !foundOldSelection {
+		if m.cursor >= len(m.blocks) {
+			m.moveCursorTo(len(m.blocks) - 1)
+		}
+	}
+}
+
+func (m *tuiModel) moveCursorTo(newPos int) {
+	m.moveCursor(newPos - m.cursor)
 }
 
 func (m *tuiModel) moveCursor(delta int) {
@@ -258,6 +309,11 @@ func (m tuiModel) View() string {
 
 		{
 			name := block.Name()
+
+			if block.IsUnnamed() {
+				name += " (unnamed)"
+			}
+
 			filename := ansi.Color(fileBlock.File, "white+d")
 
 			if active {
@@ -296,6 +352,13 @@ func (m tuiModel) View() string {
 
 	_, _ = s.WriteRune('\n')
 
+	var unnamedVerb string
+	if m.allowUnnamed {
+		unnamedVerb = "Hide"
+	} else {
+		unnamedVerb = "Show"
+	}
+
 	{
 		help := strings.Join(
 			[]string{
@@ -304,6 +367,7 @@ func (m tuiModel) View() string {
 				"Run [Enter]",
 				"Expand [Space]",
 				"Quit [q]",
+				fmt.Sprintf("%s Unnamed [u]", unnamedVerb),
 			},
 			tab,
 		)
@@ -351,6 +415,10 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			return m, tea.Quit
+
+		case "u":
+			m.allowUnnamed = !m.allowUnnamed
+			m.filterCodeBlocks()
 		}
 	}
 

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/stateful/runme/internal/executable"
 	"github.com/stateful/runme/internal/shell"
 	"github.com/yuin/goldmark/ast"
 
@@ -153,8 +154,12 @@ func (b *CodeBlock) Name() string {
 	return b.name
 }
 
-func (b *CodeBlock) NameGenerated() bool {
+func (b *CodeBlock) IsUnnamed() bool {
 	return b.nameGenerated
+}
+
+func (b *CodeBlock) IsUnknown() bool {
+	return b.Language() == "" || !executable.IsSupported(b.Language())
 }
 
 func (b *CodeBlock) Unwrap() ast.Node {

--- a/internal/project/document.go
+++ b/internal/project/document.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/pkg/errors"
 	"github.com/stateful/runme/internal/document"
-	"github.com/stateful/runme/internal/executable"
 	"github.com/stateful/runme/internal/renderer/cmark"
 )
 
@@ -39,7 +38,7 @@ func WriteMarkdownFile(filename string, fs billy.Basic, data []byte) error {
 	return util.WriteFile(fs, filename, data, 0o600)
 }
 
-func parseDocumentForCodeBlocks(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic, doFrontmatter bool) (document.CodeBlocks, *document.Frontmatter, error) {
+func parseDocumentForCodeBlocks(filepath string, fs billy.Basic, doFrontmatter bool) (document.CodeBlocks, *document.Frontmatter, error) {
 	data, err := ReadMarkdownFile(filepath, fs)
 	if err != nil {
 		return nil, nil, err
@@ -65,23 +64,11 @@ func parseDocumentForCodeBlocks(filepath string, allowUnknown bool, allowUnnamed
 
 	blocks := document.CollectCodeBlocks(node)
 
-	filtered := make(document.CodeBlocks, 0, len(blocks))
-	for _, b := range blocks {
-		if !(allowUnknown || (b.Language() != "" && executable.IsSupported(b.Language()))) {
-			continue
-		}
-
-		if !allowUnnamed && b.NameGenerated() {
-			continue
-		}
-
-		filtered = append(filtered, b)
-	}
-	return filtered, fmtr, nil
+	return blocks, fmtr, nil
 }
 
-func GetCodeBlocksAndParseFrontmatter(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) (document.CodeBlocks, document.Frontmatter, error) {
-	blocks, fmtr, err := parseDocumentForCodeBlocks(filepath, allowUnknown, allowUnnamed, fs, true)
+func GetCodeBlocksAndParseFrontmatter(filepath string, fs billy.Basic) (document.CodeBlocks, document.Frontmatter, error) {
+	blocks, fmtr, err := parseDocumentForCodeBlocks(filepath, fs, true)
 
 	var f document.Frontmatter
 	if fmtr != nil {
@@ -91,7 +78,7 @@ func GetCodeBlocksAndParseFrontmatter(filepath string, allowUnknown bool, allowU
 	return blocks, f, err
 }
 
-func GetCodeBlocks(filepath string, allowUnknown bool, allowUnnamed bool, fs billy.Basic) (document.CodeBlocks, error) {
-	blocks, _, err := parseDocumentForCodeBlocks(filepath, allowUnknown, allowUnnamed, fs, false)
+func GetCodeBlocks(filepath string, fs billy.Basic) (document.CodeBlocks, error) {
+	blocks, _, err := parseDocumentForCodeBlocks(filepath, fs, false)
 	return blocks, err
 }

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -134,8 +134,8 @@ func main() {
 -- golden-list.txt --
 NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
 echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.	True
-hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.
-hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.
+hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.	True
+hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.	True
 -- golden-list-allow-unnamed.txt --
 NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
 echo-hello	README.md	echo "Hello, runme!"	This is a basic snippet with shell command.	False
@@ -144,7 +144,7 @@ echo-inferred	README.md	echo Inferred	Names will automatically be inferred from 
 echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.	True
 echo-1	README.md	echo "1"	It can contain multiple lines too.	False
 echo-hello-3	README.md	echo "Hello, runme! Again!"	Also, the dollar sign is not needed.	False
-hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.
-hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.
+hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.	True
+hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.	True
 tempdir	README.md	temp_dir=$(mktemp -d -t "runme-XXXXXXX")	It works with cd, pushd, and similar because all lines are executed as a single script.	False
 package-main	README.md	package main	It can also execute a snippet of Go code.	False

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -132,19 +132,19 @@ func main() {
 ```
 
 -- golden-list.txt --
-NAME	FILE	FIRST COMMAND	DESCRIPTION
-echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.	True
 hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.
 hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.
 -- golden-list-allow-unnamed.txt --
-NAME	FILE	FIRST COMMAND	DESCRIPTION
-echo-hello	README.md	echo "Hello, runme!"	This is a basic snippet with shell command.
-echo-hello-2	README.md	echo "Hello, runme!"	You can omit the language, and runme will assume you are in shell.
-echo-inferred	README.md	echo Inferred	Names will automatically be inferred from a script's contents.
-echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.
-echo-1	README.md	echo "1"	It can contain multiple lines too.
-echo-hello-3	README.md	echo "Hello, runme! Again!"	Also, the dollar sign is not needed.
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+echo-hello	README.md	echo "Hello, runme!"	This is a basic snippet with shell command.	False
+echo-hello-2	README.md	echo "Hello, runme!"	You can omit the language, and runme will assume you are in shell.	False
+echo-inferred	README.md	echo Inferred	Names will automatically be inferred from a script's contents.	False
+echo	README.md	echo "Hello, runme!"	With {name=hello} you can annotate it and give it a nice name.	True
+echo-1	README.md	echo "1"	It can contain multiple lines too.	False
+echo-hello-3	README.md	echo "Hello, runme! Again!"	Also, the dollar sign is not needed.	False
 hello-js	README.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.
 hello-js-cat	README.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.
-tempdir	README.md	temp_dir=$(mktemp -d -t "runme-XXXXXXX")	It works with cd, pushd, and similar because all lines are executed as a single script.
-package-main	README.md	package main	It can also execute a snippet of Go code.
+tempdir	README.md	temp_dir=$(mktemp -d -t "runme-XXXXXXX")	It works with cd, pushd, and similar because all lines are executed as a single script.	False
+package-main	README.md	package main	It can also execute a snippet of Go code.	False


### PR DESCRIPTION
Each script-related command will now first try to find the scripts, and if it fails, try again with allowing unnamed, even if `allow-unnamed` is false. 

The TUI command also now has a `u` command which (un)hides unnamed scripts.