### PR TITLE
Experimental Command `runme env store check`

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -314,6 +314,7 @@ func setRunnerFlags(cmd *cobra.Command, serverAddr *string) func() ([]client.Run
 			client.WithInsecure(fInsecure),
 			client.WithEnableBackgroundProcesses(EnableBackgroundProcesses),
 			client.WithEnvs([]string{fmt.Sprintf("%s=%d", envStackDepth, stackDepth)}),
+			client.WithEnvStoreType(runnerv1.SessionEnvStoreType_SESSION_ENV_STORE_TYPE_UNSPECIFIED),
 		}
 
 		switch strings.ToLower(SessionStrategy) {

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -138,25 +138,24 @@ func storeCheckCmd() *cobra.Command {
 				runnerOpts,
 				client.WithinShellMaybe(),
 				client.WithStdin(cmd.InOrStdin()),
+				client.WithCleanupSession(true),
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),
 				client.WithProject(project),
 				client.WithEnvStoreType(runnerv1.SessionEnvStoreType_SESSION_ENV_STORE_TYPE_OWL),
 			)
 
-			_, err = client.NewRemoteRunner(
+			runner, err := client.NewRemoteRunner(
 				cmd.Context(),
 				serverAddr,
 				runnerOpts...,
 			)
-
 			if err != nil {
-				return fmt.Errorf("Failed to create environment for gRPC runner: %s", err.Error())
-
+				return fmt.Errorf("failed to create environment for gRPC runner: %s", err.Error())
 			}
 
-			fmt.Printf("Session created successfuly in %s\n", project.Root())
-			return nil
+			_, err = fmt.Printf("session created successfully in %s with id %s\n", project.Root(), runner.GetSessionID())
+			return err
 		},
 	}
 

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -153,7 +153,7 @@ func storeCheckCmd() *cobra.Command {
 			if err != nil {
 				// todo(sebastian): hack
 				errStr := err.Error()
-				parts := strings.Split(errStr, "rpc error: code = ")
+				parts := strings.Split(errStr, "Unknown desc = ")
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", parts[len(parts)-1])
 				return nil
 			}

--- a/internal/cmd/environment.go
+++ b/internal/cmd/environment.go
@@ -145,16 +145,21 @@ func storeCheckCmd() *cobra.Command {
 				client.WithEnvStoreType(runnerv1.SessionEnvStoreType_SESSION_ENV_STORE_TYPE_OWL),
 			)
 
-			runner, err := client.NewRemoteRunner(
+			_, err = client.NewRemoteRunner(
 				cmd.Context(),
 				serverAddr,
 				runnerOpts...,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to create environment for gRPC runner: %s", err.Error())
+				// todo(sebastian): hack
+				errStr := err.Error()
+				parts := strings.Split(errStr, "rpc error: code = ")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", parts[len(parts)-1])
+				return nil
 			}
 
-			_, err = fmt.Printf("session created successfully in %s with id %s\n", project.Root(), runner.GetSessionID())
+			// _, err = fmt.Printf("session created successfully in %s with id %s\n", project.Root(), runner.GetSessionID())
+			_, err = fmt.Println("Success")
 			return err
 		},
 	}

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -43,6 +43,8 @@ type RunnerSettings struct {
 	tlsDir   string
 
 	envs []string
+
+	envStoreType runnerv1.SessionEnvStoreType
 }
 
 func (rs *RunnerSettings) Clone() *RunnerSettings {
@@ -216,6 +218,12 @@ func WithTempSettings(rc Runner, opts []RunnerOption, cb func() error) error {
 	}
 
 	return nil
+}
+
+func WithEnvStoreType(EnvStoreType runnerv1.SessionEnvStoreType) RunnerOption {
+	return withSettings(func(rs *RunnerSettings) {
+		rs.envStoreType = EnvStoreType
+	})
 }
 
 func ApplyOptions(rc Runner, opts ...RunnerOption) error {

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -300,3 +300,7 @@ func (r *RemoteRunner) GetEnvs(ctx context.Context) ([]string, error) {
 
 	return resp.Session.Envs, nil
 }
+
+func (r *RemoteRunner) GetSessionID() string {
+	return r.sessionID
+}

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -84,10 +84,13 @@ func (r *RemoteRunner) setupSession(ctx context.Context) error {
 		return nil
 	}
 
-	resp, err := r.client.CreateSession(ctx, &runnerv1.CreateSessionRequest{
-		Envs:    os.Environ(),
-		Project: ConvertToRunnerProject(r.project),
-	})
+	request := &runnerv1.CreateSessionRequest{
+		Envs:         os.Environ(),
+		Project:      ConvertToRunnerProject(r.project),
+		EnvStoreType: r.envStoreType,
+	}
+
+	resp, err := r.client.CreateSession(ctx, request)
 	if err != nil {
 		return errors.Wrap(err, "failed to create session")
 	}


### PR DESCRIPTION
Adds an experimental command to check the smart store, it creates a new session, if the session creation fails, it prints the founded errors.

Issue: #533 