### PR TITLE
Is python3 more likely than python?

### DIFF
--- a/internal/command/command_file_test.go
+++ b/internal/command/command_file_test.go
@@ -31,7 +31,7 @@ func TestFileCommand(t *testing.T) {
 		t.Parallel()
 
 		cfg := &ProgramConfig{
-			ProgramName: "python",
+			ProgramName: "python3",
 			Source: &runnerv2alpha1.ProgramConfig_Script{
 				Script: "print('test')",
 			},


### PR DESCRIPTION
`python` is an alias for `python3` on my BMP which makes the test fail.