### PR TITLE
Skip files that include Runme session IDs (those are output files)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,15 @@
                 "--tls",
                 "/tmp/runme/tls",
             ]
-        }
+        },
+        {
+            "name": "Connect to dlv",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 56379,
+            "host": "127.0.0.1"
+        },
     ]
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -410,6 +410,11 @@ func getCodeBlocksFromFile(path string) (document.CodeBlocks, error) {
 func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
+
+	if f, _ := d.Frontmatter(); f != nil && f.Runme.Session.ID != "" {
+		return document.CodeBlocks{}, nil
+	}
+
 	node, err := d.Root()
 	if err != nil {
 		return nil, err

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -411,8 +411,8 @@ func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
 
-	if f, _ := d.Frontmatter(); f != nil && f.Runme.Session.ID != "" {
-		return document.CodeBlocks{}, nil
+	if f, err := d.Frontmatter(); err == nil && f != nil && f.Runme.Session.ID != "" {
+		return nil, nil
 	}
 
 	node, err := d.Root()

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -309,6 +309,7 @@ func TestProjectLoad(t *testing.T) {
 			LoadEventFoundDir,  // "."
 			LoadEventFoundFile, // "ignored.md"
 			LoadEventFoundFile, // "readme.md"
+			LoadEventFoundFile, // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
 			LoadEventFinishedWalk,
 			LoadEventStartedParsingDocument,  // "ignored.md"
 			LoadEventFinishedParsingDocument, // "ignored.md"
@@ -317,6 +318,8 @@ func TestProjectLoad(t *testing.T) {
 			LoadEventFinishedParsingDocument, // "readme.md"
 			LoadEventFoundTask,               // unnamed; echo-hello
 			LoadEventFoundTask,               // named; my-task
+			LoadEventStartedParsingDocument,  // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
+			LoadEventFinishedParsingDocument, // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
 		}
 		require.EqualValues(
 			t,
@@ -350,11 +353,14 @@ func TestProjectLoad(t *testing.T) {
 			LoadEventStartedWalk,
 			LoadEventFoundDir,  // "."
 			LoadEventFoundFile, // "readme.md"
+			LoadEventFoundFile, // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
 			LoadEventFinishedWalk,
 			LoadEventStartedParsingDocument,  // "readme.md"
 			LoadEventFinishedParsingDocument, // "readme.md"
 			LoadEventFoundTask,               // unnamed; echo-hello
 			LoadEventFoundTask,               // named; my-task
+			LoadEventStartedParsingDocument,  // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
+			LoadEventFinishedParsingDocument, // "session-01HJS35FZ2K0JBWPVAXPMMVTGN.md"
 		}
 		require.EqualValues(
 			t,

--- a/internal/project/testdata/dir-project/session-01HJS35FZ2K0JBWPVAXPMMVTGN.md
+++ b/internal/project/testdata/dir-project/session-01HJS35FZ2K0JBWPVAXPMMVTGN.md
@@ -1,0 +1,15 @@
+---
+runme:
+  id: 01HJS33TJYXZ6KJPG2SZZ6D1H5
+  version: v2.0
+  session:
+    id: 01HJS35FZ2K0JBWPVAXPMMVTGN
+    updated: 2023-12-28 15:16:06-05:00
+---
+
+```sh {"name":"iam-session","id":"01HJS341EYAN1QPKK7D835C6FD"}
+echo "i am a session outputs file"
+
+# Ran on 2023-12-28 15:52:03-05:00 for 719ms exited with 0
+i am a session outputs file
+```


### PR DESCRIPTION
The extension will write Outputs to a separate session file. The idea is to make saving outputs available ahead of load (deserialization) and chunk up the dev effort required to unlock both.

Since, by default, the Session Outputs file will be colocated with its original document, it's highly likely to be included when a project is being loaded. The extension UX rejects running Session Outputs files in the notebook UX (https://github.com/stateful/vscode-runme/pull/1025).

This PR introduces a check for a Runme session ID, which will skip these docs/tasks accordingly.

PS: Also brings back a launch cfg to attach to dlv which is required for tui debugging.