### PR TITLE
Fail gracefully if remote runner connection info is unreliable

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	fProject               string
 	fProjectIgnorePatterns []string
 	fRespectGitignore      bool
+	fSkipRunnerFallback    bool
 	fInsecure              bool
 	fLogEnabled            bool
 	fLogFilePath           string
@@ -53,6 +54,9 @@ func Root() *cobra.Command {
 			if envProject, ok := os.LookupEnv("RUNME_PROJECT"); ok {
 				fProject = envProject
 			}
+
+			// if insecure is explicitly set irrespective of its value, skip runner fallback
+			fSkipRunnerFallback = !cmd.Flags().Changed("insecure")
 
 			fFileMode = cmd.Flags().Changed("chdir") || cmd.Flags().Changed("filename")
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -181,7 +181,7 @@ func runCmd() *cobra.Command {
 				client.WrapWithCancelReader(),
 			}
 
-			runner, err := client.New(cmd.Context(), serverAddr, runnerOpts)
+			runner, err := client.New(cmd.Context(), serverAddr, fSkipRunnerFallback, runnerOpts)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -181,26 +181,9 @@ func runCmd() *cobra.Command {
 				client.WrapWithCancelReader(),
 			}
 
-			var runner client.Runner
-
-			if serverAddr == "" {
-				localRunner, err := client.NewLocalRunner(runnerOpts...)
-				if err != nil {
-					return err
-				}
-
-				runner = localRunner
-			} else {
-				remoteRunner, err := client.NewRemoteRunner(
-					cmd.Context(),
-					serverAddr,
-					runnerOpts...,
-				)
-				if err != nil {
-					return err
-				}
-
-				runner = remoteRunner
+			runner, err := client.New(cmd.Context(), serverAddr, runnerOpts)
+			if err != nil {
+				return err
 			}
 
 			for _, task := range runTasks {

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -99,26 +99,9 @@ func tuiCmd() *cobra.Command {
 				client.WithProject(proj),
 			)
 
-			if serverAddr != "" {
-				remoteRunner, err := client.NewRemoteRunner(
-					cmd.Context(),
-					serverAddr,
-					runnerOpts...,
-				)
-				if err != nil {
-					return errors.Wrap(err, "failed to create remote runner")
-				}
-
-				runnerClient = remoteRunner
-			} else {
-				localRunner, err := client.NewLocalRunner(
-					runnerOpts...,
-				)
-				if err != nil {
-					return errors.Wrap(err, "failed to create local runner")
-				}
-
-				runnerClient = localRunner
+			runnerClient, err = client.New(cmd.Context(), serverAddr, runnerOpts)
+			if err != nil {
+				return errors.Wrap(err, "failed to create local runner")
 			}
 
 			model := tuiModel{

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -99,7 +99,7 @@ func tuiCmd() *cobra.Command {
 				client.WithProject(proj),
 			)
 
-			runnerClient, err = client.New(cmd.Context(), serverAddr, runnerOpts)
+			runnerClient, err = client.New(cmd.Context(), serverAddr, fSkipRunnerFallback, runnerOpts)
 			if err != nil {
 				return errors.Wrap(err, "failed to create local runner")
 			}

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -68,6 +68,36 @@ type Runner interface {
 	setSettings(settings *RunnerSettings)
 }
 
+func New(context context.Context, serverAddr string, runnerOpts []RunnerOption) (Runner, error) {
+	if serverAddr != "" {
+		// check if serverAddr points at a healthy server
+		healthy, err := isServerHealthy(context, serverAddr, runnerOpts)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to check health")
+		}
+
+		if healthy {
+			remoteRunner, err := NewRemoteRunner(
+				context,
+				serverAddr,
+				runnerOpts...,
+			)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create local runner")
+			}
+
+			return remoteRunner, nil
+		}
+	}
+
+	localRunner, err := NewLocalRunner(runnerOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create remote runner")
+	}
+
+	return localRunner, nil
+}
+
 func withSettings(applySettings func(settings *RunnerSettings)) RunnerOption {
 	return withSettingsErr(func(settings *RunnerSettings) error {
 		applySettings(settings)

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -58,6 +58,12 @@ exec runme run hello-python
 stdout 'Hello from Python'
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
+env RUNME_SERVER_ADDR="123.0.0.9:12345"
+exec runme run hello-python
+stdout 'Hello from Python'
+! stderr .
+
 -- README.md --
 ---
 runme:

--- a/testdata/script/basic.txtar
+++ b/testdata/script/basic.txtar
@@ -64,6 +64,12 @@ exec runme run hello-python
 stdout 'Hello from Python'
 ! stderr .
 
+env PATH=/opt/homebrew/bin:$PATH
+env RUNME_TLS_DIR=/tmp/invalid/tls
+! exec runme run --insecure=false hello-python
+! stdout .
+stderr 'could not execute command: failed to create remote runner: open /tmp/invalid/tls/cert.pem: no such file or directory'
+
 -- README.md --
 ---
 runme:


### PR DESCRIPTION
Unless any `--insecure`/`--insecure=false`/`--insecure=true` is explicitly set.

There is an edge case when VS Code resumes previously persisted terminal sessions upon loading which shows an ugly error if the server is now no longer running under the previously specified socket. In this case, it's better UX to gracefully fall back to a local runner.

PS: Stopped short of addressing gRPC upstream deprecations. Would like to tackle them as part of moving to `runme beta` cmds.