### PR TITLE
Updates alpine based docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,15 +2,9 @@ FROM alpine:latest as build
 LABEL maintainer="StatefulHQ <mail@stateful.com>"
 
 RUN apk --no-cache add ca-certificates
-RUN mkdir /newtmp && chown 1777 /newtmp
+
 RUN mkdir -p /opt/var/runme /opt/bin
-
-FROM scratch
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /newtmp /tmp
-COPY --from=build /opt /opt
-
-COPY runme /opt/bin/
+COPY runme /opt/bin/runme
 WORKDIR /opt/var/runme
 
 ENTRYPOINT ["/opt/bin/runme"]

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,9 @@ update-gql-schema:
 .PHONY: generate
 generate:
 	go generate ./...
+
+.PHONY: docker
+docker:
+	CGO_ENABLED=0 make build
+	docker build -f Dockerfile.alpine . -t runme:alpine
+	docker build -f Dockerfile.ubuntu . -t runme:ubuntu


### PR DESCRIPTION
Removes scratch image to be compatible with the alpine base image and supports minimal environment to perform runme for shell scripts.

Closes #510