### PR TITLE
Fix dangling tempfiles

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 
 	"github.com/creack/pty"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/rs/xid"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
@@ -198,11 +198,7 @@ func newCommand(cfg *commandConfig) (*command, error) {
 			extraArgs = append(extraArgs, "-c", script)
 		case CommandModeTempFile:
 			for {
-				id, err := uuid.NewRandom()
-				if err != nil {
-					return nil, err
-				}
-
+				id := xid.New()
 				tempScriptFile = filepath.Join(cfg.Directory, fmt.Sprintf(".runme-script-%s", id.String()))
 
 				if fileExtension != "" {

--- a/internal/runner/tempfile.go
+++ b/internal/runner/tempfile.go
@@ -52,6 +52,7 @@ func (s *TempFile) Run(ctx context.Context) error {
 		return err
 	}
 	s.command = cmd
+	defer s.command.Finalize()
 	return s.run(ctx, cmd)
 }
 


### PR DESCRIPTION
In the event of an error, the cleanup which used to be irrelevant (process quits) up until file resources were introduced to unlock shebang support. The example below would keep dangling temp files on the filesystem after exiting with an error due to a "corrupt" `ts-node` installation.

```
$ runme run --filename README.md function-unnest
No preset version installed for command ts-node
Please install a version by running one of the following:

asdf install nodejs 18.13.0

or add one of the following versions in your config file at /Users/sourishkrout/.tool-versions
nodejs 19.9.0
exit code: 126
```