### PR TITLE
Guard against non-tty stdin in bubbletea

### DIFF
--- a/internal/cmd/project_loader.go
+++ b/internal/cmd/project_loader.go
@@ -23,9 +23,9 @@ type projectLoader struct {
 }
 
 func newProjectLoader(cmd *cobra.Command, allowUnknown, allowUnnamed bool) (*projectLoader, error) {
-	fd := os.Stdout.Fd()
+	ofd := os.Stdout.Fd()
 
-	if int(fd) < 0 {
+	if int(ofd) < 0 {
 		return nil, fmt.Errorf("invalid file descriptor due to restricted environments, redirected standard output, system configuration issues, or testing/simulation setups")
 	}
 
@@ -35,7 +35,7 @@ func newProjectLoader(cmd *cobra.Command, allowUnknown, allowUnnamed bool) (*pro
 		ctx:          cmd.Context(),
 		w:            cmd.OutOrStdout(),
 		r:            cmd.InOrStdin(),
-		isTerminal:   isTerminal(fd),
+		isTerminal:   isTerminal(ofd) && isTerminal(os.Stdin.Fd()),
 	}, nil
 }
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -182,10 +183,17 @@ func runCmd() *cobra.Command {
 				return err
 			}
 
+			// non-tty fails on linux otherwise
+			var stdin io.Reader
+			stdin = bytes.NewBuffer([]byte{})
+			if isTerminal(os.Stdout.Fd()) {
+				stdin = cmd.InOrStdin()
+			}
+
 			runnerOpts = append(
 				runnerOpts,
 				client.WithinShellMaybe(),
-				client.WithStdin(cmd.InOrStdin()),
+				client.WithStdin(stdin),
 				client.WithStdout(cmd.OutOrStdout()),
 				client.WithStderr(cmd.ErrOrStderr()),
 				client.WithProject(proj),

--- a/internal/cmd/tui_common.go
+++ b/internal/cmd/tui_common.go
@@ -26,7 +26,7 @@ func newProgramWithOutputs(output io.Writer, input io.Reader, model tea.Model, o
 		opts = append(opts, tea.WithOutput(output))
 	}
 
-	if input != nil {
+	if input != nil && isTerminal(os.Stdin.Fd()) {
 		opts = append(opts, tea.WithInput(input))
 	}
 


### PR DESCRIPTION
Turns out bubbletea errors when handed a non-tty stdin on Linux.

https://github.com/charmbracelet/bubbletea/issues/964

This prevent the `run` command from running into this scenario.