### PR TITLE
Use PATH from session to look for programs

### DIFF
--- a/internal/cmd/code_server.go
+++ b/internal/cmd/code_server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/stateful/runme/v3/internal/runner"
+	"github.com/stateful/runme/v3/internal/system"
 	"github.com/stateful/runme/v3/internal/tui"
 	"go.uber.org/zap"
 )
@@ -101,6 +102,7 @@ func codeServerCmd() *cobra.Command {
 					Stdout: cmd.OutOrStdout(),
 					Stderr: cmd.ErrOrStderr(),
 					Stdin:  stdin,
+					System: system.Default,
 					Logger: zap.NewNop(),
 				}
 

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stateful/runme/v3/internal/document"
 	"github.com/stateful/runme/v3/internal/project"
 	"github.com/stateful/runme/v3/internal/runner"
+	"github.com/stateful/runme/v3/internal/system"
 	"go.uber.org/zap"
 )
 
@@ -91,6 +92,7 @@ func (r *LocalRunner) newExecutable(task project.Task) (runner.Executable, error
 		Stdout:  r.stdout,
 		Stderr:  r.stderr,
 		Session: r.session,
+		System:  system.Default,
 		Logger:  r.logger,
 	}
 

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -109,7 +109,7 @@ func newCommand(cfg *commandConfig) (*command, error) {
 	// This is especially important for virtual envs.
 	sys := system.Default
 	if cfg.Session != nil {
-		if pathEnv := cfg.Session.envStorer.getEnv("PATH"); pathEnv != "" {
+		if pathEnv, err := cfg.Session.envStorer.getEnv("PATH"); err == nil && pathEnv != "" {
 			sys = system.New(system.WithPathEnvGetter(func() string { return pathEnv }))
 		}
 	}

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -16,9 +16,11 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/pkg/errors"
-	"github.com/stateful/runme/v3/internal/ulid"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+
+	"github.com/stateful/runme/v3/internal/system"
+	"github.com/stateful/runme/v3/internal/ulid"
 )
 
 const (
@@ -102,10 +104,20 @@ type commandConfig struct {
 }
 
 func newCommand(cfg *commandConfig) (*command, error) {
+	// If PATH is set in the session, use it in the system
+	// so that program paths can be resolved correctly.
+	// This is especially important for virtual envs.
+	sys := system.Default
+	if cfg.Session != nil {
+		if pathEnv := cfg.Session.envStorer.getEnv("PATH"); pathEnv != "" {
+			sys = system.New(system.WithPathEnvGetter(func() string { return pathEnv }))
+		}
+	}
+
 	programName, initialArgs := parseFileProgram(cfg.ProgramName)
 	args := initialArgs
 
-	programPath, initialArgs, err := inferFileProgram(programName, cfg.LanguageID)
+	programPath, initialArgs, err := inferFileProgram(sys, programName, cfg.LanguageID)
 	args = append(args, initialArgs...)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -658,9 +670,9 @@ func parseFileProgram(programPath string) (program string, args []string) {
 	return
 }
 
-func inferFileProgram(programPath string, languageID string) (interpreter string, args []string, err error) {
+func inferFileProgram(sys *system.System, programPath string, languageID string) (interpreter string, args []string, err error) {
 	if programPath != "" {
-		res, err := exec.LookPath(programPath)
+		res, err := sys.LookPath(programPath)
 		if err != nil {
 			return "", []string{}, ErrInvalidProgram{
 				Program: programPath,
@@ -672,7 +684,7 @@ func inferFileProgram(programPath string, languageID string) (interpreter string
 
 	for _, candidate := range programByLanguageID[languageID] {
 		program, args := parseFileProgram(candidate)
-		res, err := exec.LookPath(program)
+		res, err := sys.LookPath(program)
 		if err == nil {
 			return res, args, nil
 		}

--- a/internal/runner/env_store.go
+++ b/internal/runner/env_store.go
@@ -33,6 +33,12 @@ func (s *envStore) Add(envs ...string) *envStore {
 	return s
 }
 
+func (s *envStore) Get(k string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.values[k]
+}
+
 func getEnvSizeContribution(k, v string) int {
 	// +2 for the '=' and '\0' separators
 	return len(k) + len(v) + 2

--- a/internal/runner/executable.go
+++ b/internal/runner/executable.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"io"
 
-	"github.com/stateful/runme/v3/internal/executable"
 	"go.uber.org/zap"
+
+	"github.com/stateful/runme/v3/internal/executable"
+	"github.com/stateful/runme/v3/internal/system"
 )
 
 type Executable interface {
@@ -24,6 +26,7 @@ type ExecutableConfig struct {
 	PreEnv  []string
 	PostEnv []string
 	Session *Session
+	System  *system.System
 	Logger  *zap.Logger
 }
 

--- a/internal/runner/go.go
+++ b/internal/runner/go.go
@@ -20,7 +20,7 @@ type Go struct {
 var _ Executable = (*Go)(nil)
 
 func (g Go) DryRun(ctx context.Context, w io.Writer) {
-	_, err := exec.LookPath("go")
+	_, err := g.System.LookPath("go")
 	if err != nil {
 		_, _ = fmt.Fprintf(w, "failed to find %q executable: %s\n", "go", err)
 	}
@@ -30,7 +30,7 @@ func (g Go) DryRun(ctx context.Context, w io.Writer) {
 }
 
 func (g *Go) Run(ctx context.Context) error {
-	executable, err := exec.LookPath("go")
+	executable, err := g.System.LookPath("go")
 	if err != nil {
 		return errors.Wrapf(err, "failed to find %q executable", "go")
 	}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -15,6 +15,7 @@ import (
 var owlStoreDefault = false
 
 type envStorer interface {
+	getEnv(string) string
 	envs() ([]string, error)
 	sensitiveEnvKeys() ([]string, error)
 	addEnvs(envs []string) error
@@ -137,6 +138,10 @@ func (es *runnerEnvStorer) addEnvs(envs []string) error {
 func (es *runnerEnvStorer) sensitiveEnvKeys() ([]string, error) {
 	// noop, not supported
 	return []string{}, nil
+}
+
+func (es *runnerEnvStorer) getEnv(name string) string {
+	return es.envStore.Get(name)
 }
 
 func (es *runnerEnvStorer) envs() ([]string, error) {
@@ -307,6 +312,11 @@ func (es *owlEnvStorer) addEnvs(envs []string) error {
 	}
 	es.notifySubscribers()
 	return nil
+}
+
+func (es *owlEnvStorer) getEnv(name string) string {
+	// TODO(adamb): implement this
+	return ""
 }
 
 func (es *owlEnvStorer) sensitiveEnvKeys() ([]string, error) {

--- a/internal/system/lookpath.go
+++ b/internal/system/lookpath.go
@@ -1,0 +1,39 @@
+package system
+
+import (
+	"os"
+)
+
+var Default = newDefault()
+
+func newDefault() *System {
+	return &System{
+		getPathEnv: func() string { return os.Getenv("PATH") },
+	}
+}
+
+type Option func(*System)
+
+func WithPathEnvGetter(fn func() string) Option {
+	return func(s *System) {
+		s.getPathEnv = fn
+	}
+}
+
+type System struct {
+	getPathEnv func() string
+}
+
+func New(opts ...Option) *System {
+	s := newDefault()
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+func (s *System) LookPath(file string) (string, error) {
+	return lookPath(s.getPathEnv(), file)
+}

--- a/internal/system/lookpath_test.go
+++ b/internal/system/lookpath_test.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+// TODO(adamb): remove the build flag when [System.LookPath] is implemented for Windows.
+
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookPath(t *testing.T) {
+	tmp := t.TempDir()
+	myBinaryPath := filepath.Join(tmp, "my-binary")
+
+	// Create an empty file with execute permission.
+	err := os.WriteFile(myBinaryPath, []byte{}, 0o111)
+	require.NoError(t, err)
+
+	s := New(
+		WithPathEnvGetter(func() string { return tmp }),
+	)
+	path, err := s.LookPath("my-binary")
+	require.NoError(t, err)
+	assert.Equal(t, myBinaryPath, path)
+}

--- a/internal/system/lookpath_unix.go
+++ b/internal/system/lookpath_unix.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package system
+
+import (
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+func lookPath(pathEnv, file string) (string, error) {
+	if strings.Contains(file, "/") {
+		err := findExecutable(file)
+		if err == nil {
+			return file, nil
+		}
+		return "", &exec.Error{Name: file, Err: err}
+	}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			// Unix shell semantics: path element "" means "."
+			dir = "."
+		}
+		path := filepath.Join(dir, file)
+		if err := findExecutable(path); err == nil {
+			if !filepath.IsAbs(path) {
+				return path, &exec.Error{Name: file, Err: exec.ErrDot}
+			}
+			return path, nil
+		}
+	}
+	return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+}
+
+func findExecutable(file string) error {
+	d, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+	m := d.Mode()
+	if m.IsDir() {
+		return syscall.EISDIR
+	}
+	if m&0o111 != 0 {
+		return nil
+	}
+	return fs.ErrPermission
+}

--- a/internal/system/lookpath_windows.go
+++ b/internal/system/lookpath_windows.go
@@ -1,0 +1,9 @@
+package system
+
+import "os/exec"
+
+func lookPath(_, file string) (string, error) {
+	// TODO(adamb): implement this for Windows.
+	// Check out https://github.com/golang/go/blob/master/src/os/exec/lp_windows.go.
+	return exec.LookPath(file)
+}


### PR DESCRIPTION
If `PATH` is present in the session, use it to look for the program paths. This is especially important for situation when within a session a virtual env is created and consecutive code blocks should be executed within it.

Fixes https://github.com/stateful/runme/issues/552

Port this change to https://github.com/stateful/runme/pull/548.