### PR TITLE
Make CLI a consumer of formatter

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -27,76 +25,6 @@ import (
 )
 
 const envStackDepth = "__RUNME_STACK_DEPTH"
-
-func readMarkdownFile(args []string) ([]byte, error) {
-	arg := ""
-	if len(args) == 1 {
-		arg = args[0]
-	}
-
-	if arg == "" {
-		return project.ReadMarkdownFile(filepath.Join(fChdir, fFileName), nil)
-	}
-
-	var (
-		data []byte
-		err  error
-	)
-
-	if arg == "-" {
-		data, err = io.ReadAll(os.Stdin)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read from stdin")
-		}
-	} else if strings.HasPrefix(arg, "https://") {
-		client := http.Client{
-			Timeout: time.Second * 5,
-		}
-		resp, err := client.Get(arg)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get a file %q", arg)
-		}
-		defer func() { _ = resp.Body.Close() }()
-		data, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read body")
-		}
-	} else {
-		f, err := os.Open(arg)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to open file %q", arg)
-		}
-		defer func() { _ = f.Close() }()
-		data, err = io.ReadAll(f)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read from file %q", arg)
-		}
-	}
-
-	return data, nil
-}
-
-func writeMarkdownFile(args []string, data []byte) error {
-	arg := ""
-	if len(args) == 1 {
-		arg = args[0]
-	}
-
-	if arg == "-" {
-		return errors.New("cannot write to stdin")
-	}
-
-	if strings.HasPrefix(arg, "https://") {
-		return errors.New("cannot write to HTTP location")
-	}
-
-	fullFilename := arg
-	if fullFilename == "" {
-		return nil
-	}
-	err := os.WriteFile(fullFilename, data, 0o600)
-	return errors.Wrapf(err, "failed to write to %s", fullFilename)
-}
 
 func getProject() (proj project.Project, err error) {
 	if fFileMode {

--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -1,16 +1,11 @@
 package cmd
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/stateful/runme/internal/document"
-	"github.com/stateful/runme/internal/document/editor"
-	"github.com/stateful/runme/internal/renderer/cmark"
+	"github.com/stateful/runme/internal/project"
 )
 
 func fmtCmd() *cobra.Command {
@@ -50,59 +45,14 @@ func fmtCmd() *cobra.Command {
 				files = projectFiles
 			}
 
-			for _, relFile := range files {
-				mdFilePath := filepath.Join(proj.Dir(), relFile)
-
-				data, err := readMarkdownFile([]string{mdFilePath})
-				if err != nil {
-					return err
-				}
-
-				var formatted []byte
-
-				if flatten {
-					notebook, err := editor.Deserialize(data)
-					if err != nil {
-						return errors.Wrap(err, "failed to deserialize")
-					}
-
-					if formatJSON {
-						var buf bytes.Buffer
-						enc := json.NewEncoder(&buf)
-						enc.SetIndent("", "  ")
-						if err := enc.Encode(notebook); err != nil {
-							return errors.Wrap(err, "failed to encode to JSON")
-						}
-						formatted = buf.Bytes()
-					} else {
-						formatted, err = editor.Serialize(notebook)
-						if err != nil {
-							return errors.Wrap(err, "failed to serialize")
-						}
-					}
-				} else {
-					doc := document.New(data, cmark.Render)
-					_, astNode, err := doc.Parse()
-					if err != nil {
-						return errors.Wrap(err, "failed to parse source")
-					}
-					formatted, err = cmark.Render(astNode, data)
-					if err != nil {
-						return errors.Wrap(err, "failed to render")
-					}
-				}
-
-				if write {
-					err = writeMarkdownFile([]string{mdFilePath}, formatted)
-				} else {
-					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "===== %s =====\n", relFile)
-					_, _ = cmd.OutOrStdout().Write(formatted)
-					_, _ = fmt.Fprint(cmd.OutOrStdout(), "\n")
-				}
-
-				if err != nil {
-					return err
-				}
+			err = project.Format(files, proj.Dir(), flatten, formatJSON, write, func(file string, formatted []byte) error {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "===== %s =====\n", file)
+				_, _ = cmd.OutOrStdout().Write(formatted)
+				_, _ = fmt.Fprint(cmd.OutOrStdout(), "\n")
+				return nil
+			})
+			if err != nil {
+				return err
 			}
 
 			return nil

--- a/internal/project/document.go
+++ b/internal/project/document.go
@@ -35,6 +35,10 @@ func ReadMarkdownFile(filepath string, fs billy.Basic) ([]byte, error) {
 }
 
 func WriteMarkdownFile(filename string, fs billy.Basic, data []byte) error {
+	if fs == nil {
+		fs = osfs.Default
+	}
+
 	return util.WriteFile(fs, filename, data, 0o600)
 }
 

--- a/internal/project/formatter.go
+++ b/internal/project/formatter.go
@@ -1,0 +1,136 @@
+package project
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stateful/runme/internal/document"
+	"github.com/stateful/runme/internal/document/editor"
+	"github.com/stateful/runme/internal/renderer/cmark"
+)
+
+type funcFmt func(string, []byte) error
+
+func Format(files []string, basePath string, flatten bool, formatJSON bool, write bool, formatter funcFmt) error {
+	for _, relFile := range files {
+		data, err := readMarkdown(basePath, []string{relFile})
+		if err != nil {
+			return err
+		}
+
+		var formatted []byte
+
+		if flatten {
+			notebook, err := editor.Deserialize(data)
+			if err != nil {
+				return errors.Wrap(err, "failed to deserialize")
+			}
+
+			if formatJSON {
+				var buf bytes.Buffer
+				enc := json.NewEncoder(&buf)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(notebook); err != nil {
+					return errors.Wrap(err, "failed to encode to JSON")
+				}
+				formatted = buf.Bytes()
+			} else {
+				formatted, err = editor.Serialize(notebook)
+				if err != nil {
+					return errors.Wrap(err, "failed to serialize")
+				}
+			}
+		} else {
+			doc := document.New(data, cmark.Render)
+			_, astNode, err := doc.Parse()
+			if err != nil {
+				return errors.Wrap(err, "failed to parse source")
+			}
+			formatted, err = cmark.Render(astNode, data)
+			if err != nil {
+				return errors.Wrap(err, "failed to render")
+			}
+		}
+
+		if write {
+			err = writeMarkdown(basePath, []string{relFile}, formatted)
+		} else {
+			err = formatter(relFile, formatted)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeMarkdown(basePath string, args []string, data []byte) error {
+	arg := ""
+	if len(args) == 1 {
+		arg = args[0]
+	}
+
+	if arg == "-" {
+		return errors.New("cannot write to stdin")
+	}
+
+	if strings.HasPrefix(arg, "https://") {
+		return errors.New("cannot write to HTTP location")
+	}
+
+	fullFilename := filepath.Join(basePath, arg)
+	if fullFilename == "" {
+		return nil
+	}
+	err := WriteMarkdownFile(fullFilename, nil, data)
+	return errors.Wrapf(err, "failed to write to %s", fullFilename)
+}
+
+func readMarkdown(basePath string, args []string) ([]byte, error) {
+	arg := ""
+	if len(args) == 1 {
+		arg = args[0]
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+
+	if arg == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read from stdin")
+		}
+	} else if strings.HasPrefix(arg, "https://") {
+		client := http.Client{
+			Timeout: time.Second * 5,
+		}
+		resp, err := client.Get(arg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get a file %q", arg)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read body")
+		}
+	} else {
+		filePath := filepath.Join(basePath, arg)
+		data, err = ReadMarkdownFile(filePath, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read from file %q", arg)
+		}
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
Moving project-based file formatting into internal library.