### PR TITLE
Respect WithFindRepoUpward

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -283,8 +283,12 @@ func (p *Project) load(
 
 	switch {
 	case p.repo != nil:
-		// Even if p.repo is not nil, the current logic is identical to
-		// a dir-based project.
+		wt, err := p.repo.Worktree()
+		if err != nil {
+			p.logger.Warn("invalid worktree for repo; using base directory instead", zap.Error(err))
+		} else {
+			p.fs = wt.Filesystem
+		}
 		fallthrough
 	case p.fs != nil:
 		p.loadFromDirectory(ctx, eventc, options)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -181,6 +181,14 @@ func NewDirProject(
 		return nil, errors.WithStack(err)
 	}
 
+	if p.repo != nil {
+		wt, err := p.repo.Worktree()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		p.fs = wt.Filesystem
+	}
+
 	if p.logger == nil {
 		p.logger = zap.NewNop()
 	}
@@ -283,12 +291,8 @@ func (p *Project) load(
 
 	switch {
 	case p.repo != nil:
-		wt, err := p.repo.Worktree()
-		if err != nil {
-			p.logger.Warn("invalid worktree for repo; using base directory instead", zap.Error(err))
-		} else {
-			p.fs = wt.Filesystem
-		}
+		// The logic is identical to a dir-based project because
+		// we adjust the root to the repo's in the ctor
 		fallthrough
 	case p.fs != nil:
 		p.loadFromDirectory(ctx, eventc, options)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -243,139 +243,22 @@ func TestProjectLoad(t *testing.T) {
 	gitProjectNestedDir := testdata.GitProjectNestedPath()
 
 	t.Run("GitProjectWithNested", func(t *testing.T) {
-		require.NotEqualValues(t, gitProjectNestedDir, gitProjectDir)
-
-		p, err := NewDirProject(
-			gitProjectNestedDir,
+		pRoot, err := NewDirProject(
+			gitProjectDir,
 			WithFindRepoUpward(),
 			WithIgnoreFilePatterns(".git.bkp"),
 			WithIgnoreFilePatterns(".gitignore.bkp"),
 		)
 		require.NoError(t, err)
 
-		eventc := make(chan LoadEvent)
+		pNested, err := NewDirProject(gitProjectNestedDir,
+			WithFindRepoUpward(),
+			WithIgnoreFilePatterns(".git.bkp"),
+			WithIgnoreFilePatterns(".gitignore.bkp"),
+		)
+		require.NoError(t, err)
 
-		events := make([]LoadEvent, 0)
-		doneReadingEvents := make(chan struct{})
-		go func() {
-			defer close(doneReadingEvents)
-			for e := range eventc {
-				events = append(events, e)
-			}
-		}()
-
-		p.Load(context.Background(), eventc, false)
-		<-doneReadingEvents
-
-		expectedEvents := []LoadEventType{
-			LoadEventStartedWalk,
-			LoadEventFoundDir,  // "."
-			LoadEventFoundFile, // "git-ignored.md"
-			LoadEventFoundFile, // "ignored.md"
-			LoadEventFoundDir,  // "nested"
-			LoadEventFoundFile, // "nested/git-ignored.md"
-			LoadEventFoundFile, // "readme.md"
-			LoadEventFinishedWalk,
-			LoadEventStartedParsingDocument,  // "git-ignored.md"
-			LoadEventFinishedParsingDocument, // "git-ignored.md"
-			LoadEventFoundTask,
-			LoadEventStartedParsingDocument,  // "nested/git-ignored.md"
-			LoadEventFinishedParsingDocument, // "nested/git-ignored.md"
-			LoadEventFoundTask,
-			LoadEventStartedParsingDocument,  // "ignored.md"
-			LoadEventFinishedParsingDocument, // "ignored.md"
-			LoadEventFoundTask,
-			LoadEventStartedParsingDocument,  // "readme.md"
-			LoadEventFinishedParsingDocument, // "readme.md"
-			LoadEventFoundTask,
-			LoadEventFoundTask,
-		}
-		require.EqualValues(
-			t,
-			expectedEvents,
-			mapLoadEvents(events, func(le LoadEvent) LoadEventType { return le.Type }),
-			"collected events: %+v",
-			events,
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundDir,
-				Data: LoadEventFoundDirData{Path: gitProjectDir},
-			},
-			events[1],
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundFile,
-				Data: LoadEventFoundFileData{Path: filepath.Join(gitProjectDir, "git-ignored.md")},
-			},
-			events[2],
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundFile,
-				Data: LoadEventFoundFileData{Path: filepath.Join(gitProjectDir, "ignored.md")},
-			},
-			events[3],
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundDir,
-				Data: LoadEventFoundDirData{Path: filepath.Join(gitProjectDir, "nested")},
-			},
-			events[4],
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundFile,
-				Data: LoadEventFoundFileData{Path: filepath.Join(gitProjectDir, "nested", "git-ignored.md")},
-			},
-			events[5],
-		)
-		assert.Equal(
-			t,
-			LoadEvent{
-				Type: LoadEventFoundFile,
-				Data: LoadEventFoundFileData{Path: filepath.Join(gitProjectDir, "readme.md")},
-			},
-			events[6],
-		)
-		assert.Equal(
-			t,
-			filepath.Join(gitProjectDir, "git-ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[10]).Task.DocumentPath,
-		)
-		assert.Equal(
-			t,
-			filepath.Join(gitProjectDir, "ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[13]).Task.DocumentPath,
-		)
-		assert.Equal(
-			t,
-			filepath.Join(gitProjectDir, "nested", "git-ignored.md"),
-			ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[16]).Task.DocumentPath,
-		)
-		// Unnamed task
-		{
-			data := ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[19])
-
-			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.Task.DocumentPath)
-			assert.Equal(t, "echo-hello", data.Task.CodeBlock.Name())
-			assert.True(t, data.Task.CodeBlock.IsUnnamed())
-		}
-		// Named task
-		{
-			data := ExtractDataFromLoadEvent[LoadEventFoundTaskData](events[20])
-
-			assert.Equal(t, filepath.Join(gitProjectDir, "readme.md"), data.Task.DocumentPath)
-			assert.Equal(t, "my-task", data.Task.CodeBlock.Name())
-			assert.False(t, data.Task.CodeBlock.IsUnnamed())
-		}
+		require.EqualValues(t, pRoot.fs.Root(), pNested.fs.Root())
 	})
 
 	t.Run("DirProjectWithRespectGitignoreAndIgnorePatterns", func(t *testing.T) {

--- a/internal/project/testdata/testdata.go
+++ b/internal/project/testdata/testdata.go
@@ -19,6 +19,10 @@ func GitProjectPath() string {
 	return filepath.Join(testdataDir(), "git-project")
 }
 
+func GitProjectNestedPath() string {
+	return filepath.Join(testdataDir(), "git-project", "nested")
+}
+
 func ProjectFilePath() string {
 	return filepath.Join(testdataDir(), "file-project.md")
 }


### PR DESCRIPTION
This matches the existing behavior where sub-dirs within a repo will start at the root of the repo instead of the context sub-dir.

Probably just an oversight.