### PR TITLE
Restore project flag behavior

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -58,12 +58,18 @@ func getProject() (*project.Project, error) {
 			projDir = "."
 		}
 
-		// By default, all commands try to find repo upward.
 		opts = append(
 			opts,
-			project.WithFindRepoUpward(),
 			project.WithIgnoreFilePatterns(fProjectIgnorePatterns...),
 		)
+
+		// By default, commands try to find repo upward unless project is non-empty.
+		if fProject == "" {
+			opts = append(
+				opts,
+				project.WithFindRepoUpward(),
+			)
+		}
 
 		if fRespectGitignore {
 			opts = append(opts, project.WithRespectGitignore())

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -58,7 +58,7 @@ func listCmd() *cobra.Command {
 				block := task.CodeBlock
 				lines := block.Lines()
 				relPath, err := filepath.Rel(getCwd(), task.DocumentPath)
-				if err != nil || !isTerminal(io.Out.Fd()) {
+				if err != nil {
 					relPath = task.DocumentPath
 				}
 				r := row{

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,7 +71,7 @@ func Root() *cobra.Command {
 	pflags.StringVar(&fFileName, "filename", "README.md", "Name of the README file")
 	pflags.BoolVar(&fInsecure, "insecure", false, "Run command in insecure-mode")
 
-	pflags.StringVar(&fProject, "project", ".", "Root project to find runnable tasks")
+	pflags.StringVar(&fProject, "project", "", "Root project to find runnable tasks")
 	pflags.BoolVar(&fRespectGitignore, "git-ignore", true, "Whether to respect .gitignore file(s) in project")
 	pflags.StringArrayVar(&fProjectIgnorePatterns, "ignore-pattern", []string{"node_modules", ".venv"}, "Patterns to ignore in project mode")
 

--- a/main_test.go
+++ b/main_test.go
@@ -34,6 +34,12 @@ func TestRunme(t *testing.T) {
 	})
 }
 
+func TestRunmeFlags(t *testing.T) {
+	testscript.Run(t, testscript.Params{
+		Dir: "testdata/flags",
+	})
+}
+
 func TestRunmeCategories(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir: "testdata/categories",

--- a/testdata/flags/project.txtar
+++ b/testdata/flags/project.txtar
@@ -1,0 +1,102 @@
+cd nested
+exec runme ls
+cmp stdout ../gitupwards.txt
+! stderr .
+
+cd ..
+exec runme ls --project nested
+cmp stdout projectset.txt
+! stderr .
+
+-- .git/config --
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true
+-- .git/HEAD --
+ref: refs/heads/main
+-- nested/file.md --
+---
+runme:
+  id: 01HFVTDYA775K2HREH9ZGQJ75B
+  version: 2.0
+---
+
+```sh {"name":"echo"}
+$ echo "Hello, runme!"
+```
+
+It can contain multiple lines too:
+
+```sh {"interactive":"false"}
+$ echo "1"
+$ echo "2"
+$ echo "3"
+```
+-- root.md --
+---
+runme:
+  id: 01HFVTDBE512K2HREH9ZJGQB57
+  version: 2.0
+---
+
+It can even run scripting languages:
+
+```js {"name":"hello-js"}
+console.log("Hello, runme, from javascript!")
+```
+
+And it can even run a cell with a custom interpreter:
+
+```js {"interpreter":"cat","name":"hello-js-cat"}
+console.log("Hello, runme, from javascript!")
+```
+
+It works with `cd`, `pushd`, and similar because all lines are executed as a single script:
+
+```sh
+temp_dir=$(mktemp -d -t "runme-XXXXXXX")
+pushd $temp_dir
+echo "hi!" > hi.txt
+pwd
+cat hi.txt
+popd
+pwd
+```
+
+## Go
+
+It can also execute a snippet of Go code:
+
+```go
+package main
+
+import (
+    "fmt"
+)
+
+func main() {
+    fmt.Println("Hello from Go, runme!")
+}
+```
+
+## Python
+
+```python {"interpreter":"python3","name":"hello-python"}
+def say_hi():
+  print("Hello from Python")
+
+say_hi()
+```
+-- gitupwards.txt --
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+echo	file.md	echo "Hello, runme!"		Yes
+hello-js	../root.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.	Yes
+hello-js-cat	../root.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.	Yes
+hello-python	../root.md	def say_hi():		Yes
+-- projectset.txt --
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+echo	nested/file.md	echo "Hello, runme!"		Yes


### PR DESCRIPTION
Empty project flag actually means default to cwd but with find repo upwards whereas non-empty project flag pins the specified dir (without applying find repo upwards).

PS: This matches the behavior of the pre-project-svc implementation.