### PR TITLE
Increase max msg size to 100 MiB

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -97,7 +97,7 @@ The kernel is used to run long running processes like shells and interacting wit
 
 			logger.Info("started listening", zap.String("addr", lis.Addr().String()))
 
-			const maxMsgSize = 4 * 1024 * 1024 // 4 MiB
+			const maxMsgSize = 100 * 1024 * 1024 // 100 MiB
 
 			server := grpc.NewServer(
 				grpc.MaxRecvMsgSize(maxMsgSize),

--- a/internal/runner/service_test.go
+++ b/internal/runner/service_test.go
@@ -1083,7 +1083,6 @@ func Test_runnerService(t *testing.T) {
 	})
 
 	t.Run("ExecuteStoreLastOutput", func(t *testing.T) {
-		t.Parallel()
 		s, err := client.CreateSession(context.Background(), &runnerv1.CreateSessionRequest{})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Sessions Output documents can get quite large. 4 MiB isn't enough.