### PR TITLE
Fixes the language resolution from the FencedCodeBlock AST

### DIFF
--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -294,7 +294,7 @@ func getLanguage(node *ast.FencedCodeBlock, source []byte) string {
 
 	// If the language is the same as the raw attributes,
 	// it means Goldmark is not aware of our internal language segment usage.
-	if lang := string(node.Language(source)); lang != "" && rawAttrs != lang {
+	if lang := string(node.Language(source)); lang != "" && !strings.HasPrefix(rawAttrs, lang) {
 		return lang
 	}
 	return ""

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -286,7 +286,15 @@ func getAttributes(node *ast.FencedCodeBlock, source []byte, parser attributePar
 
 // TODO(mxs): use guesslang model
 func getLanguage(node *ast.FencedCodeBlock, source []byte) string {
-	if lang := string(node.Language(source)); lang != "" {
+	var rawAttrs string
+	if node.Info != nil {
+		codeBlockInfo := node.Info.Text(source)
+		rawAttrs = string(rawAttributes(codeBlockInfo))
+	}
+
+	// If the language is the same as the raw attributes,
+	// it means Goldmark is not aware of our internal language segment usage.
+	if lang := string(node.Language(source)); lang != "" && rawAttrs != lang {
 		return lang
 	}
 	return ""

--- a/internal/document/node_test.go
+++ b/internal/document/node_test.go
@@ -75,3 +75,60 @@ console.log("hello world!")
 	assert.Equal(t, "", blocks[0].Intro())
 	assert.Equal(t, "This is an intro", blocks[1].Intro())
 }
+
+func TestCodeBlockAttributes(t *testing.T) {
+	testCases := []struct {
+		data             string
+		expectedLanguage string
+	}{
+		{
+			data: `
+			` + "```" + `{"name":"foo"}
+			console.log("hello world!")
+			`,
+			expectedLanguage: "",
+		},
+		{
+			data: `
+			` + "```" + ` {"name":"foo"}
+			console.log("hello world!")
+			`,
+			expectedLanguage: "",
+		},
+		{
+			data: `
+			` + "```" + `js {"name":"foo"}
+			console.log("hello world!")
+			`,
+			expectedLanguage: "js",
+		},
+		{
+			data: `
+			` + "```" + `js {"name": "foo"}
+			console.log("hello world!")
+			`,
+			expectedLanguage: "js",
+		},
+		{
+			data: `
+			` + "```" + `{"name": "foo"}
+			console.log("hello world!")
+			`,
+			expectedLanguage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		b := bytes.TrimSpace([]byte(tc.data))
+		doc := New(b, identityResolverNone)
+		node, err := doc.Root()
+		require.NoError(t, err)
+
+		blocks := CollectCodeBlocks(node)
+		require.Len(t, blocks, 1)
+
+		block := blocks[0]
+		assert.Len(t, block.attributes, 1)
+		assert.Equal(t, tc.expectedLanguage, block.language)
+	}
+}

--- a/testdata/flags/fmt.txtar
+++ b/testdata/flags/fmt.txtar
@@ -15,6 +15,12 @@ runme:
 ``` {"name":"bash-echo-1"}
 echo 1
 ```
+
+## Fenced codeblock with valid JSON annotations but using spaces
+
+```{"name": "bash-echo-2"}
+echo 2
+```
 -- README-FORMATED.md --
 ---
 runme:
@@ -26,4 +32,10 @@ runme:
 
 ```{"name":"bash-echo-1"}
 echo 1
+```
+
+## Fenced codeblock with valid JSON annotations but using spaces
+
+```{"name":"bash-echo-2"}
+echo 2
 ```

--- a/testdata/flags/fmt.txtar
+++ b/testdata/flags/fmt.txtar
@@ -1,0 +1,29 @@
+env SHELL=/bin/bash
+exec runme fmt --write
+cmp README-FORMATED.md README.md
+! stderr .
+
+-- README.md --
+---
+runme:
+  id: 01HMEC2Y9ZGB0EFGE6TT201V0N
+  version: v2.0
+---
+
+## Fenced codeblock without language
+
+``` {"name":"bash-echo-1"}
+echo 1
+```
+-- README-FORMATED.md --
+---
+runme:
+  id: 01HMEC2Y9ZGB0EFGE6TT201V0N
+  version: v2.2
+---
+
+## Fenced codeblock without language
+
+```{"name":"bash-echo-1"}
+echo 1
+```


### PR DESCRIPTION
Closes: #475

This is a temporary solution, I think we can deal with it by extending the Parser with custom logic to handle the language resolution for this edge case and generate an AST according to our necessity.

Some examples of Goldmark extensions:

https://github.com/yuin/goldmark#list-of-extensions 

