### PR TITLE
breaking(docker): move runme to /opt/bin/

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,11 +3,14 @@ LABEL maintainer="StatefulHQ <mail@stateful.com>"
 
 RUN apk --no-cache add ca-certificates
 RUN mkdir /newtmp && chown 1777 /newtmp
+RUN mkdir -p /opt/var/runme /opt/bin
 
 FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /newtmp /tmp
+COPY --from=build /opt /opt
 
-COPY runme /
+COPY runme /opt/bin/
+WORKDIR /opt/var/runme
 
-ENTRYPOINT ["/runme"]
+ENTRYPOINT ["/opt/bin/runme"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,8 @@
 FROM ubuntu:23.10 as build
 LABEL maintainer="StatefulHQ <mail@stateful.com>"
 
-COPY runme /
+RUN mkdir -p /opt/var/runme /opt/bin
+COPY runme /opt/bin/runme
+WORKDIR /opt/var/runme
 
-ENTRYPOINT ["/runme"]
+ENTRYPOINT ["/opt/bin/runme"]


### PR DESCRIPTION
Relocate the runme executable to the **`/opt/bin`** directory and designate **`/opt/var/runme`** as the working directory. This adjustment prevents crashes resulting from accessing the root filesystem (**`/`**) when the image is used outside a multi-stage build.

The right way to use the docker image outside multi-stage builds is the following:

* Use the default working directory:
  **`docker run -it --volume /your/runbooks:/opt/var/runme statefulhq/runme`** 

* Changing the working directory:
  **`docker run -it -w /runbooks --volume /your/runbooks:/runbooks statefulhq/runme`**

* Passing the **`--project`** flag:
  **`docker run -it --volume /your/runbooks:/runbooks statefulhq/runme --project /runbooks`** 
  

Sample:

![image](https://github.com/stateful/runme/assets/43882/a624fb7b-1337-4148-a60c-c3f65b4db373)

Closes: #504

**For multi-stage dependants that are using the binary from **/runme** it will be a breaking change.**
