### PR TITLE
Temporarily disable these until fix is ready

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -597,10 +597,10 @@ var programByLanguageID = map[string][]string{
 	"jsx":             {"node"},
 	"javascriptreact": {"node"},
 
-	"ts":              {"ts-node", "deno", "bun"},
-	"typescript":      {"ts-node", "deno", "bun"},
-	"tsx":             {"ts-node", "deno", "bun"},
-	"typescriptreact": {"ts-node", "deno", "bun"},
+	"ts":              {"ts-node"},
+	"typescript":      {"ts-node"},
+	"tsx":             {"ts-node"},
+	"typescriptreact": {"ts-node"},
 
 	"sh":         {"bash", "sh"},
 	"bash":       {"bash", "sh"},


### PR DESCRIPTION
Both `deno` & `bun` require the `run` argument to be passed.