### PR TITLE
Copy runme binary to extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ proto/clean:
 proto/dev: build proto/clean proto/generate
 	rm -rf $(RUNME_EXT_BASE)/node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts/runme
 	cp -vrf internal/gen/proto/ts/runme $(RUNME_EXT_BASE)/node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts
+	rm -f $(RUNME_EXT_BASE)/bin/runme
 	cp runme $(RUNME_EXT_BASE)/bin/runme
 
 .PHONY: proto/dev/reset

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ proto/clean:
 proto/dev: build proto/clean proto/generate
 	rm -rf $(RUNME_EXT_BASE)/node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts/runme
 	cp -vrf internal/gen/proto/ts/runme $(RUNME_EXT_BASE)/node_modules/@buf/stateful_runme.community_timostamm-protobuf-ts
+	cp runme $(RUNME_EXT_BASE)/bin/runme
 
 .PHONY: proto/dev/reset
 proto/dev/reset:


### PR DESCRIPTION
This PR copies the binary created for the kernel into the /bin/ folder of vscode-runme when running `proto/dev`

