### PR TITLE
Simplify `commandFactory.buildVirtual`

### DIFF
--- a/internal/command/command_virtual.go
+++ b/internal/command/command_virtual.go
@@ -49,6 +49,10 @@ func (c *virtualCommand) Pid() int {
 	return c.cmd.Process.Pid
 }
 
+func (c *virtualCommand) Stdin() io.Reader {
+	return c.stdin
+}
+
 func (c *virtualCommand) Start(ctx context.Context) (err error) {
 	c.pty, c.tty, err = pty.Open()
 	if err != nil {

--- a/internal/command/factory.go
+++ b/internal/command/factory.go
@@ -173,12 +173,9 @@ func (f *commandFactory) buildNative(base *base) internalCommand {
 
 func (f *commandFactory) buildVirtual(base *base, opts CommandOptions) internalCommand {
 	var stdin io.ReadCloser
-
-	if !isNil(base.Stdin()) {
-		stdin = &readCloser{r: base.Stdin(), done: make(chan struct{})}
-		base.stdin = stdin
+	if in := base.Stdin(); !isNil(in) {
+		stdin = &readCloser{r: in, done: make(chan struct{})}
 	}
-
 	return &virtualCommand{
 		base:          base,
 		isEchoEnabled: opts.EnableEcho,


### PR DESCRIPTION
In the case of `virtualCommand`, `stdin` is wrapped in `readCloser` and it should be returned to any other struct that depends on `virtualCommand`. `base.stdin` should stay unchanged.