### PR TITLE
Fix bug in tui for execution when markdown does not contain frontmatter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
             "type": "go",
             "request": "attach",
             "mode": "remote",
-            "remotePath": "${workspaceFolder}",
+            "remotePath": "${workspaceFolder}/main.go",
             "port": 56379,
             "host": "127.0.0.1"
         },

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -168,7 +168,7 @@ func tuiCmd() *cobra.Command {
 					return err
 				}
 
-				if !fmtr.SkipPrompts {
+				if fmtr != nil && !fmtr.SkipPrompts {
 					err = promptEnvVars(cmd, sessionEnvs, task)
 					if err != nil {
 						return err


### PR DESCRIPTION
Simple check to avoid running into a nil pointer solves https://github.com/stateful/runme/issues/481.

Fyi, Runme-fied files without frontmatter don't happen very often any more since Runme adds frontmatter to the markdown once files are being modified/written.