### PR TITLE
Disable SONAR scan in PRs created from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,6 @@ jobs:
         run: |
           go build -o runme main.go
           ./runme --version
-      - name: Test All
-        run: |
-          export SHELL=/bin/bash
-          export TZ=UTC
-          make test
-        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test
         run: |
           export SHELL=/bin/bash
@@ -70,10 +64,7 @@ jobs:
           TAGS="test_with_docker" make test/coverage
           make test/coverage/func
         if: ${{ matrix.os == 'ubuntu-latest' }}
-      # make test should run on all os's because
-      # on windows only a subset of the tests run.
       - name: Test
-        # N.B. Set-Timezone is a windows command
         run: |
           Set-Timezone -Id "UTC" -PassThru
           make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           export SHELL=/bin/bash
           export TZ=UTC
-          make test          
+          make test
         if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test
         run: |
@@ -69,15 +69,15 @@ jobs:
           export TZ=UTC
           TAGS="test_with_docker" make test/coverage
           make test/coverage/func
-        if: ${{ matrix.os == 'ubuntu-latest' }}      
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       # make test should run on all os's because
       # on windows only a subset of the tests run.
       - name: Test
-        # N.B. Set-Timezone is a windows command 
+        # N.B. Set-Timezone is a windows command
         run: |
           Set-Timezone -Id "UTC" -PassThru
           make test
-        if: ${{ matrix.os == 'windows-latest' }}        
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         if: ${{github.actor != 'dependabot[bot]' && matrix.os == 'ubuntu-latest'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v2.1.1
+        # Skip this test if the PR is created from a fork.
+        # If its created from a fork the PR won't be able to fetch the secrets so
+        # the step will fail.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,12 @@ jobs:
           TAGS="test_with_docker" make test/coverage
           make test/coverage/func
         if: ${{ matrix.os == 'ubuntu-latest' }}
+      # make test should run on all os's because
+      # on windows only a subset of the tests run.
       - name: Test
         run: |
           Set-Timezone -Id "UTC" -PassThru
-          make test
-        if: ${{ matrix.os == 'windows-latest' }}
+          make test        
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         if: ${{github.actor != 'dependabot[bot]' && matrix.os == 'ubuntu-latest'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,27 @@ jobs:
         run: |
           go build -o runme main.go
           ./runme --version
+      - name: Test All
+        run: |
+          export SHELL=/bin/bash
+          export TZ=UTC
+          make test          
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Test
         run: |
           export SHELL=/bin/bash
           export TZ=UTC
           TAGS="test_with_docker" make test/coverage
           make test/coverage/func
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}      
       # make test should run on all os's because
       # on windows only a subset of the tests run.
       - name: Test
+        # N.B. Set-Timezone is a windows command 
         run: |
           Set-Timezone -Id "UTC" -PassThru
-          make test        
+          make test
+        if: ${{ matrix.os == 'windows-latest' }}        
       - name: Upload coverage
         uses: actions/upload-artifact@v4
         if: ${{github.actor != 'dependabot[bot]' && matrix.os == 'ubuntu-latest'}}

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -347,7 +347,7 @@ func Test_runnerService(t *testing.T) {
 	})
 
 	t.Run("Input", func(t *testing.T) {
-		if os.Getenv("RUN_FLAKY") == "" {
+		if skip, err := strconv.ParseBool(os.Getenv("SKIP_FLAKY")); err == nil && skip {
 			t.Skip("skipping flaky test")
 		}
 		t.Parallel()

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -347,6 +347,9 @@ func Test_runnerService(t *testing.T) {
 	})
 
 	t.Run("Input", func(t *testing.T) {
+		if os.Getenv("RUN_FLAKY") == "" {
+			t.Skip("skipping flaky test")
+		}
 		t.Parallel()
 
 		stream, err := client.Execute(context.Background())


### PR DESCRIPTION
* Disable the SONAR scan in PRs created from forks. It won't be able to run because the GHA can't get the secrets for PRs created from a fork.
  * The failure creates noise in various dashboards because we see the red "x" by the PR.


~~* A lot of unittests aren't running on CI because the GHA currently ~~

~~  * Runs all tests but only on windows and a bunch of tests have the build tag !windows~~
~~  * On docker ubuntu only the tests with the dag docker ubuntu run~~

~~* The fix is to add a GHA step that runs `make test` to run on all OSS~~
~~  * This rule doesn't use any build tags so it will run all tests.~~
~~Related to #587~~

* Mark some locally flaky tests to be skipped

