### PR TITLE
Create machine logs to support AI retraining

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -35,6 +35,7 @@ func serverCmd() *cobra.Command {
 		devMode      bool
 		enableRunner bool
 		tlsDir       string
+		enableAILogs bool
 	)
 
 	cmd := cobra.Command{
@@ -56,7 +57,7 @@ The kernel is used to run long running processes like shells and interacting wit
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger, err := getLogger(devMode)
+			logger, err := getLogger(devMode, enableAILogs)
 			if err != nil {
 				return err
 			}
@@ -133,8 +134,9 @@ The kernel is used to run long running processes like shells and interacting wit
 	cmd.Flags().StringVarP(&addr, "address", "a", defaultAddr, "Address to create unix (unix:///path/to/socket) or IP socket (localhost:7890)")
 	cmd.Flags().BoolVar(&devMode, "dev", false, "Enable development mode")
 	cmd.Flags().BoolVar(&enableRunner, "runner", true, "Enable runner service (legacy, defaults to true)")
+	cmd.Flags().BoolVar(&enableAILogs, "ai-logs", false, "Enable logs to support training an AI")
 	cmd.Flags().StringVar(&tlsDir, "tls", defaultTLSDir, "Directory in which to generate TLS certificates & use for all incoming and outgoing messages")
-
+	cmd.Flags().StringVar(&configDir, configDirF, GetDefaultConfigHome(), "If ai logs is enabled logs will be written to ${config-dir}/logs")
 	_ = cmd.Flags().MarkHidden("runner")
 
 	return &cmd


### PR DESCRIPTION
To support collecting implicit feedback and retraining an AI we need to create machine readable logs that contain the actual command executed.

The design is described in #574.

With this change and ai logs enabled here is what the logs look like.

On the console a sample log message looks like the following

1.716425780157274e+09	info	runner/service.go:233	received initial request	{"_id": "01HYHF5TXWTPV0ZGSQP9WKMZP9", "req": "{\"commands\":[\"ls\"]}"}

In the JSON log we get a log message like the following

{"severity":"info","time":1716425780.157274,"caller":"runner/service.go:233","function":"github.com/stateful/runme/v3/internal/runner.(*runnerService).Execute","message":"received initial request","_id":"01HYHF5TXWTPV0ZGSQP9WKMZP9","req":"{\"commands\":[\"ls\"]}"}

Related to #574