### PR TITLE
Fix intermediate state where newly gen frontmatter wasn't saved yet

### DIFF
--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -88,9 +88,10 @@ First paragraph
 
 		frontmatter, err := doc.Frontmatter()
 		require.NoError(t, err)
-		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
+		marshaledFrontmatter, docID, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
 		require.NoError(t, err)
 		assert.Regexp(t, `---\nkey: value\nrunme:\n  id: .*\n  version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+|\d+)\n---`, string(marshaledFrontmatter))
+		assert.Len(t, docID, 26)
 	})
 
 	t.Run("Format", func(t *testing.T) {

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -88,10 +88,11 @@ First paragraph
 
 		frontmatter, err := doc.Frontmatter()
 		require.NoError(t, err)
-		marshaledFrontmatter, docID, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
+		var docID bytes.Buffer
+		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled(), &docID)
 		require.NoError(t, err)
 		assert.Regexp(t, `---\nkey: value\nrunme:\n  id: .*\n  version: v(?:[3-9]\d*|2\.\d+\.\d+|2\.\d+|\d+)\n---`, string(marshaledFrontmatter))
-		assert.Len(t, docID, 26)
+		assert.Len(t, docID.String(), 26)
 	})
 
 	t.Run("Format", func(t *testing.T) {

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -139,7 +139,7 @@ func Test_IdentityAll(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 2)
+		assert.Len(t, dResp.Notebook.Metadata, 3)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")
@@ -180,7 +180,7 @@ func Test_IdentityDocument(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 2)
+		assert.Len(t, dResp.Notebook.Metadata, 3)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -93,6 +93,7 @@ func Test_IdentityUnspecified(t *testing.T) {
 
 		dResp, err := deserialize(client, tt.content, identity)
 		assert.NoError(t, err)
+		assert.Contains(t, dResp.Notebook.Metadata, "runme.dev/id")
 
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		if tt.hasExtraFrontmatter {
@@ -217,6 +218,7 @@ func Test_IdentityCell(t *testing.T) {
 	for _, tt := range tests {
 		dResp, err := deserialize(client, tt.content, identity)
 		assert.NoError(t, err)
+		assert.Contains(t, dResp.Notebook.Metadata, "runme.dev/id")
 
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 
@@ -268,7 +270,7 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 
 	assert.True(t, ok)
-	assert.Len(t, dResp.Notebook.Metadata, 3)
+	assert.Len(t, dResp.Notebook.Metadata, 2)
 	assert.Contains(t, rawFrontmatter, "prop: value\n")
 	assert.NotContains(t, rawFrontmatter, "id: \"123\"\n")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -292,6 +292,34 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 }
 
+func Test_NewFile_EmptyDocument_WithIdentityAll(t *testing.T) {
+	doc := ""
+
+	identity := parserv1.RunmeIdentity_RUNME_IDENTITY_ALL
+
+	dResp, err := deserialize(client, doc, identity)
+	assert.NoError(t, err)
+
+	rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
+	assert.True(t, ok)
+	assert.Len(t, dResp.Notebook.Metadata, 3)
+	assert.Regexp(t, versionRegex, rawFrontmatter, "Wrong version")
+
+	assert.NotNil(t, dResp.Notebook.Frontmatter)
+	prasedRunmeID := dResp.Notebook.Frontmatter.Runme.Id
+	assert.Contains(t, rawFrontmatter, "id: "+prasedRunmeID+"\n")
+
+	sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+	assert.NoError(t, err)
+
+	content := string(sResp.Result)
+
+	assert.Contains(t, content, "runme:\n")
+	assert.Contains(t, content, "id: "+prasedRunmeID+"\n")
+	assert.Contains(t, content, "version: v")
+	assert.Regexp(t, "^---\n", content)
+}
+
 func Test_parserServiceServer_Ast(t *testing.T) {
 	t.Run("Metadata", func(t *testing.T) {
 		os.Setenv("RUNME_AST_METADATA", "true")

--- a/pkg/document/identity/resolver.go
+++ b/pkg/document/identity/resolver.go
@@ -71,11 +71,6 @@ func (ir *IdentityResolver) DocumentEnabled() bool {
 	return ir.documentIdentity
 }
 
-// EphemeralDocumentID returns a new document ID which is not persisted.
-func (ir *IdentityResolver) EphemeralDocumentID() string {
-	return ulid.GenerateID()
-}
-
 // GetCellID returns a cell ID and a boolean indicating if it's new or from attributes.
 func (ir *IdentityResolver) GetCellID(obj any, attributes map[string]string) (string, bool) {
 	if !ir.cellIdentity {

--- a/pkg/document/identity/resolver.go
+++ b/pkg/document/identity/resolver.go
@@ -73,9 +73,8 @@ func (ir *IdentityResolver) DocumentEnabled() bool {
 
 // GetCellID returns a cell ID and a boolean indicating if it's new or from attributes.
 func (ir *IdentityResolver) GetCellID(obj any, attributes map[string]string) (string, bool) {
-	if !ir.cellIdentity {
-		return "", false
-	}
+	// we used to early return here when !ir.cellIdentity, but we
+	// need cell IDs for the ephemeral case too, ie 'runme.dev/id'
 
 	// todo(sebastian): are invalid ulid's valid IDs?
 	// Check for a valid 'id' in attributes;

--- a/pkg/document/identity/resolver_test.go
+++ b/pkg/document/identity/resolver_test.go
@@ -57,9 +57,4 @@ func TestIdentityResolver(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotEmpty(t, id)
 	})
-
-	t.Run("EphemeralDocumentID", func(t *testing.T) {
-		resolver := NewResolver(DefaultLifecycleIdentity)
-		assert.Len(t, resolver.EphemeralDocumentID(), 26)
-	})
 }

--- a/pkg/document/identity/resolver_test.go
+++ b/pkg/document/identity/resolver_test.go
@@ -46,10 +46,22 @@ func TestIdentityResolver(t *testing.T) {
 		assert.True(t, resolver.DocumentEnabled())
 	})
 
-	t.Run("GetCellID", func(t *testing.T) {
+	t.Run("GetCellID_IdentityRequired", func(t *testing.T) {
 		id := "01HF53Z4RCVPRANKFBZYMS72QW"
 		ulid.MockGenerator(id)
 		resolver := NewResolver(CellLifecycleIdentity)
+		obj := struct{}{}
+		attributes := map[string]string{"id": id}
+		id, ok := resolver.GetCellID(obj, attributes)
+
+		assert.True(t, ok)
+		assert.NotEmpty(t, id)
+	})
+
+	t.Run("GetCellID_IdentityNotRequired", func(t *testing.T) {
+		id := "01J1D6BDDD767E819NV8W7YQC2"
+		ulid.MockGenerator(id)
+		resolver := NewResolver(UnspecifiedLifecycleIdentity)
 		obj := struct{}{}
 		attributes := map[string]string{"id": id}
 		id, ok := resolver.GetCellID(obj, attributes)


### PR DESCRIPTION
Also simplifies logic when document-level lifecycle identity (i.e. doc ID) is turned off.