### PR TITLE
fix: adding flag to skip prompting for variables

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -40,6 +40,7 @@ func runCmd() *cobra.Command {
 	var (
 		dryRun         bool
 		runAll         bool
+		skipPromptVars bool
 		parallel       bool
 		replaceScripts []string
 		serverAddr     string
@@ -172,9 +173,11 @@ func runCmd() *cobra.Command {
 				return err
 			}
 
-			err = promptEnvVars(cmd, sessionEnvs, runBlocks...)
-			if err != nil {
-				return err
+			if isTerminal(os.Stdout.Fd()) && !skipPromptVars {
+				err = promptEnvVars(cmd, sessionEnvs, runBlocks...)
+				if err != nil {
+					return err
+				}
 			}
 
 			if runMany {
@@ -287,6 +290,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
+	cmd.Flags().BoolVar(&skipPromptVars, "skip-prompt-vars", false, "Skip prompting for variables.")
 	cmd.Flags().StringVarP(&category, "category", "c", "", "Run from a specific category.")
 	cmd.Flags().IntVarP(&runIndex, "index", "i", -1, "Index of command to run, 0-based. (Ignored in project mode)")
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -40,7 +40,7 @@ func runCmd() *cobra.Command {
 	var (
 		dryRun         bool
 		runAll         bool
-		skipPromptVars bool
+		skipPrompts    bool
 		parallel       bool
 		replaceScripts []string
 		serverAddr     string
@@ -173,7 +173,7 @@ func runCmd() *cobra.Command {
 				return err
 			}
 
-			if isTerminal(os.Stdout.Fd()) && !skipPromptVars {
+			if isTerminal(os.Stdout.Fd()) && !skipPrompts {
 				err = promptEnvVars(cmd, sessionEnvs, runBlocks...)
 				if err != nil {
 					return err
@@ -290,7 +290,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
-	cmd.Flags().BoolVarP(&skipPromptVars, "skip-prompt-vars", "v", false, "Skip prompting for variables.")
+	cmd.Flags().BoolVar(&skipPrompts, "skip-prompt", false, "Skip prompting for variables.")
 	cmd.Flags().StringVarP(&category, "category", "c", "", "Run from a specific category.")
 	cmd.Flags().IntVarP(&runIndex, "index", "i", -1, "Index of command to run, 0-based. (Ignored in project mode)")
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -290,7 +290,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
-	cmd.Flags().BoolVar(&skipPromptVars, "skip-prompt-vars", false, "Skip prompting for variables.")
+	cmd.Flags().BoolVarP(&skipPromptVars, "skip-prompt-vars", "v", false, "Skip prompting for variables.")
 	cmd.Flags().StringVarP(&category, "category", "c", "", "Run from a specific category.")
 	cmd.Flags().IntVarP(&runIndex, "index", "i", -1, "Index of command to run, 0-based. (Ignored in project mode)")
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -38,15 +38,16 @@ type CommandExportExtractMatch struct {
 
 func runCmd() *cobra.Command {
 	var (
-		dryRun         bool
-		runAll         bool
-		skipPrompts    bool
-		parallel       bool
-		replaceScripts []string
-		serverAddr     string
-		category       string
-		getRunnerOpts  func() ([]client.RunnerOption, error)
-		runIndex       int
+		dryRun                bool
+		runAll                bool
+		skipPrompts           bool
+		skipPromptsExplicitly bool
+		parallel              bool
+		replaceScripts        []string
+		serverAddr            string
+		category              string
+		getRunnerOpts         func() ([]client.RunnerOption, error)
+		runIndex              int
 	)
 
 	cmd := cobra.Command{
@@ -172,8 +173,7 @@ func runCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			if isTerminal(os.Stdout.Fd()) && !skipPrompts {
+			if (skipPromptsExplicitly || isTerminal(os.Stdout.Fd())) && !skipPrompts {
 				err = promptEnvVars(cmd, sessionEnvs, runBlocks...)
 				if err != nil {
 					return err
@@ -290,9 +290,12 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
-	cmd.Flags().BoolVar(&skipPrompts, "skip-prompt", true, "Skip prompting for variables.")
+	cmd.Flags().BoolVar(&skipPrompts, "skip-prompts", false, "Skip prompting for variables.")
 	cmd.Flags().StringVarP(&category, "category", "c", "", "Run from a specific category.")
 	cmd.Flags().IntVarP(&runIndex, "index", "i", -1, "Index of command to run, 0-based. (Ignored in project mode)")
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		skipPromptsExplicitly = cmd.Flags().Changed("skip-prompts")
+	}
 
 	getRunnerOpts = setRunnerFlags(&cmd, &serverAddr)
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -290,7 +290,7 @@ func runCmd() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&replaceScripts, "replace", "r", nil, "Replace instructions using sed.")
 	cmd.Flags().BoolVarP(&parallel, "parallel", "p", false, "Run tasks in parallel.")
 	cmd.Flags().BoolVarP(&runAll, "all", "a", false, "Run all commands.")
-	cmd.Flags().BoolVar(&skipPrompts, "skip-prompt", false, "Skip prompting for variables.")
+	cmd.Flags().BoolVar(&skipPrompts, "skip-prompt", true, "Skip prompting for variables.")
 	cmd.Flags().StringVarP(&category, "category", "c", "", "Run from a specific category.")
 	cmd.Flags().IntVarP(&runIndex, "index", "i", -1, "Index of command to run, 0-based. (Ignored in project mode)")
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -178,12 +178,12 @@ func runCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-			}
 
-			if runMany {
-				err := confirmExecution(cmd, len(runBlocks), parallel, category)
-				if err != nil {
-					return err
+				if runMany {
+					err := confirmExecution(cmd, len(runBlocks), parallel, category)
+					if err != nil {
+						return err
+					}
 				}
 			}
 


### PR DESCRIPTION
Solving issue https://github.com/stateful/runme/issues/297

Introducing new `runme run --skip-prompts` to skip prompting for variables
you can also do `runme run --skip-prompts=false` `runme run --skip-prompts=true`