### PR TITLE
(release): remove 'v' for tag names

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -139,26 +139,26 @@ dockers:
     goarch: amd64
     image_templates:
       - "statefulhq/runme:latest"
-      - "statefulhq/runme:v{{ .Version }}-alpine-amd64"
+      - "statefulhq/runme:{{ .Version }}-alpine-amd64"
     skip_push: auto
     dockerfile: Dockerfile.alpine
   - goos: linux
     goarch: amd64
     image_templates:
       - "statefulhq/runme:latest"
-      - "statefulhq/runme:v{{ .Version }}-ubuntu-amd64"
+      - "statefulhq/runme:{{ .Version }}-ubuntu-amd64"
     skip_push: auto
     dockerfile: Dockerfile.ubuntu
   - goos: linux
     goarch: arm64
     image_templates:
-      - "statefulhq/runme:v{{ .Version }}-alpine-arm64"
+      - "statefulhq/runme:{{ .Version }}-alpine-arm64"
     skip_push: auto
     dockerfile: Dockerfile.alpine
   - goos: linux
     goarch: arm64
     image_templates:
-      - "statefulhq/runme:v{{ .Version }}-ubuntu-arm64"
+      - "statefulhq/runme:{{ .Version }}-ubuntu-arm64"
     skip_push: auto
     dockerfile: Dockerfile.ubuntu
 


### PR DESCRIPTION
The manifests didn't expect the `v` in front of the versions and it seems that most container don't have it anyway so removing.