### PR TITLE
Use "internal/project" in commands

### DIFF
--- a/examples/frontmatter/skipPrompts/DISABLED.md
+++ b/examples/frontmatter/skipPrompts/DISABLED.md
@@ -7,4 +7,5 @@ skipPrompts: false
 
 ```sh {"id":"01HF7BT3HCDS1X1WJJHB8775HP"}
 $ export ENV="<insert-env-here>"
+$ echo "ENV=$ENV"
 ```

--- a/examples/frontmatter/skipPrompts/ENABLED.md
+++ b/examples/frontmatter/skipPrompts/ENABLED.md
@@ -7,4 +7,5 @@ skipPrompts: true
 
 ```sh {"id":"01HF7BT3HBDTRGQAQMHNSXB9K2"}
 $ export ENV="<insert-env-here>"
+$ echo "ENV=$ENV"
 ```

--- a/examples/frontmatter/skipPrompts/NONE.md
+++ b/examples/frontmatter/skipPrompts/NONE.md
@@ -6,4 +6,5 @@ runme:
 
 ```sh {"id":"01HF7BT3HBDTRGQAQMHFPKGXRH"}
 $ export ENV="<insert-env-here>"
+$ echo "ENV=$ENV"
 ```

--- a/internal/cmd/code_server.go
+++ b/internal/cmd/code_server.go
@@ -45,7 +45,7 @@ func codeServerCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to get project")
 			}
 
-			openDir := proj.Dir()
+			openDir := proj.Root()
 
 			if len(args) > 0 {
 				openDir = args[0]

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -43,17 +43,9 @@ func getProject() (*project.Project, error) {
 			return nil, errors.WithStack(err)
 		}
 	} else {
-		var err error
-
 		projDir := fProject
-		// TODO(adamb): wrap it in a function that will explain the logic
 		if projDir == "" {
-			projDir, err = os.Getwd()
-			if err != nil {
-				return nil, errors.WithMessage(err, "failed to get cwd")
-			}
-
-			opts = append(opts, project.WithFindRepoUpward())
+			projDir = "."
 		}
 
 		opts = append(
@@ -66,6 +58,7 @@ func getProject() (*project.Project, error) {
 			opts = append(opts, project.WithEnvFilesReadOrder(fEnvOrder))
 		}
 
+		var err error
 		proj, err = project.NewDirProject(projDir, opts...)
 		if err != nil {
 			return nil, err

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -44,15 +44,22 @@ func getProject() (*project.Project, error) {
 		}
 	} else {
 		projDir := fProject
+		// If no project directory is specified, use the current directory.
+		// "." is a valid project directory, similarly to "..".
 		if projDir == "" {
 			projDir = "."
 		}
 
+		// By default, all commands try to find repo upward.
 		opts = append(
 			opts,
-			project.WithRespectGitignore(),
+			project.WithFindRepoUpward(),
 			project.WithIgnoreFilePatterns(fProjectIgnorePatterns...),
 		)
+
+		if fRespectGitignore {
+			opts = append(opts, project.WithRespectGitignore())
+		}
 
 		if fLoadEnv && fEnvOrder != nil {
 			opts = append(opts, project.WithEnvFilesReadOrder(fEnvOrder))

--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -1,11 +1,22 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/stateful/runme/pkg/project"
+
+	"github.com/stateful/runme/internal/document"
+	"github.com/stateful/runme/internal/document/editor"
+	"github.com/stateful/runme/internal/document/identity"
+	"github.com/stateful/runme/internal/renderer/cmark"
 )
 
 func fmtCmd() *cobra.Command {
@@ -29,38 +40,23 @@ func fmtCmd() *cobra.Command {
 				}
 			}
 
-			proj, err := getProject()
-			if err != nil {
-				return err
-			}
-
 			files := args
 
-			if len(files) == 0 {
-				loader, err := newProjectLoader(cmd)
+			if len(args) == 0 {
+				var err error
+				files, err = getProjectFiles(cmd)
 				if err != nil {
 					return err
 				}
-
-				projectFiles, err := loader.LoadFiles(proj)
-				if err != nil {
-					return err
-				}
-
-				files = projectFiles
 			}
 
-			err = project.Format(files, proj.Dir(), flatten, formatJSON, write, func(file string, formatted []byte) error {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "===== %s =====\n", file)
-				_, _ = cmd.OutOrStdout().Write(formatted)
-				_, _ = fmt.Fprint(cmd.OutOrStdout(), "\n")
+			return fmtFiles(files, flatten, formatJSON, write, func(file string, formatted []byte) error {
+				out := cmd.OutOrStdout()
+				_, _ = fmt.Fprintf(out, "===== %s =====\n", file)
+				_, _ = out.Write(formatted)
+				_, _ = fmt.Fprint(out, "\n")
 				return nil
 			})
-			if err != nil {
-				return err
-			}
-
-			return nil
 		},
 	}
 
@@ -71,4 +67,108 @@ func fmtCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&write, "write", "w", false, "Write result to the source file instead of stdout.")
 
 	return &cmd
+}
+
+type funcOutput func(string, []byte) error
+
+func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputter funcOutput) error {
+	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
+
+	for _, file := range files {
+		data, err := readMarkdown(file)
+		if err != nil {
+			return err
+		}
+
+		var formatted []byte
+
+		if flatten {
+			notebook, err := editor.Deserialize(data, identityResolver)
+			if err != nil {
+				return errors.Wrap(err, "failed to deserialize")
+			}
+
+			if formatJSON {
+				var buf bytes.Buffer
+				enc := json.NewEncoder(&buf)
+				enc.SetIndent("", "  ")
+				if err := enc.Encode(notebook); err != nil {
+					return errors.Wrap(err, "failed to encode to JSON")
+				}
+				formatted = buf.Bytes()
+			} else {
+				formatted, err = editor.Serialize(notebook, nil)
+				if err != nil {
+					return errors.Wrap(err, "failed to serialize")
+				}
+			}
+		} else {
+			doc := document.New(data, identityResolver)
+			astNode, err := doc.RootAST()
+			if err != nil {
+				return errors.Wrap(err, "failed to parse source")
+			}
+			formatted, err = cmark.Render(astNode, data)
+			if err != nil {
+				return errors.Wrap(err, "failed to render")
+			}
+		}
+
+		if write {
+			err = writeMarkdown(file, formatted)
+		} else {
+			err = outputter(file, formatted)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readMarkdown(source string) ([]byte, error) {
+	var (
+		data []byte
+		err  error
+	)
+
+	if source == "-" {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read from stdin")
+		}
+	} else if strings.HasPrefix(source, "https://") {
+		client := http.Client{
+			Timeout: time.Second * 5,
+		}
+		resp, err := client.Get(source)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get a file %q", source)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read body")
+		}
+	} else {
+		data, err = os.ReadFile(source)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read from file %q", source)
+		}
+	}
+
+	return data, nil
+}
+
+func writeMarkdown(destination string, data []byte) error {
+	if destination == "-" {
+		_, err := os.Stdout.Write(data)
+		return errors.Wrap(err, "failed to write to stdout")
+	}
+	if strings.HasPrefix(destination, "https://") {
+		return errors.New("cannot write to HTTPS location")
+	}
+	err := os.WriteFile(destination, data, 0o600)
+	return errors.Wrapf(err, "failed to write data to %q", destination)
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -51,8 +51,6 @@ func listCmd() *cobra.Command {
 				return errors.Errorf("no named code blocks, consider adding flag --allow-unnamed")
 			}
 
-			tasks = project.SortTasks(tasks)
-
 			// TODO: this should be taken from cmd.
 			io := iostreams.System()
 			var rows []row

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"path/filepath"
 	"strings"
 
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -59,7 +58,7 @@ func listCmd() *cobra.Command {
 				lines := block.Lines()
 				r := row{
 					Name:         block.Name(),
-					File:         filepath.Base(task.DocumentPath),
+					File:         task.DocumentPath,
 					FirstCommand: shell.TryGetNonCommentLine(lines),
 					Description:  block.Intro(),
 					Named:        !block.IsUnnamed(),

--- a/internal/cmd/project_loader.go
+++ b/internal/cmd/project_loader.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/stateful/runme/internal/project"
+)
+
+type projectLoader struct {
+	allowUnknown bool
+	allowUnnamed bool
+	ctx          context.Context
+	w            io.Writer
+	r            io.Reader
+	isTerminal   bool
+}
+
+func newProjectLoader(cmd *cobra.Command, allowUnknown, allowUnnamed bool) (*projectLoader, error) {
+	fd := os.Stdout.Fd()
+
+	if int(fd) < 0 {
+		return nil, fmt.Errorf("invalid file descriptor due to restricted environments, redirected standard output, system configuration issues, or testing/simulation setups")
+	}
+
+	return &projectLoader{
+		allowUnknown: allowUnknown,
+		allowUnnamed: allowUnnamed,
+		ctx:          cmd.Context(),
+		w:            cmd.OutOrStdout(),
+		r:            cmd.InOrStdin(),
+		isTerminal:   isTerminal(fd),
+	}, nil
+}
+
+func (pl projectLoader) LoadFiles(proj *project.Project) ([]string, error) {
+	files, _, err := pl.load(proj, true)
+	return files, err
+}
+
+func (pl projectLoader) LoadTasks(proj *project.Project) ([]project.Task, error) {
+	_, tasks, err := pl.load(proj, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if pl.allowUnknown && pl.allowUnnamed {
+		return tasks, nil
+	}
+
+	filtered := make([]project.Task, 0, len(tasks))
+
+	for _, task := range tasks {
+		if !pl.allowUnknown && task.CodeBlock.IsUnknown() {
+			continue
+		}
+
+		if !pl.allowUnnamed && task.CodeBlock.IsUnnamed() {
+			continue
+		}
+
+		filtered = append(filtered, task)
+	}
+
+	return filtered, nil
+}
+
+func (pl projectLoader) LoadAllTasks(proj *project.Project) ([]project.Task, error) {
+	_, tasks, err := pl.load(proj, false)
+	return tasks, err
+}
+
+func (pl projectLoader) load(proj *project.Project, onlyFiles bool) ([]string, []project.Task, error) {
+	if pl.isTerminal {
+		return pl.loadInTerminal(proj, onlyFiles)
+	}
+	return pl.loadWithoutTerminal(proj, onlyFiles)
+}
+
+func (pl projectLoader) loadInTerminal(proj *project.Project, onlyFiles bool) ([]string, []project.Task, error) {
+	eventc := make(chan project.LoadEvent)
+
+	go proj.LoadWithOptions(pl.ctx, eventc, project.LoadOptions{OnlyFiles: onlyFiles})
+
+	nextTaskMsg := func() tea.Msg {
+		event, ok := <-eventc
+		if !ok {
+			return loadTasksFinished{}
+		}
+		return loadTasksEvent{Event: event}
+	}
+
+	m := newLoadTasksModel(nextTaskMsg)
+
+	p := tea.NewProgram(m, tea.WithOutput(pl.w), tea.WithInput(pl.r))
+	result, err := p.Run()
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	resultModel := result.(loadTasksModel)
+
+	if resultModel.err != nil {
+		return nil, nil, err
+	}
+
+	return resultModel.files, resultModel.tasks, nil
+}
+
+func (pl projectLoader) loadWithoutTerminal(proj *project.Project, onlyFiles bool) ([]string, []project.Task, error) {
+	eventc := make(chan project.LoadEvent)
+
+	go proj.Load(pl.ctx, eventc, onlyFiles)
+
+	var (
+		files []string
+		tasks []project.Task
+	)
+
+	for event := range eventc {
+		switch event.Type {
+		case project.LoadEventError:
+			err := project.ExtractDataFromLoadEvent[project.LoadEventErrorData](event).Err
+			return nil, nil, err
+
+		case project.LoadEventFoundFile:
+			path := project.ExtractDataFromLoadEvent[project.LoadEventFoundFileData](event).Path
+			files = append(files, path)
+
+		case project.LoadEventFoundTask:
+			if onlyFiles {
+				continue
+			}
+
+			task := project.ExtractDataFromLoadEvent[project.LoadEventFoundTaskData](event).Task
+			tasks = append(tasks, task)
+		}
+	}
+
+	return files, tasks, nil
+}
+
+type loadTasksEvent struct {
+	Event project.LoadEvent
+}
+
+type loadTasksFinished struct{}
+
+type loadTasksModel struct {
+	spinner spinner.Model
+
+	status   string
+	filename string
+
+	finished bool
+	err      error
+
+	tasks []project.Task
+	files []string
+
+	nextTaskMsg tea.Cmd
+}
+
+func newLoadTasksModel(nextTaskMsg tea.Cmd) loadTasksModel {
+	return loadTasksModel{
+		spinner:     spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		nextTaskMsg: nextTaskMsg,
+		status:      "Initializing...",
+	}
+}
+
+func (m loadTasksModel) Init() tea.Cmd {
+	return tea.Batch(
+		func() tea.Msg {
+			return m.spinner.Tick()
+		},
+		m.nextTaskMsg,
+	)
+}
+
+func (m loadTasksModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.err != nil {
+		return m, tea.Quit
+	}
+
+	switch msg := msg.(type) {
+	case loadTasksFinished:
+		m.finished = true
+		return m, tea.Quit
+
+	case loadTasksEvent:
+		return m.handleTask(msg.Event)
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyCtrlD:
+			m.err = errors.New("aborted")
+			return m, tea.Quit
+		}
+	}
+
+	return m, nil
+}
+
+func (m loadTasksModel) handleTask(event project.LoadEvent) (tea.Model, tea.Cmd) {
+	cmd := m.nextTaskMsg
+
+	switch event.Type {
+	case project.LoadEventError:
+		data := project.ExtractDataFromLoadEvent[project.LoadEventErrorData](event)
+		m.err = data.Err
+		cmd = tea.Quit
+
+	case project.LoadEventStartedWalk:
+		m.filename = ""
+		m.status = "Searching for files..."
+
+	case project.LoadEventFinishedWalk:
+		m.filename = ""
+		m.status = "Parsing files..."
+
+	case project.LoadEventFoundDir:
+		data := project.ExtractDataFromLoadEvent[project.LoadEventFoundDirData](event)
+		m.filename = data.Path
+
+	case project.LoadEventStartedParsingDocument:
+		data := project.ExtractDataFromLoadEvent[project.LoadEventStartedParsingDocumentData](event)
+		m.filename = data.Path
+
+	case project.LoadEventFoundFile:
+		data := project.ExtractDataFromLoadEvent[project.LoadEventFoundFileData](event)
+		m.files = append(m.files, data.Path)
+
+	case project.LoadEventFoundTask:
+		data := project.ExtractDataFromLoadEvent[project.LoadEventFoundTaskData](event)
+		m.tasks = append(m.tasks, data.Task)
+	}
+
+	return m, cmd
+}
+
+func (m loadTasksModel) View() (s string) {
+	if m.finished {
+		return
+	}
+
+	s += m.spinner.View()
+	s += " "
+	s += m.status
+
+	if m.filename != "" {
+		s += fmt.Sprintf(" (%s)", m.filename)
+	}
+
+	return
+}

--- a/internal/cmd/project_loader.go
+++ b/internal/cmd/project_loader.go
@@ -107,7 +107,7 @@ func (pl projectLoader) loadInTerminal(proj *project.Project, onlyFiles bool) ([
 	resultModel := result.(loadTasksModel)
 
 	if resultModel.err != nil {
-		return nil, nil, err
+		return nil, nil, resultModel.err
 	}
 
 	return resultModel.files, resultModel.tasks, nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,7 +71,7 @@ func Root() *cobra.Command {
 
 	pflags.StringVar(&fProject, "project", ".", "Root project to find runnable tasks")
 	pflags.BoolVar(&fRespectGitignore, "git-ignore", true, "Whether to respect .gitignore file(s) in project")
-	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules"}, "Patterns to ignore in project mode")
+	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules", ".venv"}, "Patterns to ignore in project mode")
 
 	setAPIFlags(pflags)
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,6 +20,8 @@ var (
 	fProjectIgnorePatterns []string
 	fRespectGitignore      bool
 	fInsecure              bool
+	fLogEnabled            bool
+	fLogFilePath           string
 )
 
 func Root() *cobra.Command {
@@ -73,6 +75,9 @@ func Root() *cobra.Command {
 	pflags.BoolVar(&fRespectGitignore, "git-ignore", true, "Whether to respect .gitignore file(s) in project")
 	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules", ".venv"}, "Patterns to ignore in project mode")
 
+	pflags.BoolVar(&fLogEnabled, "log", false, "Enable logging")
+	pflags.StringVar(&fLogFilePath, "log-file", filepath.Join(getTempDir(), "runme.log"), "Log file path")
+
 	setAPIFlags(pflags)
 
 	tuiCmd := tuiCmd()
@@ -124,4 +129,12 @@ func getCwd() string {
 		cwd = "."
 	}
 	return cwd
+}
+
+func getTempDir() string {
+	tmp := "/var/tmp"
+	if _, err := os.Stat(tmp); err != nil {
+		tmp = os.TempDir()
+	}
+	return tmp
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -69,7 +69,7 @@ func Root() *cobra.Command {
 	pflags.StringVar(&fFileName, "filename", "README.md", "Name of the README file")
 	pflags.BoolVar(&fInsecure, "insecure", false, "Run command in insecure-mode")
 
-	pflags.StringVar(&fProject, "project", "", "Root project to find runnable tasks")
+	pflags.StringVar(&fProject, "project", ".", "Root project to find runnable tasks")
 	pflags.BoolVar(&fRespectGitignore, "git-ignore", true, "Whether to respect .gitignore file(s) in project")
 	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules"}, "Patterns to ignore in project mode")
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -53,16 +53,16 @@ The parser allows serializing and deserializing markdown content.
 
 The kernel is used to run long running processes like shells and interacting with them.`,
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			var (
-				logger *zap.Logger
-				err    error
-			)
-			if devMode {
-				logger, err = zap.NewDevelopment()
-			} else {
-				logger, err = zap.NewProduction()
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// By default, we want to log when running the server command.
+			fLogEnabled = true
+			// By default, we want to log to stderr when running the server command.
+			if !cmd.Flags().Changed("log-file") {
+				fLogFilePath = "stderr"
 			}
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, err := getLogger(devMode)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -61,8 +61,6 @@ func tuiCmd() *cobra.Command {
 				}
 			}
 
-			tasks = project.SortTasks(tasks)
-
 			if len(tasks) == 0 {
 				if fFileMode {
 					return errors.Errorf("no code blocks in %s", fFileName)

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -151,6 +151,10 @@ func (f *Frontmatter) ensureID() {
 	f.Runme.Version = baseVersion
 }
 
+// TODO(adamb): Frontmatter can return (nil, nil) which indicates that
+// there is no error, but also that there is no FrontMatter. It is not
+// the best API. Consider adding HasFrontmatter() and returning an error
+// if there is none from this method.
 func (d *Document) Frontmatter() (*Frontmatter, error) {
 	d.splitSource()
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -210,33 +210,33 @@ func TestProjectLoad(t *testing.T) {
 		assert.Equal(
 			t,
 			filepath.Join(gitProjectDir, "git-ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[10]).DocumentPath,
+			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[10]).Task.DocumentPath,
 		)
 		assert.Equal(
 			t,
 			filepath.Join(gitProjectDir, "ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[13]).DocumentPath,
+			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[13]).Task.DocumentPath,
 		)
 		assert.Equal(
 			t,
 			filepath.Join(gitProjectDir, "nested", "git-ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[16]).DocumentPath,
+			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[16]).Task.DocumentPath,
 		)
 		// Unnamed task
 		{
 			data := ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[19])
 
-			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.DocumentPath)
-			assert.Equal(t, "echo-hello", data.Name)
-			assert.True(t, data.IsNameGenerated)
+			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.Task.DocumentPath)
+			assert.Equal(t, "echo-hello", data.Task.CodeBlock.Name())
+			assert.True(t, data.Task.CodeBlock.IsUnnamed())
 		}
 		// Named task
 		{
 			data := ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[20])
 
-			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.DocumentPath)
-			assert.Equal(t, "my-task", data.Name)
-			assert.False(t, data.IsNameGenerated)
+			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.Task.DocumentPath)
+			assert.Equal(t, "my-task", data.Task.CodeBlock.Name())
+			assert.False(t, data.Task.CodeBlock.IsUnnamed())
 		}
 	})
 
@@ -414,9 +414,19 @@ func TestProjectLoad(t *testing.T) {
 		assert.Equal(
 			t,
 			fileProject,
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[5]).DocumentPath,
+			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[5]).Task.DocumentPath,
 		)
 	})
+}
+
+func TestLoadTasks(t *testing.T) {
+	gitProjectDir := testdata.GitProjectPath()
+	p, err := NewDirProject(gitProjectDir, WithFindRepoUpward(), WithIgnoreFilePatterns(".*.bkp"))
+	require.NoError(t, err)
+
+	tasks, err := LoadTasks(context.Background(), p)
+	require.NoError(t, err)
+	assert.Len(t, tasks, 5)
 }
 
 func mapLoadEvents[T any](events []LoadEvent, fn func(LoadEvent) T) []T {

--- a/internal/project/projectservice/project_service.go
+++ b/internal/project/projectservice/project_service.go
@@ -160,10 +160,10 @@ func setDataForLoadResponseFromLoadEvent(resp *projectv1.LoadResponse, event pro
 
 		resp.Data = &projectv1.LoadResponse_FoundTask{
 			FoundTask: &projectv1.LoadEventFoundTask{
-				DocumentPath:    data.DocumentPath,
-				Id:              data.ID,
-				Name:            data.Name,
-				IsNameGenerated: data.IsNameGenerated,
+				DocumentPath:    data.Task.DocumentPath,
+				Id:              data.Task.CodeBlock.ID(),
+				Name:            data.Task.CodeBlock.Name(),
+				IsNameGenerated: data.Task.CodeBlock.IsUnnamed(),
 			},
 		}
 	case project.LoadEventError:

--- a/internal/project/task.go
+++ b/internal/project/task.go
@@ -1,0 +1,238 @@
+package project
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/stateful/runme/internal/document"
+)
+
+// Task is a project-specific struct.
+// It's a `document.CodeBlock` with a path
+// to the document it belongs to.
+//
+// Instance of `Document` can be retrieved
+// from `document.CodeBlock`.
+type Task struct {
+	CodeBlock    *document.CodeBlock
+	DocumentPath string
+}
+
+func (t Task) ID() string {
+	return t.DocumentPath + ":" + t.CodeBlock.Name()
+}
+
+func (t Task) String() string {
+	return t.ID()
+}
+
+func (t Task) Format(s fmt.State, verb rune) {
+	_, _ = s.Write([]byte("project.Task#" + t.ID()))
+}
+
+// LoadFiles returns a list of file names found in the project.
+//
+// TODO(adamb): figure out a strategy for error handling. There are
+// two options: (1) stop and return the error immediately,
+// (2) continue and return first (or all) error and the list of file names.
+func LoadFiles(ctx context.Context, p *Project) ([]string, error) {
+	eventc := make(chan LoadEvent)
+
+	go p.Load(ctx, eventc, true)
+
+	var (
+		result []string
+		err    error
+	)
+
+	for event := range eventc {
+		switch event.Type {
+		case LoadEventError:
+			data := ExtractDataFromLoadEvent[LoadEventErrorData](event)
+			if err != nil {
+				err = data.Err
+			}
+		case LoadEventFoundFile:
+			data := ExtractDataFromLoadEvent[LoadEventFoundFileData](event)
+			result = append(result, data.Path)
+		}
+	}
+
+	return result, err
+}
+
+func LoadTasks(ctx context.Context, p *Project) ([]Task, error) {
+	eventc := make(chan LoadEvent)
+
+	go p.Load(ctx, eventc, false)
+
+	var (
+		result []Task
+		err    error
+	)
+
+	for event := range eventc {
+		switch event.Type {
+		case LoadEventError:
+			data := ExtractDataFromLoadEvent[LoadEventErrorData](event)
+			if err != nil {
+				err = data.Err
+			}
+		case LoadEventFoundTask:
+			data := ExtractDataFromLoadEvent[LoadEventFoundTaskData](event)
+			result = append(result, data.Task)
+		}
+	}
+
+	return result, err
+}
+
+// SortTasks sorts tasks in ascending nested order.
+func SortTasks(tasks []Task) []Task {
+	tasksByFile := make(map[string][]Task)
+
+	var files []string
+
+	for _, task := range tasks {
+		if arr, ok := tasksByFile[task.DocumentPath]; ok {
+			tasksByFile[task.DocumentPath] = append(arr, task)
+			continue
+		}
+
+		tasksByFile[task.DocumentPath] = []Task{task}
+		files = append(files, task.DocumentPath)
+	}
+
+	sort.SliceStable(files, func(i, j int) bool {
+		return getFileDepth(files[i]) < getFileDepth(files[j])
+	})
+
+	result := make([]Task, 0, len(tasks))
+
+	for _, file := range files {
+		result = append(result, tasksByFile[file]...)
+	}
+
+	return result
+}
+
+func getFileDepth(fp string) int {
+	return len(strings.Split(fp, string(filepath.Separator)))
+}
+
+var ErrReturnEarly = errors.New("return early")
+
+func FilterTasks(tasks []Task, fn func(Task) (bool, error)) (result []Task, err error) {
+	for _, task := range tasks {
+		include, errFn := fn(task)
+
+		if include {
+			result = append(result, task)
+		}
+
+		if errFn != nil {
+			if !errors.Is(errFn, ErrReturnEarly) {
+				err = errFn
+			}
+			break
+		}
+	}
+
+	return
+}
+
+type Matcher interface {
+	MatchString(string) bool
+}
+
+type matchAll struct{}
+
+func (matchAll) MatchString(string) bool { return true }
+
+func compileQuery(query string) (Matcher, error) {
+	if query == "" {
+		return &matchAll{}, nil
+	}
+	reg, err := regexp.Compile(query)
+	return reg, errors.Wrapf(err, "invalid regexp %q", query)
+}
+
+func FilterTasksByID(tasks []Task, query string) ([]Task, error) {
+	queryMatcher, err := compileQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []Task
+
+	for _, task := range tasks {
+		if !queryMatcher.MatchString(task.ID()) {
+			continue
+		}
+
+		results = append(results, task)
+	}
+
+	return results, nil
+}
+
+func FilterTasksByFileAndTaskName(tasks []Task, queryFile string, queryName string) ([]Task, error) {
+	fileMatcher, err := compileQuery(queryFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []Task
+
+	foundFile := false
+
+	for _, task := range tasks {
+		if !fileMatcher.MatchString(task.DocumentPath) {
+			continue
+		}
+
+		foundFile = true
+
+		// This is expected that the task name query is
+		// matched exactly.
+		if queryName != task.CodeBlock.Name() {
+			continue
+		}
+
+		results = append(results, task)
+	}
+
+	if len(results) == 0 {
+		if !foundFile {
+			return nil, &ErrTaskWithFilenameNotFound{queryFile: queryFile}
+		}
+		return nil, &ErrTaskWithNameNotFound{queryName: queryName}
+	}
+
+	return results, nil
+}
+
+type ErrTaskWithFilenameNotFound struct {
+	queryFile string
+}
+
+func (e ErrTaskWithFilenameNotFound) Error() string {
+	return fmt.Sprintf("unable to find file in project matching regex %q", e.queryFile)
+}
+
+type ErrTaskWithNameNotFound struct {
+	queryName string
+}
+
+func (e ErrTaskWithNameNotFound) Error() string {
+	return fmt.Sprintf("unable to find any script named %q", e.queryName)
+}
+
+func IsTaskNotFoundError(err error) bool {
+	return errors.As(err, &ErrTaskWithFilenameNotFound{}) || errors.As(err, &ErrTaskWithNameNotFound{})
+}

--- a/internal/project/task.go
+++ b/internal/project/task.go
@@ -3,10 +3,7 @@ package project
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"regexp"
-	"sort"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/stateful/runme/internal/document"
@@ -90,39 +87,6 @@ func LoadTasks(ctx context.Context, p *Project) ([]Task, error) {
 	}
 
 	return result, err
-}
-
-// SortTasks sorts tasks in ascending nested order.
-func SortTasks(tasks []Task) []Task {
-	tasksByFile := make(map[string][]Task)
-
-	var files []string
-
-	for _, task := range tasks {
-		if arr, ok := tasksByFile[task.DocumentPath]; ok {
-			tasksByFile[task.DocumentPath] = append(arr, task)
-			continue
-		}
-
-		tasksByFile[task.DocumentPath] = []Task{task}
-		files = append(files, task.DocumentPath)
-	}
-
-	sort.SliceStable(files, func(i, j int) bool {
-		return getFileDepth(files[i]) < getFileDepth(files[j])
-	})
-
-	result := make([]Task, 0, len(tasks))
-
-	for _, file := range files {
-		result = append(result, tasksByFile[file]...)
-	}
-
-	return result
-}
-
-func getFileDepth(fp string) int {
-	return len(strings.Split(fp, string(filepath.Separator)))
 }
 
 var ErrReturnEarly = errors.New("return early")

--- a/internal/project/task_test.go
+++ b/internal/project/task_test.go
@@ -1,0 +1,3 @@
+package project
+
+// TODO(adamb): add missing unit tests

--- a/internal/project/testdata/testdata.go
+++ b/internal/project/testdata/testdata.go
@@ -40,6 +40,8 @@ func CleanupGitProject() {
 // prepareGitProject copies .git.bkp from the ./testdata/git-project to .git in order to
 // make ./testdata/git-project a valid git project.
 func prepareGitProject() {
+	cleanupGitProject()
+
 	dir := GitProjectPath()
 
 	srcBkpFilesToDestFiles := map[string]string{
@@ -49,7 +51,7 @@ func prepareGitProject() {
 	}
 
 	for src, dest := range srcBkpFilesToDestFiles {
-		cmd := exec.Command("cp", "-fr", src, dest)
+		cmd := exec.Command("cp", "-f", "-r", src, dest)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			log.Fatalf("failed to prepare %s: %v; output: %s", dest, err, output)
 		}
@@ -66,7 +68,7 @@ func cleanupGitProject() {
 	}
 
 	for _, file := range files {
-		cmd := exec.Command("rm", "-rf", file)
+		cmd := exec.Command("rm", "-r", "-f", file)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			log.Fatalf("failed clean up %s: %v; output: %s", file, err, output)
 		}

--- a/internal/runner/client/client_test.go
+++ b/internal/runner/client/client_test.go
@@ -1,16 +1,17 @@
 package client
 
 import (
+	"context"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/stateful/runme/pkg/project"
+	"github.com/stateful/runme/internal/project"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ResolveDirectory(t *testing.T) {
+func TestResolveDirectory(t *testing.T) {
 	_, b, _, _ := runtime.Caller(0)
 	root := filepath.Clean(
 		filepath.Join(
@@ -26,17 +27,17 @@ func Test_ResolveDirectory(t *testing.T) {
 		return filepath.Join(root, filepath.FromSlash(rel))
 	}
 
-	proj, err := project.NewDirectoryProject(projectRoot, false, false, false, []string{})
+	proj, err := project.NewDirProject(projectRoot)
 	require.NoError(t, err)
 
-	tasks, err := project.LoadProjectTasks(proj)
+	tasks, err := project.LoadTasks(context.Background(), proj)
 	require.NoError(t, err)
 
-	taskMap := make(map[string]string)
+	taskMap := make(map[string]string, len(tasks))
 
 	for _, task := range tasks {
 		resolved := ResolveDirectory(root, task)
-		taskMap[task.Block.Name()] = resolved
+		taskMap[task.CodeBlock.Name()] = resolved
 	}
 
 	if runtime.GOOS == "windows" {

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -587,7 +587,7 @@ func Test_runnerService(t *testing.T) {
 			result := <-execResult
 
 			assert.NoError(t, result.Err)
-			assert.EqualValues(t, 0, result.ExitCode)
+			assert.EqualValues(t, 0, result.ExitCode, "expected exit code; stdout: %s; stderr: %s", result.Stdout, result.Stderr)
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func root() (status int) {
 
 	rootWithCPUProfile(func() {
 		if err := root.Execute(); err != nil {
-			logf("could not execute command: %v", err)
+			logf("could not execute command: %v\n", err)
 			status = 1
 		}
 	})
@@ -32,12 +32,12 @@ func rootWithCPUProfile(fn func()) {
 	if profile := os.Getenv("RUNME_PROFILE_CPU"); profile != "" {
 		f, err := os.Create(profile)
 		if err != nil {
-			fatalf("could not create CPU profile: %v", err)
+			fatalf("could not create CPU profile: %v\n", err)
 		}
 		defer f.Close()
 
 		if err := pprof.StartCPUProfile(f); err != nil {
-			fatalf("could not start CPU profile: %v", err)
+			fatalf("could not start CPU profile: %v\n", err)
 		}
 		defer pprof.StopCPUProfile()
 	}
@@ -47,14 +47,14 @@ func rootWithCPUProfile(fn func()) {
 	if profile := os.Getenv("RUNME_PROFILE_MEM"); profile != "" {
 		f, err := os.Create(profile)
 		if err != nil {
-			fatalf("could not create mem profile: %v", err)
+			fatalf("could not create mem profile: %v\n", err)
 		}
 		defer f.Close()
 
 		runtime.GC()
 
 		if err := pprof.WriteHeapProfile(f); err != nil {
-			fatalf("could not write heap profile: %v", err)
+			fatalf("could not write heap profile: %v\n", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -3,21 +3,67 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/pprof"
 
 	"github.com/stateful/runme/internal/cmd"
 	"github.com/stateful/runme/internal/version"
 )
 
-func root() int {
-	root := cmd.Root()
-	root.Version = fmt.Sprintf("%s (%s) on %s", version.BuildVersion, version.Commit, version.BuildDate)
-	if err := root.Execute(); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err.Error())
-		return 1
-	}
-	return 0
-}
-
 func main() {
 	os.Exit(root())
+}
+
+func root() (status int) {
+	root := cmd.Root()
+	root.Version = fmt.Sprintf("%s (%s) on %s", version.BuildVersion, version.Commit, version.BuildDate)
+
+	rootWithCPUProfile(func() {
+		if err := root.Execute(); err != nil {
+			logf("could not execute command: %v", err)
+			status = 1
+		}
+	})
+
+	return
+}
+
+func rootWithCPUProfile(fn func()) {
+	if profile := os.Getenv("RUNME_PROFILE_CPU"); profile != "" {
+		f, err := os.Create(profile)
+		if err != nil {
+			fatalf("could not create CPU profile: %v", err)
+		}
+		defer f.Close()
+
+		if err := pprof.StartCPUProfile(f); err != nil {
+			fatalf("could not start CPU profile: %v", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	fn()
+
+	if profile := os.Getenv("RUNME_PROFILE_MEM"); profile != "" {
+		f, err := os.Create(profile)
+		if err != nil {
+			fatalf("could not create mem profile: %v", err)
+		}
+		defer f.Close()
+
+		runtime.GC()
+
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			fatalf("could not write heap profile: %v", err)
+		}
+	}
+}
+
+func fatalf(format string, args ...interface{}) {
+	logf(format, args...)
+	os.Exit(1)
+}
+
+func logf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, format, args...)
 }

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -11,7 +11,7 @@ cmp stdout golden-list-allow-unnamed.txt
 ! stderr .
 
 ! exec runme ls --filename nonexistent.md
-stderr 'failed to open markdown file .*/nonexistent.md: no such file or directory'
+stderr 'failed to open file-based project \".*\/nonexistent.md\": file does not exist'
 ! stdout .
 
 env SHELL=/bin/bash


### PR DESCRIPTION
In https://github.com/stateful/runme/pull/438, a new package for handling projects was introduced: `internal/project`. In this PR, `internal/project` is used in all TUI and non-TUI CLI commands.

This is ready to be reviewed. All tests should pass, I did substantial manual testing, but it likely needs more of that.