### PR TITLE
Simplify dependency tree in internal/document

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -31,16 +31,14 @@ func getIdentityResolver() *identity.IdentityResolver {
 }
 
 func getProject() (*project.Project, error) {
-	opts := []project.ProjectOption{
-		project.WithIdentityResolver(getIdentityResolver()),
-	}
-
 	logger, err := getLogger(false)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append(opts, project.WithLogger(logger))
+	opts := []project.ProjectOption{
+		project.WithLogger(logger),
+	}
 
 	var proj *project.Project
 

--- a/internal/document/block.go
+++ b/internal/document/block.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/stateful/runme/internal/document/identity"
+	"github.com/yuin/goldmark/ast"
+
 	"github.com/stateful/runme/internal/executable"
 	"github.com/stateful/runme/internal/shell"
-	"github.com/yuin/goldmark/ast"
 )
 
 type BlockKind int
@@ -67,7 +67,7 @@ type CodeBlock struct {
 func newCodeBlock(
 	document *Document,
 	node *ast.FencedCodeBlock,
-	identityResolver *identity.IdentityResolver,
+	identityResolver identityResolver,
 	nameResolver *nameResolver,
 	source []byte,
 	render Renderer,

--- a/internal/document/constants/constants.go
+++ b/internal/document/constants/constants.go
@@ -1,6 +1,3 @@
 package constants
 
-const (
-	MaxFinalLineBreaks = 10
-	FinalLineBreaksKey = "finalLineBreaks"
-)
+const FinalLineBreaksKey = "finalLineBreaks"

--- a/internal/document/document.go
+++ b/internal/document/document.go
@@ -12,7 +12,6 @@ import (
 	"github.com/yuin/goldmark/text"
 
 	"github.com/stateful/runme/internal/document/constants"
-	"github.com/stateful/runme/internal/document/identity"
 	"github.com/stateful/runme/internal/renderer/cmark"
 )
 
@@ -20,7 +19,7 @@ var DefaultRenderer = cmark.Render
 
 type Document struct {
 	source           []byte
-	identityResolver *identity.IdentityResolver
+	identityResolver identityResolver
 	nameResolver     *nameResolver
 	parser           parser.Parser
 	renderer         Renderer
@@ -41,7 +40,7 @@ type Document struct {
 	frontmatter          *Frontmatter
 }
 
-func New(source []byte, identityResolver *identity.IdentityResolver) *Document {
+func New(source []byte, identityResolver identityResolver) *Document {
 	return &Document{
 		source:           source,
 		identityResolver: identityResolver,

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/stateful/runme/internal/document/identity"
-	"github.com/stateful/runme/internal/renderer/cmark"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stateful/runme/internal/document/identity"
+	"github.com/stateful/runme/internal/renderer/cmark"
 )
 
-var identityResolver = identity.NewResolver(identity.AllLifecycleIdentity)
+var testIdentityResolver = identity.NewResolver(identity.DefaultLifecycleIdentity)
 
 func TestDocument_Parse(t *testing.T) {
 	data := []byte(`# Examples
@@ -35,7 +36,7 @@ First paragraph.
 2. Item 2
 3. Item 3
 `)
-	doc := New(data, identityResolver)
+	doc := New(data, testIdentityResolver)
 	node, err := doc.Root()
 	require.NoError(t, err)
 	assert.Len(t, node.children, 4)
@@ -79,7 +80,7 @@ First paragraph
 `,
 		))
 
-		doc := New(data, identityResolver)
+		doc := New(data, testIdentityResolver)
 		err := doc.Parse()
 		require.NoError(t, err)
 		assert.Equal(t, []byte("First paragraph"), doc.Content())
@@ -87,7 +88,7 @@ First paragraph
 
 		frontmatter, err := doc.Frontmatter()
 		require.NoError(t, err)
-		marshaledFrontmatter, err := frontmatter.Marshal(identityResolver.DocumentEnabled())
+		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
 		require.NoError(t, err)
 		assert.Regexp(t, `---\nkey: value\nrunme:\n  id: .*\n  version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+)\n---`, string(marshaledFrontmatter))
 	})
@@ -136,7 +137,7 @@ shell = "fish"
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
-				doc := New(tc.Data, identityResolver)
+				doc := New(tc.Data, testIdentityResolver)
 				_, err := doc.Root()
 				require.NoError(t, err)
 
@@ -157,7 +158,7 @@ shell = "fish"
 ---
 `,
 		))
-		doc := New(data, identityResolver)
+		doc := New(data, testIdentityResolver)
 		err := doc.Parse()
 		require.NoError(t, err)
 
@@ -171,7 +172,7 @@ func TestDocument_TrailingLineBreaks(t *testing.T) {
 	data := []byte(`This will test final line breaks`)
 
 	t.Run("No breaks", func(t *testing.T) {
-		doc := New(data, identityResolver)
+		doc := New(data, testIdentityResolver)
 		astNode, err := doc.RootAST()
 		require.NoError(t, err)
 
@@ -188,7 +189,7 @@ func TestDocument_TrailingLineBreaks(t *testing.T) {
 
 	t.Run("1 LF", func(t *testing.T) {
 		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 1)...)
-		doc := New(withLineBreaks, identityResolver)
+		doc := New(withLineBreaks, testIdentityResolver)
 		astNode, err := doc.RootAST()
 		require.NoError(t, err)
 
@@ -205,7 +206,7 @@ func TestDocument_TrailingLineBreaks(t *testing.T) {
 
 	t.Run("1 CRLF", func(t *testing.T) {
 		withLineBreaks := append(data, bytes.Repeat([]byte{'\r', '\n'}, 1)...)
-		doc := New(withLineBreaks, identityResolver)
+		doc := New(withLineBreaks, testIdentityResolver)
 		astNode, err := doc.RootAST()
 		require.NoError(t, err)
 
@@ -222,7 +223,7 @@ func TestDocument_TrailingLineBreaks(t *testing.T) {
 
 	t.Run("7 LFs", func(t *testing.T) {
 		withLineBreaks := append(data, bytes.Repeat([]byte{'\n'}, 7)...)
-		doc := New(withLineBreaks, identityResolver)
+		doc := New(withLineBreaks, testIdentityResolver)
 		astNode, err := doc.RootAST()
 		require.NoError(t, err)
 

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stateful/runme/internal/document"
-	ulid "github.com/stateful/runme/internal/ulid"
 	"github.com/yuin/goldmark/ast"
+
+	"github.com/stateful/runme/internal/document"
+	"github.com/stateful/runme/internal/ulid"
 )
 
 const (

--- a/internal/document/editor/cell_test.go
+++ b/internal/document/editor/cell_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stateful/runme/internal/document"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stateful/runme/internal/document"
 )
 
 var (

--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/stateful/runme/internal/document"
 
+	"github.com/stateful/runme/internal/document"
 	"github.com/stateful/runme/internal/document/constants"
 	"github.com/stateful/runme/internal/document/identity"
 )

--- a/internal/document/identity.go
+++ b/internal/document/identity.go
@@ -1,0 +1,5 @@
+package document
+
+type identityResolver interface {
+	GetCellID(obj any, attributes map[string]string) (string, bool)
+}

--- a/internal/document/identity/resolver_test.go
+++ b/internal/document/identity/resolver_test.go
@@ -3,9 +3,9 @@ package identity
 import (
 	"testing"
 
-	parserv1 "github.com/stateful/runme/internal/gen/proto/go/runme/parser/v1"
-	identity "github.com/stateful/runme/internal/ulid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stateful/runme/internal/ulid"
 )
 
 func TestLifecycleIdentities(t *testing.T) {
@@ -47,34 +47,14 @@ func TestIdentityResolver(t *testing.T) {
 	})
 
 	t.Run("GetCellID", func(t *testing.T) {
-		ulid := "01HF53Z4RCVPRANKFBZYMS72QW"
-		identity.MockGenerator(ulid)
+		id := "01HF53Z4RCVPRANKFBZYMS72QW"
+		ulid.MockGenerator(id)
 		resolver := NewResolver(CellLifecycleIdentity)
 		obj := struct{}{}
-		attributes := map[string]string{"id": ulid}
+		attributes := map[string]string{"id": id}
 		id, ok := resolver.GetCellID(obj, attributes)
 
 		assert.True(t, ok)
 		assert.NotEmpty(t, id)
 	})
-}
-
-func TestToLifecycleIdentity(t *testing.T) {
-	tests := []struct {
-		name     string
-		idt      parserv1.RunmeIdentity
-		expected LifecycleIdentity
-	}{
-		{"AllIdentity", parserv1.RunmeIdentity_RUNME_IDENTITY_ALL, AllLifecycleIdentity},
-		{"DocumentIdentity", parserv1.RunmeIdentity_RUNME_IDENTITY_DOCUMENT, DocumentLifecycleIdentity},
-		{"CellIdentity", parserv1.RunmeIdentity_RUNME_IDENTITY_CELL, CellLifecycleIdentity},
-		{"UnspecifiedIdentity", parserv1.RunmeIdentity(999), UnspecifiedLifecycleIdentity},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ToLifecycleIdentity(tt.idt)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -106,12 +106,6 @@ func WithFindRepoUpward() ProjectOption {
 	}
 }
 
-func WithIdentityResolver(resolver *identity.IdentityResolver) ProjectOption {
-	return func(p *Project) {
-		p.identityResolver = resolver
-	}
-}
-
 func WithEnvFilesReadOrder(order []string) ProjectOption {
 	return func(p *Project) {
 		p.envFilesReadOrder = order
@@ -125,8 +119,6 @@ func WithLogger(logger *zap.Logger) ProjectOption {
 }
 
 type Project struct {
-	identityResolver *identity.IdentityResolver
-
 	// filePath is used for file-based projects.
 	filePath string
 


### PR DESCRIPTION
Highlights:
* `internal/project` does not require `internal/document/identity`; it was unused.
* Reordered a bunch of `import`s.
* `IdentityResolver` is thread-safe now.