### PR TITLE
adds support to handle skipPrompts from MD files in the cli

### DIFF
--- a/examples/frontmatter/skipPrompts/README.md
+++ b/examples/frontmatter/skipPrompts/README.md
@@ -1,0 +1,8 @@
+---
+skipPrompts: true
+---
+
+```sh { name=skip-prompts-sample }
+$ export ENV="<insert-env-here>"
+$ echo "The content of ENV is ${ENV}"
+```

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -85,6 +85,10 @@ func runCmd() *cobra.Command {
 					return err
 				}
 
+				if len(blocks) > 0 && blocks[0].Frontmatter.SkipPrompts {
+					skipPrompts = true
+				}
+
 				if runWithIndex {
 					if runIndex >= len(blocks) {
 						return fmt.Errorf("command index %v out of range", runIndex)
@@ -95,13 +99,18 @@ func runCmd() *cobra.Command {
 					for _, fileBlock := range blocks {
 						block := fileBlock.Block
 
-						if category == "" || block.ExcludeFromRunAll() {
+						if runAll && block.ExcludeFromRunAll() {
 							continue
 						}
 
-						containsCategory := slices.Contains(strings.Split(block.Category(), ","), category)
-						if !containsCategory {
-							continue
+						if category != "" {
+							if block.ExcludeFromRunAll() {
+								continue
+							}
+
+							if !slices.Contains(strings.Split(block.Category(), ","), category) {
+								continue
+							}
 						}
 
 						runBlocks = append(runBlocks, fileBlock)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -85,10 +85,6 @@ func runCmd() *cobra.Command {
 					return err
 				}
 
-				if len(blocks) > 0 && blocks[0].Frontmatter.SkipPrompts {
-					skipPrompts = true
-				}
-
 				if runWithIndex {
 					if runIndex >= len(blocks) {
 						return fmt.Errorf("command index %v out of range", runIndex)
@@ -192,6 +188,14 @@ func runCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			for _, block := range runBlocks {
+				if block.GetFrontmatter().SkipPrompts {
+					skipPrompts = true
+					break
+				}
+			}
+
 			if (skipPromptsExplicitly || isTerminal(os.Stdout.Fd())) && !skipPrompts {
 				err = promptEnvVars(cmd, sessionEnvs, runBlocks...)
 				if err != nil {

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -155,9 +155,11 @@ func tuiCmd() *cobra.Command {
 
 				runBlock := result.block.Clone()
 
-				err = promptEnvVars(cmd, sessionEnvs, runBlock)
-				if err != nil {
-					return err
+				if !runBlock.GetFrontmatter().SkipPrompts {
+					err = promptEnvVars(cmd, sessionEnvs, runBlock)
+					if err != nil {
+						return err
+					}
 				}
 
 				err = inRawMode(func() error {

--- a/main_test.go
+++ b/main_test.go
@@ -59,7 +59,7 @@ func TestSkipPromptsWithinAPty(t *testing.T) {
 	defer ptmx.Close()
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(ptmx)
+	_, _ = buf.ReadFrom(ptmx)
 
 	if ctx.Err() == context.DeadlineExceeded {
 		t.Fatalf("Command timed out")

--- a/main_test.go
+++ b/main_test.go
@@ -49,8 +49,10 @@ func TestRunmeRunAll(t *testing.T) {
 func TestSkipPromptsWithinAPty(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	_ = os.Setenv("RUNME_VERBOSE", "false")
+	defer os.Unsetenv("RUNME_VERBOSE")
 
-	cmd := exec.Command("go", "run", ".", "run", "skip-prompts-sample")
+	cmd := exec.Command("go", "run", ".", "run", "skip-prompts-sample", "--chdir", "./examples/frontmatter/skipPrompts")
 	ptmx, err := pty.StartWithAttrs(cmd, &pty.Winsize{Rows: 25, Cols: 80}, &syscall.SysProcAttr{})
 	if err != nil {
 		t.Fatalf("Could not start command with pty: %s", err)
@@ -68,7 +70,8 @@ func TestSkipPromptsWithinAPty(t *testing.T) {
 	assert.Nil(t, err, "Command execution failed")
 
 	expected := "The content of ENV is <insert-env-here>"
-	current := RemoveAnsiCodes(buf.String())
+	current := buf.String()
+	current = RemoveAnsiCodes(current)
 	current = strings.TrimSpace(current)
 
 	assert.Equal(t, expected, current, "Output does not match")

--- a/main_test.go
+++ b/main_test.go
@@ -3,10 +3,19 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/rogpeppe/go-internal/testscript"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -35,4 +44,38 @@ func TestRunmeRunAll(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir: "testdata/runall",
 	})
+}
+
+func TestSkipPromptsWithinAPty(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.Command("go", "run", ".", "run", "skip-prompts-sample")
+	ptmx, err := pty.StartWithAttrs(cmd, &pty.Winsize{Rows: 25, Cols: 80}, &syscall.SysProcAttr{})
+
+	if err != nil {
+		t.Fatalf("Could not start command with pty: %s", err)
+	}
+	defer ptmx.Close()
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(ptmx)
+
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("Command timed out")
+		return
+	}
+
+	assert.Nil(t, err, "Command execution failed")
+
+	expected := "The content of ENV is <insert-env-here>"
+	current := RemoveAnsiCodes(buf.String())
+	current = strings.TrimSpace(current)
+
+	assert.Equal(t, expected, current, "Output does not match")
+}
+
+func RemoveAnsiCodes(str string) string {
+	re := regexp.MustCompile(`\x1b\[.*?[a-zA-Z]|\x1b\].*?\x1b\\`)
+	return re.ReplaceAllString(str, "")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -24,3 +24,15 @@ func TestRunme(t *testing.T) {
 		Dir: "testdata/script",
 	})
 }
+
+func TestRunmeCategories(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata/categories",
+	})
+}
+
+func TestRunmeRunAll(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata/runall",
+	})
+}

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,6 @@ func TestSkipPromptsWithinAPty(t *testing.T) {
 
 	cmd := exec.Command("go", "run", ".", "run", "skip-prompts-sample")
 	ptmx, err := pty.StartWithAttrs(cmd, &pty.Winsize{Rows: 25, Cols: 80}, &syscall.SysProcAttr{})
-
 	if err != nil {
 		t.Fatalf("Could not start command with pty: %s", err)
 	}

--- a/testdata/categories/basic.txtar
+++ b/testdata/categories/basic.txtar
@@ -1,0 +1,42 @@
+env SHELL=/bin/bash
+exec runme run --all --category=foo --filename=CATEGORIES.md
+cmp stdout foo-bar-list.txt
+! stderr .
+
+env SHELL=/bin/bash
+exec runme run --all --category=bar --filename=CATEGORIES.md
+cmp stdout bar-list.txt
+! stderr .
+
+-- CATEGORIES.md --
+
+```bash { name=set-env category=foo }
+$ export ENV="foo!"
+```
+
+```bash { name=print-foo category=foo }
+$ stty -opost
+$ echo "$ENV"
+```
+
+```bash { name=print-bar category=foo,bar }
+$ stty -opost
+$ echo "bar!"
+```
+
+```bash { name=excluded category=foo,bar excludeFromRunAll=true }
+$ stty -opost
+$ echo "excluded!"
+```
+
+-- foo-bar-list.txt --
+ ►  Running task set-env...
+ ►  ✓ Task set-env exited with code 0
+ ►  Running task print-foo...
+foo!
+ ►  ✓ Task print-foo exited with code 0
+ ►  Running task print-bar...
+bar!
+ ►  ✓ Task print-bar exited with code 0
+-- bar-list.txt --
+bar!

--- a/testdata/runall/basic.txtar
+++ b/testdata/runall/basic.txtar
@@ -1,0 +1,37 @@
+env SHELL=/bin/bash
+exec runme run --all --filename=README.md
+cmp stdout all.txt
+! stderr .
+
+-- all.txt --
+ ►  Running task set-env...
+ ►  ✓ Task set-env exited with code 0
+ ►  Running task print-foo...
+foo!
+ ►  ✓ Task print-foo exited with code 0
+ ►  Running task print-bar...
+bar!
+ ►  ✓ Task print-bar exited with code 0
+-- README.md --
+---
+skipPrompts: true
+---
+
+```bash { name=set-env category=foo }
+$ export ENV="foo!"
+```
+
+```bash { name=print-foo category=foo }
+$ stty -opost
+$ echo "$ENV"
+```
+
+```bash { name=print-bar category=foo,bar }
+$ stty -opost
+$ echo "bar!"
+```
+
+```bash { name=excluded category=foo,bar excludeFromRunAll=true }
+$ stty -opost
+$ echo "excluded!"
+```

--- a/testdata/runall/basic.txtar
+++ b/testdata/runall/basic.txtar
@@ -3,6 +3,11 @@ exec runme run --all --filename=README.md
 cmp stdout all.txt
 ! stderr .
 
+env SHELL=/bin/bash
+exec runme run foo-command
+cmp stdout skip.txt
+! stderr .
+
 -- all.txt --
  ►  Running task set-env...
  ►  ✓ Task set-env exited with code 0
@@ -12,26 +17,38 @@ foo!
  ►  Running task print-bar...
 bar!
  ►  ✓ Task print-bar exited with code 0
+-- skip.txt --
+foo-command
 -- README.md --
 ---
 skipPrompts: true
 ---
 
-```bash { name=set-env category=foo }
+```bash { name=set-env category=foo interactive=true  }
 $ export ENV="foo!"
 ```
 
-```bash { name=print-foo category=foo }
+```bash { name=print-foo category=foo interactive=true }
 $ stty -opost
 $ echo "$ENV"
 ```
 
-```bash { name=print-bar category=foo,bar }
+```bash { name=print-bar category=foo,bar interactive=true }
 $ stty -opost
 $ echo "bar!"
 ```
 
-```bash { name=excluded category=foo,bar excludeFromRunAll=true }
+```bash { name=excluded category=foo,bar interactive=true excludeFromRunAll=true }
 $ stty -opost
 $ echo "excluded!"
+```
+-- SKIP.md --
+---
+skipPrompts: true
+---
+
+```sh { name=foo-command category=c1 interactive=true}
+$ stty -opost
+export BAR="foo-command"
+echo $BAR
 ```


### PR DESCRIPTION
Fix: https://github.com/stateful/runme/issues/407
Closes: https://github.com/stateful/runme/issues/405

Smoke tests:

1. Switch to the branch `delta/allow-skipprompts`
2. Run: `runme run make-build`.
3. Execute: `runme run make-test`.
4. Run: `./runme run skip-prompts-sample`.
5. Update the VS Code extension to point to the generated binary.

    Example:

    `"runme.server.binaryPath": "/home/cristian/go/src/github.com/stateful/runme/runme"`

6. Test the execution of the markdown files.
