### PR TITLE
Avoid unit overflow when signal interrupt processes

### DIFF
--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -74,7 +74,7 @@ func getExecuteResult(
 	stream runnerv1.RunnerService_ExecuteClient,
 	resultc chan<- executeResult,
 ) {
-	var result executeResult
+	result := executeResult{ExitCode: -1}
 
 	for {
 		r, rerr := stream.Recv()


### PR DESCRIPTION
Fixes the downstream overflow issue https://github.com/stateful/runme/issues/413.

However, the culprit of `-1` as an error code is likely upstream when signals not already covered (e.g. SIGHUP) below are involved.

https://github.com/stateful/runme/blob/1f01109235ac9e575a1f77afe4130551993dae27/internal/runner/command.go#L537-L546

I am creating a separate issue to look into improving ☝️ (cc @adambabik).