### PR TITLE
(bugfix): support multiple categories

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -90,3 +90,15 @@ To still display unknown snippets, provide `--allow-unknown` to the `list` comma
 username = admin
 password = admin
 ```
+
+## Categories
+
+```sh { name=a category=a }
+echo "Category A"
+```
+```sh { name=b category=a,b }
+echo "Category A,B"
+```
+```sh { name=c category=a,b,c }
+echo "Category A,B,C"
+```

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stateful/runme/internal/project"
 	"github.com/stateful/runme/internal/runner/client"
 	"github.com/stateful/runme/internal/tui"
+	"golang.org/x/exp/slices"
 )
 
 const (
@@ -87,12 +88,16 @@ func runCmd() *cobra.Command {
 					for _, fileBlock := range blocks {
 						block := fileBlock.Block
 
-						if !block.ExcludeFromRunAll() {
-							if category != "" && category != block.Category() {
-								continue
-							}
-							runBlocks = append(runBlocks, fileBlock)
+						if category == "" || block.ExcludeFromRunAll() {
+							continue
 						}
+
+						containsCategory := slices.Contains(strings.Split(block.Category(), ","), category)
+						if !containsCategory {
+							continue
+						}
+
+						runBlocks = append(runBlocks, fileBlock)
 					}
 
 					if len(runBlocks) == 0 && !fAllowUnnamed {


### PR DESCRIPTION
Given a user has the following markdown defined:

````md
```sh { name=a category=a }
echo "Category A"
```
```sh { name=b category=a,b }
echo "Category A,B"
```
```sh { name=c category=a,b,c }
echo "Category A,B,C"
```
````

If I currently run:

```sh
 ./runme run -c b
```

it returns:

```
No tasks to execute with the category provided
```

even though I expect the following:

```
Run 2 tasks for category b? [Y/n] Y

 ►  Running task b...
Category A,B
 ►  ✓ Task b exited with code 0
 ►  Running task c...
Category A,B,C
 ►  ✓ Task c exited with code 0
```
