### PR TITLE
Use pointers internally for frontmatter

### DIFF
--- a/internal/document/editor/editor_test.go
+++ b/internal/document/editor/editor_test.go
@@ -218,11 +218,11 @@ A paragraph
 	rpath := "README.md"
 	invalidTs := "invalid-timestamp-should-be-overwritten"
 	outputMetadata := &document.RunmeMetadata{
-		Session: document.RunmeMetadataSession{
+		Session: &document.RunmeMetadataSession{
 			ID:      sid,
 			Updated: invalidTs,
 		},
-		Document: document.RunmeMetadataDocument{RelativePath: rpath},
+		Document: &document.RunmeMetadataDocument{RelativePath: rpath},
 	}
 	result, err := Serialize(notebook, outputMetadata)
 	require.NoError(t, err)

--- a/internal/document/editor/editorservice/service.go
+++ b/internal/document/editor/editorservice/service.go
@@ -74,7 +74,7 @@ func (s *parserServiceServer) Deserialize(_ context.Context, req *parserv1.Deser
 			runme.Version = notebook.Frontmatter.Runme.Version
 		}
 
-		if notebook.Frontmatter.Runme.Session.ID != "" {
+		if notebook.Frontmatter.Runme.Session != nil && notebook.Frontmatter.Runme.Session.ID != "" {
 			runme.Session = &parserv1.RunmeSession{
 				Id: notebook.Frontmatter.Runme.Session.ID,
 				Document: &parserv1.RunmeSessionDocument{
@@ -123,10 +123,10 @@ func (s *parserServiceServer) Serialize(_ context.Context, req *parserv1.Seriali
 		}
 
 		outputMetadata = &document.RunmeMetadata{
-			Session: document.RunmeMetadataSession{
+			Session: &document.RunmeMetadataSession{
 				ID: req.Options.Session.GetId(),
 			},
-			Document: document.RunmeMetadataDocument{
+			Document: &document.RunmeMetadataDocument{
 				RelativePath: relativePath,
 			},
 		}

--- a/internal/document/editor/editorservice/service_test.go
+++ b/internal/document/editor/editorservice/service_test.go
@@ -99,8 +99,8 @@ func Test_IdentityUnspecified(t *testing.T) {
 			assert.True(t, ok)
 			assert.Len(t, dResp.Notebook.Metadata, 3)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
-			assert.Contains(t, rawFrontmatter, "id: 123\n")
-			assert.Contains(t, rawFrontmatter, "version: v99\n")
+			assert.Contains(t, rawFrontmatter, "id: \"123\"\n")
+			assert.Contains(t, rawFrontmatter, "version: v")
 		} else {
 			assert.False(t, ok)
 			assert.Len(t, dResp.Notebook.Metadata, 2)
@@ -224,7 +224,7 @@ func Test_IdentityCell(t *testing.T) {
 			assert.True(t, ok)
 			assert.Len(t, dResp.Notebook.Metadata, 3)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
-			assert.Contains(t, rawFrontmatter, "id: 123\n")
+			assert.Contains(t, rawFrontmatter, "id: \"123\"\n")
 			assert.Regexp(t, versionRegex, rawFrontmatter, "Wrong version")
 		} else {
 			assert.False(t, ok)
@@ -238,8 +238,8 @@ func Test_IdentityCell(t *testing.T) {
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, content, "runme:\n")
-			assert.Contains(t, content, "id: 123\n")
-			assert.Contains(t, content, "version: v99\n")
+			assert.NotContains(t, content, "id: \"123\"\n")
+			assert.Contains(t, content, "version: v")
 		} else {
 			assert.NotRegexp(t, "^---\n", content)
 			assert.NotRegexp(t, "^\n\n", content)

--- a/internal/document/frontmatter.go
+++ b/internal/document/frontmatter.go
@@ -30,6 +30,14 @@ type RunmeMetadataSession struct {
 	Updated string `yaml:"updated,omitempty" json:"updated,omitempty" toml:"updated,omitempty"`
 }
 
+func (s *RunmeMetadataSession) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return s.ID
+}
+
 type RunmeMetadata struct {
 	ID       string                 `yaml:"id,omitempty" json:"id,omitempty" toml:"id,omitempty"`
 	Version  string                 `yaml:"version,omitempty" json:"version,omitempty" toml:"version,omitempty"`

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -492,7 +492,7 @@ func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
 
-	if f, err := d.Frontmatter(); err == nil && f != nil && !f.Runme.IsEmpty() && f.Runme.Session != nil && f.Runme.Session.ID != "" {
+	if f, err := d.Frontmatter(); err == nil && f != nil && !f.Runme.IsEmpty() && f.Runme.Session.GetID() != "" {
 		return nil, nil
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -492,7 +492,7 @@ func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
 
-	if f, err := d.Frontmatter(); err == nil && f != nil && f.Runme != nil && f.Runme.Session != nil && f.Runme.Session.ID != "" {
+	if f, err := d.Frontmatter(); err == nil && f != nil && !f.Runme.IsEmpty() && f.Runme.Session != nil && f.Runme.Session.ID != "" {
 		return nil, nil
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -492,7 +492,7 @@ func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
 
-	if f, err := d.Frontmatter(); err == nil && f != nil && f.Runme.Session.ID != "" {
+	if f, err := d.Frontmatter(); err == nil && f != nil && f.Runme != nil && f.Runme.Session != nil && f.Runme.Session.ID != "" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Changes to futher relax the requirement that Session Outputs always require document-level lifecycle identity.

1. The lifecycle identity (frontmatter) is a deserialization option. The best way for serialization is to check if lifecycle identity is present.
2. Reduce dependency of the test suite to particular version number. Makes it easier to run when build/test flags are set differently.
3. When JSON frontmatter was being used, the `---` trailer didn't start with a new line. Fixed.