### PR TITLE
Use spinner with more contrast

### DIFF
--- a/internal/cmd/project_loader.go
+++ b/internal/cmd/project_loader.go
@@ -169,7 +169,7 @@ type loadTasksModel struct {
 
 func newLoadTasksModel(nextTaskMsg tea.Cmd) loadTasksModel {
 	return loadTasksModel{
-		spinner:     spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		spinner:     spinner.New(spinner.WithSpinner(spinner.Pulse)),
 		nextTaskMsg: nextTaskMsg,
 		status:      "Initializing...",
 	}

--- a/pkg/project/loader.go
+++ b/pkg/project/loader.go
@@ -45,7 +45,7 @@ type loadTaskFinished struct{}
 
 func (pl ProjectLoader) newLoadTasksModel(nextTaskMsg tea.Cmd) loadTasksModel {
 	return loadTasksModel{
-		spinner:     spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		spinner:     spinner.New(spinner.WithSpinner(spinner.Pulse)),
 		nextTaskMsg: nextTaskMsg,
 		status:      "Initializing...",
 		tasks:       make(CodeBlocks, 0),


### PR DESCRIPTION
Make it more obvious when initialization is doing work. While long init times are an exception, when it happens the contrasting spinner makes sure users know the process isn't stuck/dead-locked.

https://github.com/stateful/runme/assets/250527/ab2f69b7-e142-4f66-9c45-a74a0bf732ff