### PR TITLE
(release): fix bump-homebrew-formula configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,5 @@ jobs:
         if: ${{ !contains(github.ref, '-') }}
         with:
           formula-name: runme
-          download-url: https://github.com/stateful/runme.git
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
The default value for `download-url` is:

    https://github.com/OWNER/REPO/archive/refs/tags/<tag-name>.tar.gz

Which is what we want for the "url" field of the Homebrew formula and not the git clone URL. The "sha256" field will be automatically calculated upon new `runme` tag releases.

https://github.com/Homebrew/homebrew-core/blob/c3d5f19331d19bc7a396320a93f9a9485d6cec98/Formula/r/runme.rb#L4-L5

Reverts https://github.com/stateful/runme/pull/332 /cc @christian-bromann @sourishkrout 

Ref. https://github.com/mislav/bump-homebrew-formula-action/issues/69
Ref. https://github.com/mislav/bump-homebrew-formula-action#action-inputs