### PR TITLE
Delete `make docker` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,9 +156,3 @@ update-gql-schema:
 .PHONY: generate
 generate:
 	go generate ./...
-
-.PHONY: docker
-docker:
-	CGO_ENABLED=0 make build
-	docker build -f docker/alpine.Dockerfile . -t runme:alpine
-	docker build -f docker/ubuntu.Dockerfile . -t runme:ubuntu

--- a/Makefile
+++ b/Makefile
@@ -160,5 +160,5 @@ generate:
 .PHONY: docker
 docker:
 	CGO_ENABLED=0 make build
-	docker build -f docker/Dockerfile.alpine . -t runme:alpine
-	docker build -f docker/Dockerfile.ubuntu . -t runme:ubuntu
+	docker build -f docker/alpine.Dockerfile . -t runme:alpine
+	docker build -f docker/ubuntu.Dockerfile . -t runme:ubuntu

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -40,7 +40,8 @@ func TestExtractDataFromLoadEvent(t *testing.T) {
 }
 
 func TestNewDirProject(t *testing.T) {
-	testData := teststub.Setup(t, t.TempDir())
+	temp := t.TempDir()
+	testData := teststub.Setup(t, temp)
 
 	t.Run("ProperDirProject", func(t *testing.T) {
 		_, err := NewDirProject(testData.DirProjectPath())
@@ -135,6 +136,7 @@ func TestProjectRoot(t *testing.T) {
 func TestProjectLoad(t *testing.T) {
 	temp := t.TempDir()
 	testData := teststub.Setup(t, temp)
+
 	gitProjectDir := testData.GitProjectPath()
 
 	t.Run("GitProject", func(t *testing.T) {

--- a/internal/project/teststub/teststub.go
+++ b/internal/project/teststub/teststub.go
@@ -15,6 +15,7 @@ func Setup(t *testing.T, temp string) Path {
 
 	testDataSrc := originalTestDataPath()
 	require.NoError(t, copy.Copy(testDataSrc, temp))
+	Cleanup(t, temp)
 
 	err := os.Rename(
 		filepath.Join(temp, "git-project", ".git.bkp"),
@@ -35,6 +36,13 @@ func Setup(t *testing.T, temp string) Path {
 	require.NoError(t, err)
 
 	return Path{root: temp}
+}
+
+func Cleanup(t *testing.T, temp string) {
+	t.Helper()
+
+	err := os.RemoveAll(filepath.Join(temp, "git-project", ".git"))
+	require.NoError(t, err)
 }
 
 func OriginalPath() Path {


### PR DESCRIPTION
During a setup on a new machine, I noticed the command `make docker` was not working due to a path issue.

@adambabik I was wondering if it's still needed. is it?.


Trying to solve this issue on Linux:

![image](https://github.com/stateful/runme/assets/43882/ef7dfb39-808f-4a56-a370-0ba5b9172bdd)
