### PR TITLE
Attempt to make git-repo tests less flakey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,22 @@ wasm:
 	cp $(GO_ROOT)/misc/wasm/wasm_exec.js $(WASM_OUTPUT)
 	GOOS=js GOARCH=wasm go build -o $(WASM_OUTPUT)/runme.wasm -ldflags="$(LDFLAGS)" ./web
 
-.PHONY: test
-test: PKGS ?= "./..."
-test: build
+.PHONY: test/execute
+test/execute: PKGS ?= "./..."
+test/execute: build test/prep-git-project
 	@TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -timeout=30s -covermode=atomic -coverprofile=cover.out -coverpkg=./... $(PKGS)
+
+.PHONY: test/prep-git-project
+test/prep-git-project:
+	@cp -r -f internal/project/testdata/git-project/.git.bkp internal/project/testdata/git-project/.git
+	@cp -r -f internal/project/testdata/git-project/.gitignore.bkp internal/project/testdata/git-project/.gitignore
+	@cp -r -f internal/project/testdata/git-project/nested/.gitignore.bkp internal/project/testdata/git-project/nested/.gitignore
+
+.PHONY: test
+test: test/execute
+	@rm -r -f internal/project/testdata/git-project/.git
+	@rm -r -f internal/project/testdata/git-project/.gitignore
+	@rm -r -f internal/project/testdata/git-project/nested/.gitignore
 
 .PHONY: test/update-snapshots
 test/update-snapshots:

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -38,14 +38,6 @@ func TestExtractDataFromLoadEvent(t *testing.T) {
 	})
 }
 
-func TestMain(m *testing.M) {
-	testdata.PrepareGitProject()
-	defer testdata.CleanupGitProject()
-
-	code := m.Run()
-	os.Exit(code)
-}
-
 func TestNewDirProject(t *testing.T) {
 	t.Run("ProperDirProject", func(t *testing.T) {
 		projectDir := testdata.DirProjectPath()

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -38,6 +38,13 @@ func TestExtractDataFromLoadEvent(t *testing.T) {
 	})
 }
 
+func TestMain(m *testing.M) {
+	testdata.AssertGitProject()
+
+	code := m.Run()
+	os.Exit(code)
+}
+
 func TestNewDirProject(t *testing.T) {
 	t.Run("ProperDirProject", func(t *testing.T) {
 		projectDir := testdata.DirProjectPath()

--- a/internal/project/projectservice/project_service_test.go
+++ b/internal/project/projectservice/project_service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net"
-	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -21,14 +20,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
-
-func TestMain(m *testing.M) {
-	testdata.PrepareGitProject()
-	defer testdata.CleanupGitProject()
-
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestProjectServiceServer_Load(t *testing.T) {
 	t.Parallel()

--- a/internal/project/projectservice/project_service_test.go
+++ b/internal/project/projectservice/project_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -20,6 +21,13 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
+
+func TestMain(m *testing.M) {
+	testdata.AssertGitProject()
+
+	code := m.Run()
+	os.Exit(code)
+}
 
 func TestProjectServiceServer_Load(t *testing.T) {
 	t.Parallel()

--- a/internal/project/testdata/testdata.go
+++ b/internal/project/testdata/testdata.go
@@ -42,15 +42,15 @@ func AssertGitProject() {
 func assertGitProject() {
 	dir := GitProjectPath()
 
-	srcBkpFilesToDestFiles := []string{
+	gitProjectDestFiles := []string{
 		filepath.Join(dir, ".git"),
 		filepath.Join(dir, ".gitignore"),
 		filepath.Join(dir, "nested", ".gitignore"),
 	}
 
-	for _, dest := range srcBkpFilesToDestFiles {
+	for _, dest := range gitProjectDestFiles {
 		if _, err := os.Stat(dest); err != nil {
-			log.Fatalf("failed to prepare %s: %v; please run maket target 'test/prepare-git-project'.", dest, err)
+			log.Fatalf("failed to assert %s: %v; please run maket target 'test/prepare-git-project'.", dest, err)
 		}
 	}
 }

--- a/internal/project/testdata/testdata.go
+++ b/internal/project/testdata/testdata.go
@@ -1,6 +1,8 @@
 package testdata
 
 import (
+	"log"
+	"os"
 	"path/filepath"
 	"runtime"
 )
@@ -29,4 +31,26 @@ func ProjectFilePath() string {
 func testdataDir() string {
 	_, b, _, _ := runtime.Caller(0)
 	return filepath.Dir(b)
+}
+
+func AssertGitProject() {
+	assertGitProject()
+}
+
+// assertGitProject checks that ./testdata/git-project is a valid git project.
+// If it's not it will fail with a call to action to run the right make targets.
+func assertGitProject() {
+	dir := GitProjectPath()
+
+	srcBkpFilesToDestFiles := []string{
+		filepath.Join(dir, ".git"),
+		filepath.Join(dir, ".gitignore"),
+		filepath.Join(dir, "nested", ".gitignore"),
+	}
+
+	for _, dest := range srcBkpFilesToDestFiles {
+		if _, err := os.Stat(dest); err != nil {
+			log.Fatalf("failed to prepare %s: %v; please run maket target 'test/prepare-git-project'.", dest, err)
+		}
+	}
 }

--- a/internal/project/testdata/testdata.go
+++ b/internal/project/testdata/testdata.go
@@ -1,8 +1,6 @@
 package testdata
 
 import (
-	"log"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 )
@@ -31,50 +29,4 @@ func ProjectFilePath() string {
 func testdataDir() string {
 	_, b, _, _ := runtime.Caller(0)
 	return filepath.Dir(b)
-}
-
-func PrepareGitProject() {
-	prepareGitProject()
-}
-
-func CleanupGitProject() {
-	cleanupGitProject()
-}
-
-// prepareGitProject copies .git.bkp from the ./testdata/git-project to .git in order to
-// make ./testdata/git-project a valid git project.
-func prepareGitProject() {
-	cleanupGitProject()
-
-	dir := GitProjectPath()
-
-	srcBkpFilesToDestFiles := map[string]string{
-		filepath.Join(dir, ".git.bkp"):                 filepath.Join(dir, ".git"),
-		filepath.Join(dir, ".gitignore.bkp"):           filepath.Join(dir, ".gitignore"),
-		filepath.Join(dir, "nested", ".gitignore.bkp"): filepath.Join(dir, "nested", ".gitignore"),
-	}
-
-	for src, dest := range srcBkpFilesToDestFiles {
-		cmd := exec.Command("cp", "-f", "-r", src, dest)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Fatalf("failed to prepare %s: %v; output: %s", dest, err, output)
-		}
-	}
-}
-
-func cleanupGitProject() {
-	dir := GitProjectPath()
-
-	files := []string{
-		filepath.Join(dir, ".git"),
-		filepath.Join(dir, ".gitignore"),
-		filepath.Join(dir, "nested", ".gitignore"),
-	}
-
-	for _, file := range files {
-		cmd := exec.Command("rm", "-r", "-f", file)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Fatalf("failed clean up %s: %v; output: %s", file, err, output)
-		}
-	}
 }


### PR DESCRIPTION
1. Move copy/remove operations to make targets to avoid race conditions with parallel execution.
2. Evolve exiting code to assert but not longer copy/remove.
3. The assertions error calls out the make target to help during local dev/debugging.

This will hopefully get rid of a 50%-ish flake rate on Windows.