### PR TITLE
internal/tls: rotate tls 7 days ahead

### DIFF
--- a/examples/grpc-client/main.go
+++ b/examples/grpc-client/main.go
@@ -37,7 +37,7 @@ func main() {
 }
 
 func run() error {
-	tlsConfig, err := runmetls.LoadTLSConfig(*tlsDir)
+	tlsConfig, err := runmetls.LoadTLSConfig(*tlsDir, true)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,8 @@ require (
 	google.golang.org/protobuf v1.28.1
 )
 
+require github.com/benbjohnson/clock v1.1.0 // indirect
+
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/briandowns/spinner v1.18.1 h1:yhQmQtM1zsqFsouh09Bk/jCjd50pC3EOGsh28gLVvwY=
 github.com/briandowns/spinner v1.18.1/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -55,7 +55,7 @@ func NewRemoteRunner(ctx context.Context, addr string, opts ...RunnerOption) (*R
 	if r.insecure {
 		creds = insecure.NewCredentials()
 	} else {
-		tlsConfig, err := runmetls.LoadTLSConfig(r.tlsDir)
+		tlsConfig, err := runmetls.LoadTLSConfig(r.tlsDir, true)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -151,8 +151,8 @@ generateNew:
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
-			CommonName:   "stateful",
-			Organization: []string{"Stateful, INC."},
+			CommonName:   "runme",
+			Organization: []string{"Stateful, Inc."},
 			Country:      []string{"US"},
 			Province:     []string{"California"},
 			Locality:     []string{"Berkeley"},

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -23,6 +23,11 @@ type TLSFiles[T any] struct {
 	PrivKey T
 }
 
+// Done for mocking purposes
+var getNow = func() time.Time {
+	return time.Now()
+}
+
 func getTLSFiles(tlsDir string) TLSFiles[string] {
 	return TLSFiles[string]{
 		Cert:    path.Join(tlsDir, "cert.pem"),
@@ -125,7 +130,7 @@ func GenerateTLS(tlsDir string, tlsFileMode os.FileMode, logger *zap.Logger) (*t
 			goto generateNew
 		}
 
-		if time.Now().AddDate(0, 0, 7).After(cert.NotAfter) {
+		if getNow().AddDate(0, 0, 7).After(cert.NotAfter) {
 			logger.Info("pre-existing certificate will expire soon, generating new certificate...")
 			goto generateNew
 		}
@@ -152,8 +157,8 @@ generateNew:
 			Province:     []string{"California"},
 			Locality:     []string{"Berkeley"},
 		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(0, 0, 30),
+		NotBefore:             getNow(),
+		NotAfter:              getNow().AddDate(0, 0, 30),
 		IsCA:                  true,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -49,7 +49,24 @@ func getTLSBytes(tlsDir string) (*TLSFiles[[]byte], error) {
 	}, nil
 }
 
-func LoadTLSConfig(tlsDir string) (*tls.Config, error) {
+func serverTLSConfig(cert tls.Certificate, certPool *x509.CertPool) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+func clientTLSConfig(cert tls.Certificate, certPool *x509.CertPool) *tls.Config {
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      certPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+func LoadTLSConfig(tlsDir string, isClient bool) (*tls.Config, error) {
 	pemBytes, err := getTLSBytes(tlsDir)
 	if err != nil {
 		return nil, err
@@ -65,13 +82,15 @@ func LoadTLSConfig(tlsDir string) (*tls.Config, error) {
 		return nil, err
 	}
 
-	tlsConfig := tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      certPool,
-		MinVersion:   tls.VersionTLS12,
+	var tlsConfig *tls.Config
+
+	if isClient {
+		tlsConfig = clientTLSConfig(cert, certPool)
+	} else {
+		tlsConfig = serverTLSConfig(cert, certPool)
 	}
 
-	return &tlsConfig, nil
+	return tlsConfig, nil
 }
 
 func GenerateTLS(tlsDir string, tlsFileMode os.FileMode, logger *zap.Logger) (*tls.Config, error) {
@@ -94,8 +113,29 @@ func GenerateTLS(tlsDir string, tlsFileMode os.FileMode, logger *zap.Logger) (*t
 		pkPath   = path.Join(tlsDir, "key.pem")
 	)
 
-	// TODO: rotation strategy here
+	if tlsConfig, err := LoadTLSConfig(tlsDir, false); err == nil {
+		if len(tlsConfig.Certificates) < 1 || len(tlsConfig.Certificates[0].Certificate) < 1 {
+			logger.Warn("invalid TLS certificate, generating new certificate...")
+			goto generateNew
+		}
 
+		cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
+		if err != nil {
+			logger.Warn("failed to parse certificate, generating new certificate...", zap.Error(err))
+			goto generateNew
+		}
+
+		if time.Now().AddDate(0, 0, 7).After(cert.NotAfter) {
+			logger.Info("pre-existing certificate will expire soon, generating new certificate...")
+			goto generateNew
+		}
+
+		logger.Info("using pre-existing TLS certificate")
+
+		return tlsConfig, nil
+	}
+
+generateNew:
 	logger.Info("generating new TLS certificate...")
 
 	privKey, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -148,11 +188,10 @@ func GenerateTLS(tlsDir string, tlsFileMode os.FileMode, logger *zap.Logger) (*t
 		return nil, err
 	}
 
-	// TODO: probably a more efficient way to create a `tls.Certificate`
-	// rather than unencrypting the PEM again...
-	tlsCa, err := tls.X509KeyPair(caPEM.Bytes(), privKeyPEM.Bytes())
-	if err != nil {
-		return nil, err
+	tlsCa := tls.Certificate{
+		Certificate: [][]byte{certificateBytes},
+		PrivateKey:  privKey,
+		Leaf:        ca,
 	}
 
 	certPool := x509.NewCertPool()
@@ -176,6 +215,7 @@ func GenerateTLS(tlsDir string, tlsFileMode os.FileMode, logger *zap.Logger) (*t
 	if err := os.WriteFile(pkPath, privKeyPEM.Bytes(), tlsFileMode); err != nil {
 		return nil, err
 	}
+
 	logger.Info("successfully generated new TLS certificate!")
 
 	return tlsConfig, nil

--- a/internal/tls/tls_test.go
+++ b/internal/tls/tls_test.go
@@ -13,8 +13,8 @@ import (
 
 func Test_GenerateTLS(t *testing.T) {
 	tlsDir := filepath.Join(os.TempDir(), uuid.New().String())
-	os.RemoveAll(tlsDir)
-	os.MkdirAll(tlsDir, 0o700)
+	_ = os.RemoveAll(tlsDir)
+	_ = os.MkdirAll(tlsDir, 0o700)
 	defer os.RemoveAll(tlsDir)
 
 	logger := zaptest.NewLogger(t)

--- a/internal/tls/tls_test.go
+++ b/internal/tls/tls_test.go
@@ -1,0 +1,50 @@
+package tls
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func Test_GenerateTLS(t *testing.T) {
+	tlsDir := filepath.Join(os.TempDir(), uuid.New().String())
+	os.RemoveAll(tlsDir)
+	os.MkdirAll(tlsDir, 0o700)
+	defer os.RemoveAll(tlsDir)
+
+	logger := zaptest.NewLogger(t)
+	tlsConfig, err := GenerateTLS(tlsDir, 0o700, logger)
+	require.NoError(t, err)
+
+	tlsConfig2, err := GenerateTLS(tlsDir, 0o700, logger)
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		tlsConfig.Certificates[0].Certificate[0],
+		tlsConfig2.Certificates[0].Certificate[0],
+	)
+
+	oldGetNow := getNow
+	defer func() {
+		getNow = oldGetNow
+	}()
+
+	getNow = func() time.Time {
+		return time.Now().AddDate(0, 0, 24)
+	}
+
+	tlsConfig3, err := GenerateTLS(tlsDir, 0o700, logger)
+	require.NoError(t, err)
+
+	require.NotEqual(
+		t,
+		tlsConfig.Certificates[0].Certificate[0],
+		tlsConfig3.Certificates[0].Certificate[0],
+	)
+}


### PR DESCRIPTION
Enables using pre-existing tls certificate, and re-generates 7 days ahead of the certificate's expiration date.