### PR TITLE
Not pretty but practical fix to have node shebang hit

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
 brew "bufbuild/buf/buf"
 brew "grpcurl"
 brew "go"
+brew "node"

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -10,6 +10,7 @@ exec runme ls --allow-unnamed=true
 cmp stdout golden-list-allow-unnamed.txt
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
 ! exec runme ls --filename nonexistent.md
 stderr 'failed to open markdown file .*/nonexistent.md: no such file or directory'
 ! stdout .

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -10,7 +10,6 @@ exec runme ls --allow-unnamed=true
 cmp stdout golden-list-allow-unnamed.txt
 ! stderr .
 
-env PATH=/opt/homebrew/bin:$PATH
 ! exec runme ls --filename nonexistent.md
 stderr 'failed to open markdown file .*/nonexistent.md: no such file or directory'
 ! stdout .
@@ -44,14 +43,17 @@ exec sh -c 'runme run --allow-unnamed package-main'
 stdout 'Hello from Go, runme!'
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
 exec runme run hello-js
 stdout 'Hello, runme, from javascript!'
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
 exec runme run hello-js-cat
 stdout 'console\.log\(\"Hello, runme, from javascript!\"\)'
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
 exec runme run hello-python
 stdout 'Hello from Python'
 ! stderr .


### PR DESCRIPTION
When a node version manager is involved (asdf in my case), this test keeps failing due to the way asdf "interjects" calling the node runtime. This fixes it locally and should be harmless in CI/CD.

Btw, there is a way to set up the Environ in the test harness. However, that will apply it to all test cases and make other things fail for unrelated reasons.