### PR TITLE
Runme v3 release prep

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -12,9 +12,10 @@ import (
 
 func loginCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "login",
-		Short: "Log in to Runme (optional)",
-		Long:  "Log in to Runme is not required for standalone functionality",
+		Use:    "login",
+		Hidden: true,
+		Short:  "Log in to Runme (optional)",
+		Long:   "Log in to Runme is not required for standalone functionality",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return newAuth().Login(cmd.Context())
 		},
@@ -25,8 +26,9 @@ func loginCmd() *cobra.Command {
 
 func logoutCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Log out from Runme",
+		Use:    "logout",
+		Hidden: true,
+		Short:  "Log out from Runme",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return newAuth().Logout()
 		},

--- a/internal/cmd/code_server_test.go
+++ b/internal/cmd/code_server_test.go
@@ -1,3 +1,5 @@
+//go:test !darwin
+
 package cmd
 
 import (

--- a/internal/cmd/extension.go
+++ b/internal/cmd/extension.go
@@ -19,7 +19,7 @@ func extensionCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "extension",
-		Short: "Check your Stateful VS Code extension status",
+		Short: "Check your Runme VS Code extension status",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			model := tui.NewModel(
 				newExtensionerModel(force),

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -90,11 +90,6 @@ func Root() *cobra.Command {
 		}
 	})
 
-	branchCmd := branchCmd()
-	suggestCmd := suggestCmd()
-	suggestCmd.AddCommand(branchCmd)
-
-	cmd.AddCommand(branchCmd)
 	cmd.AddCommand(codeServerCmd())
 	cmd.AddCommand(environmentCmd())
 	cmd.AddCommand(fmtCmd())
@@ -107,7 +102,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(runLocally())
 	cmd.AddCommand(serverCmd())
 	cmd.AddCommand(shellCmd())
-	cmd.AddCommand(suggestCmd)
+	cmd.AddCommand(suggestCmd())
 	cmd.AddCommand(tasksCmd())
 	cmd.AddCommand(tokenCmd())
 	cmd.AddCommand(tuiCmd)

--- a/internal/cmd/run_locally.go
+++ b/internal/cmd/run_locally.go
@@ -15,8 +15,9 @@ func runLocally() *cobra.Command {
 	var category string
 
 	cmd := cobra.Command{
-		Use:   "run-locally [command1 command2 ...]",
-		Short: "Run one or more commands.",
+		Use:    "run-locally [command1 command2 ...]",
+		Hidden: true,
+		Short:  "Run one or more commands.",
 		Long: `Run commands by providing their names delimited by space.
 The names are interpreted as glob patterns.
 

--- a/internal/cmd/suggest.go
+++ b/internal/cmd/suggest.go
@@ -13,21 +13,12 @@ import (
 )
 
 func suggestCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "suggest",
-		Short: "Use our suggestion engine to give contextual advice",
-	}
-
-	return cmd
-}
-
-func branchCmd() *cobra.Command {
 	var repoUser string
 
 	cmd := &cobra.Command{
-		Use:     "branch DESCRIPTION",
-		Aliases: []string{"branchGPT", "branchgpt"},
-		Short:   "Suggest a branch name (aka branchGPT)",
+		Use:    "suggest DESCRIPTION",
+		Hidden: true,
+		Short:  "Suggest a branch name",
 		Long: `Suggest a branch name for a description.
 
 Remember to wrap the DESCRIPTION in double quotes as otherwise
@@ -36,7 +27,7 @@ it will be interpreted as multiple arguments.
 Disclaimer: This uses AI, so the suggestions may be biased, wrong,
 or just bad. Please use with discretion.
 `,
-		Deprecated: "Please note this command will be removed with the next major release",
+		Deprecated: "Please note this command does not receive updates and will be removed in the future.",
 		Args:       cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := graphql.ContextWithTrackInput(cmd.Context(), trackInputFromCmd(cmd, args))

--- a/internal/document/document_test.go
+++ b/internal/document/document_test.go
@@ -90,7 +90,7 @@ First paragraph
 		require.NoError(t, err)
 		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
 		require.NoError(t, err)
-		assert.Regexp(t, `---\nkey: value\nrunme:\n  id: .*\n  version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+)\n---`, string(marshaledFrontmatter))
+		assert.Regexp(t, `---\nkey: value\nrunme:\n  id: .*\n  version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+|\d+)\n---`, string(marshaledFrontmatter))
 	})
 
 	t.Run("Format", func(t *testing.T) {

--- a/internal/document/editor/cell.go
+++ b/internal/document/editor/cell.go
@@ -168,6 +168,13 @@ func toCellsRec(
 				metadata[PrefixAttributeName(InternalAttributePrefix, "id")] = cellID
 			}
 			metadata[PrefixAttributeName(InternalAttributePrefix, "name")] = block.Name()
+
+			nameGeneratedStr := "false"
+			if block.IsUnnamed() {
+				nameGeneratedStr = "true"
+			}
+			metadata[PrefixAttributeName(InternalAttributePrefix, "nameGenerated")] = nameGeneratedStr
+
 			*cells = append(*cells, &Cell{
 				Kind:       CodeKind,
 				Value:      string(block.Content()),

--- a/internal/document/editor/editor_test.go
+++ b/internal/document/editor/editor_test.go
@@ -84,6 +84,11 @@ func TestEditor_CodeBlock(t *testing.T) {
 			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "name")],
 			"echo-1",
 		)
+		assert.Equal(
+			t,
+			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "nameGenerated")],
+			"true",
+		)
 		// "name" is empty because it was not included in the original snippet.
 		assert.Empty(
 			t,
@@ -103,6 +108,11 @@ func TestEditor_CodeBlock(t *testing.T) {
 			t,
 			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "name")],
 			"name1",
+		)
+		assert.Equal(
+			t,
+			cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "nameGenerated")],
+			"false",
 		)
 		// "name" is not nil because it was included in the original snippet.
 		assert.Equal(

--- a/internal/document/editor/editorservice/service_test.go
+++ b/internal/document/editor/editorservice/service_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	versionRegex = `version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+)`
+	versionRegex = `version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+|\d+)`
 	testMockID   = ulid.GenerateID()
 
 	client parserv1.ParserServiceClient

--- a/internal/document/editor/editorservice/service_test.go
+++ b/internal/document/editor/editorservice/service_test.go
@@ -46,7 +46,7 @@ var (
 		"prop: value",
 		"runme:",
 		"  id: 123",
-		"  version: v99.9",
+		"  version: v99",
 		"---",
 		"",
 		documentWithoutFrontmatter,
@@ -100,7 +100,7 @@ func Test_IdentityUnspecified(t *testing.T) {
 			assert.Len(t, dResp.Notebook.Metadata, 2)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
 			assert.Contains(t, rawFrontmatter, "id: 123\n")
-			assert.Contains(t, rawFrontmatter, "version: v99.9\n")
+			assert.Contains(t, rawFrontmatter, "version: v99\n")
 		} else {
 			assert.False(t, ok)
 			assert.Len(t, dResp.Notebook.Metadata, 1)
@@ -239,7 +239,7 @@ func Test_IdentityCell(t *testing.T) {
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, content, "runme:\n")
 			assert.Contains(t, content, "id: 123\n")
-			assert.Contains(t, content, "version: v99.9\n")
+			assert.Contains(t, content, "version: v99\n")
 		} else {
 			assert.NotRegexp(t, "^---\n", content)
 			assert.NotRegexp(t, "^\n\n", content)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -19,11 +19,11 @@ func BaseVersion() string {
 		return BuildDate
 	}
 
-	return fmt.Sprintf("v%d.%d", v.Major(), v.Minor())
+	return fmt.Sprintf("v%d", v.Major())
 }
 
 func BaseVersionAuthoritative() (string, bool) {
 	_, err := semver.NewVersion(BuildVersion)
 	baseVersion := BaseVersion()
-	return baseVersion, err == nil && baseVersion != "v0.0" && baseVersion != "v99.9"
+	return baseVersion, err == nil && baseVersion != "v0" && baseVersion != "v99"
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -15,22 +15,22 @@ func TestBaseVersion(t *testing.T) {
 		{
 			name:                "standard version",
 			buildVersion:        "1.7.8-11-g2300850-2300850",
-			expectedBaseVersion: "v1.7",
+			expectedBaseVersion: "v1",
 		},
 		{
 			name:                "only major and minor version",
 			buildVersion:        "2.3-11-g2300850-2300850",
-			expectedBaseVersion: "v2.3",
+			expectedBaseVersion: "v2",
 		},
 		{
 			name:                "only major version",
 			buildVersion:        "3-11-g2300850-2300850",
-			expectedBaseVersion: "v3.0",
+			expectedBaseVersion: "v3",
 		},
 		{
 			name:                "no version",
 			buildVersion:        "0.0.0",
-			expectedBaseVersion: "v0.0",
+			expectedBaseVersion: "v0",
 		},
 		{
 			name:                "invalid semver",
@@ -58,17 +58,17 @@ func TestBaseVersionAuthoritative(t *testing.T) {
 		{
 			name:                "zeros",
 			buildVersion:        "0.0.0",
-			expectedBaseVersion: "v0.0",
+			expectedBaseVersion: "v0",
 		},
 		{
 			name:                "nines",
 			buildVersion:        "99.9.9",
-			expectedBaseVersion: "v99.9",
+			expectedBaseVersion: "v99",
 		},
 		{
 			name:                "standard version",
 			buildVersion:        "1.7.8-11-g2300850-2300850",
-			expectedBaseVersion: "v1.7",
+			expectedBaseVersion: "v1",
 			authoritative:       true,
 		},
 		{


### PR DESCRIPTION
Final changes to get v3.0 out the door:

1. Remove `branch` cmd (however, keep `suggest` in please for now which works the same way).
2. Login/logout are hidden since they are no longer required (`branch` cmd, removed).
3. Base Version is no longer defined as `v<major>.<minor>`, it's `v<major>` now.
4. Unrelated item, include private metadata into cell whether or not a name was generated for future extension feature.

That's it.