### PR TITLE
Fix .env which broke as part of moving cmds to the project service

### DIFF
--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -49,6 +49,20 @@ func (rs *RunnerSettings) Clone() *RunnerSettings {
 	return &newRs
 }
 
+func (rs *RunnerSettings) ApplyProjectEnvs() error {
+	if rs.project == nil {
+		return nil
+	}
+
+	projEnvs, err := rs.project.LoadEnv()
+	if err != nil {
+		return err
+	}
+	rs.envs = append(rs.envs, projEnvs...)
+
+	return nil
+}
+
 type Runner interface {
 	RunTask(ctx context.Context, task project.Task) error
 	DryRunTask(ctx context.Context, task project.Task, w io.Writer, opts ...RunnerOption) error

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/muesli/cancelreader"
+	"github.com/pkg/errors"
 	"github.com/stateful/runme/internal/document"
 	runnerv1 "github.com/stateful/runme/internal/gen/proto/go/runme/runner/v1"
 	"github.com/stateful/runme/internal/project"
@@ -55,12 +56,9 @@ func (rs *RunnerSettings) ApplyProjectEnvs() error {
 	}
 
 	projEnvs, err := rs.project.LoadEnv()
-	if err != nil {
-		return err
-	}
 	rs.envs = append(rs.envs, projEnvs...)
 
-	return nil
+	return errors.Wrap(err, "failed applying project envs")
 }
 
 type Runner interface {

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -58,7 +58,7 @@ func (rs *RunnerSettings) ApplyProjectEnvs() error {
 	projEnvs, err := rs.project.LoadEnv()
 	rs.envs = append(rs.envs, projEnvs...)
 
-	return errors.Wrap(err, "failed applying project envs")
+	return errors.Wrap(err, "failed to apply project envs")
 }
 
 type Runner interface {

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -47,6 +47,10 @@ func NewLocalRunner(opts ...RunnerOption) (*LocalRunner, error) {
 		return nil, err
 	}
 
+	if err := r.ApplyProjectEnvs(); err != nil {
+		return nil, err
+	}
+
 	if r.logger == nil {
 		r.logger = zap.NewNop()
 	}
@@ -95,7 +99,6 @@ func (r *LocalRunner) newExecutable(task project.Task) (runner.Executable, error
 		Logger:  r.logger,
 	}
 
-	// TODO(adamb): what about `r.envs`?
 	cfg.PreEnv, err = r.project.LoadEnv()
 	if err != nil {
 		return nil, err

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -47,10 +47,6 @@ func NewLocalRunner(opts ...RunnerOption) (*LocalRunner, error) {
 		return nil, err
 	}
 
-	if err := r.ApplyProjectEnvs(); err != nil {
-		return nil, err
-	}
-
 	if r.logger == nil {
 		r.logger = zap.NewNop()
 	}

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -52,10 +52,6 @@ func NewRemoteRunner(ctx context.Context, addr string, opts ...RunnerOption) (*R
 		return nil, err
 	}
 
-	if err := r.ApplyProjectEnvs(); err != nil {
-		return nil, err
-	}
-
 	var creds credentials.TransportCredentials
 
 	if r.insecure {

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -52,6 +52,10 @@ func NewRemoteRunner(ctx context.Context, addr string, opts ...RunnerOption) (*R
 		return nil, err
 	}
 
+	if err := r.ApplyProjectEnvs(); err != nil {
+		return nil, err
+	}
+
 	var creds credentials.TransportCredentials
 
 	if r.insecure {

--- a/testdata/script/dotenv.txtar
+++ b/testdata/script/dotenv.txtar
@@ -1,0 +1,15 @@
+exec runme run env1
+stdout 'SOMETHING=in-my-dot-env'
+! stderr .
+
+-- .env --
+SOMETHING="in-my-dot-env"
+
+-- README.md --
+---
+shell: bash
+---
+
+```sh {"name":"env1"}
+echo SOMETHING=${SOMETHING}
+```


### PR DESCRIPTION
Please see #492 for details.

Before vs after:
```
❯ runme run hello1
SOMETHING1=[]
❯ ./runme run hello1
SOMETHING1=[this]
```

Fixes #492.