### PR TITLE
Enable extension to do lid-less caching

### DIFF
--- a/internal/document/editor/editor.go
+++ b/internal/document/editor/editor.go
@@ -12,7 +12,10 @@ import (
 	"github.com/stateful/runme/v3/internal/document/identity"
 )
 
-const FrontmatterKey = "frontmatter"
+const (
+	FrontmatterKey = "frontmatter"
+	DocumentID     = "id"
+)
 
 func Deserialize(data []byte, identityResolver *identity.IdentityResolver) (*Notebook, error) {
 	// Deserialize content to cells.
@@ -39,6 +42,11 @@ func Deserialize(data []byte, identityResolver *identity.IdentityResolver) (*Not
 	// TODO(adamb): handle the error.
 	if raw, err := frontmatter.Marshal(identityResolver.DocumentEnabled()); err == nil && len(raw) > 0 {
 		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)] = string(raw)
+	}
+
+	// Store internal ephemeral document ID if the document lifecycle ID is disabled.
+	if !identityResolver.DocumentEnabled() {
+		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, DocumentID)] = identityResolver.EphemeralDocumentID()
 	}
 
 	return notebook, nil

--- a/internal/document/editor/editorservice/service_test.go
+++ b/internal/document/editor/editorservice/service_test.go
@@ -97,13 +97,13 @@ func Test_IdentityUnspecified(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		if tt.hasExtraFrontmatter {
 			assert.True(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 2)
+			assert.Len(t, dResp.Notebook.Metadata, 3)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
 			assert.Contains(t, rawFrontmatter, "id: 123\n")
 			assert.Contains(t, rawFrontmatter, "version: v99\n")
 		} else {
 			assert.False(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 1)
+			assert.Len(t, dResp.Notebook.Metadata, 2)
 		}
 
 		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
@@ -222,13 +222,13 @@ func Test_IdentityCell(t *testing.T) {
 
 		if tt.hasExtraFrontmatter {
 			assert.True(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 2)
+			assert.Len(t, dResp.Notebook.Metadata, 3)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
 			assert.Contains(t, rawFrontmatter, "id: 123\n")
 			assert.Regexp(t, versionRegex, rawFrontmatter, "Wrong version")
 		} else {
 			assert.False(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 1)
+			assert.Len(t, dResp.Notebook.Metadata, 2)
 		}
 
 		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)

--- a/internal/document/identity/resolver.go
+++ b/internal/document/identity/resolver.go
@@ -71,6 +71,11 @@ func (ir *IdentityResolver) DocumentEnabled() bool {
 	return ir.documentIdentity
 }
 
+// EphemeralDocumentID returns a new document ID which is not persisted.
+func (ir *IdentityResolver) EphemeralDocumentID() string {
+	return ulid.GenerateID()
+}
+
 // GetCellID returns a cell ID and a boolean indicating if it's new or from attributes.
 func (ir *IdentityResolver) GetCellID(obj any, attributes map[string]string) (string, bool) {
 	if !ir.cellIdentity {

--- a/internal/document/identity/resolver_test.go
+++ b/internal/document/identity/resolver_test.go
@@ -57,4 +57,9 @@ func TestIdentityResolver(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotEmpty(t, id)
 	})
+
+	t.Run("EphemeralDocumentID", func(t *testing.T) {
+		resolver := NewResolver(DefaultLifecycleIdentity)
+		assert.Len(t, resolver.EphemeralDocumentID(), 26)
+	})
 }


### PR DESCRIPTION
The serializer in the extension does not have access to it's origin-document's metadata, e.g. filepath etc, which makes it difficult to have a reliable ID that's persistent across the "session lifecycle".

This is why the deserializer will insert an internal/ephemeral document ID when persistent lifecycle ID is disabled.