### PR TITLE
Fix 1455 and retain invalid frontmatter over failing/overwriting

### DIFF
--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -72,6 +72,10 @@ func fmtCmd() *cobra.Command {
 type funcOutput func(string, []byte) error
 
 func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputter funcOutput) error {
+	logger, err := getLogger(false, false)
+	if err != nil {
+		return err
+	}
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 
 	for _, file := range files {
@@ -83,7 +87,7 @@ func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputt
 		var formatted []byte
 
 		if flatten {
-			notebook, err := editor.Deserialize(data, identityResolver)
+			notebook, err := editor.Deserialize(logger, data, identityResolver)
 			if err != nil {
 				return errors.Wrap(err, "failed to deserialize")
 			}
@@ -97,7 +101,7 @@ func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputt
 				}
 				formatted = buf.Bytes()
 			} else {
-				formatted, err = editor.Serialize(notebook, nil)
+				formatted, err = editor.Serialize(logger, notebook, nil)
 				if err != nil {
 					return errors.Wrap(err, "failed to serialize")
 				}

--- a/internal/cmd/fmt.go
+++ b/internal/cmd/fmt.go
@@ -87,7 +87,7 @@ func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputt
 		var formatted []byte
 
 		if flatten {
-			notebook, err := editor.Deserialize(logger, data, identityResolver)
+			notebook, err := editor.Deserialize(data, editor.Options{LoggerInstance: logger, IdentityResolver: identityResolver})
 			if err != nil {
 				return errors.Wrap(err, "failed to deserialize")
 			}
@@ -101,7 +101,7 @@ func fmtFiles(files []string, flatten bool, formatJSON bool, write bool, outputt
 				}
 				formatted = buf.Bytes()
 			} else {
-				formatted, err = editor.Serialize(logger, notebook, nil)
+				formatted, err = editor.Serialize(notebook, nil, editor.Options{LoggerInstance: logger})
 				if err != nil {
 					return errors.Wrap(err, "failed to serialize")
 				}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -101,7 +101,7 @@ func runCmd() *cobra.Command {
 						// Check if the block matches any of the specified categories
 						if len(cmdCategories) > 0 {
 							blockCategories := block.Categories()
-							fm, _ := block.Document().Frontmatter()
+							fm := block.Document().Frontmatter()
 							fmCategories := resolveFrontmatterCategories(fm)
 							match := false
 							if len(fmCategories) > 0 && containsCategories(fmCategories, cmdCategories) {
@@ -187,7 +187,11 @@ func runCmd() *cobra.Command {
 			}
 
 			for _, task := range runTasks {
-				fmtr, err := task.CodeBlock.Document().Frontmatter()
+				doc := task.CodeBlock.Document()
+				if err := doc.FrontmatterError(); err != nil {
+					return err
+				}
+				fmtr := doc.Frontmatter()
 				if err != nil {
 					return err
 				}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -188,11 +188,8 @@ func runCmd() *cobra.Command {
 
 			for _, task := range runTasks {
 				doc := task.CodeBlock.Document()
-				if err := doc.FrontmatterError(); err != nil {
-					return err
-				}
 				fmtr := doc.Frontmatter()
-				if err != nil {
+				if err := doc.FrontmatterError(); err != nil {
 					return err
 				}
 				if fmtr != nil && fmtr.SkipPrompts {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -188,8 +188,8 @@ func runCmd() *cobra.Command {
 
 			for _, task := range runTasks {
 				doc := task.CodeBlock.Document()
-				fmtr := doc.Frontmatter()
-				if err := doc.FrontmatterError(); err != nil {
+				fmtr, err := doc.FrontmatterWithError()
+				if err != nil {
 					return err
 				}
 				if fmtr != nil && fmtr.SkipPrompts {

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -139,10 +139,11 @@ func tuiCmd() *cobra.Command {
 
 				task := result.task
 
-				fmtr, err := task.CodeBlock.Document().Frontmatter()
-				if err != nil {
+				doc := task.CodeBlock.Document()
+				if err := doc.FrontmatterError(); err != nil {
 					return err
 				}
+				fmtr := doc.Frontmatter()
 
 				if fmtr != nil && !fmtr.SkipPrompts {
 					err = promptEnvVars(cmd, runnerClient, task)

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -140,10 +140,10 @@ func tuiCmd() *cobra.Command {
 				task := result.task
 
 				doc := task.CodeBlock.Document()
-				if err := doc.FrontmatterError(); err != nil {
+				fmtr, err := doc.FrontmatterWithError()
+				if err != nil {
 					return err
 				}
-				fmtr := doc.Frontmatter()
 
 				if fmtr != nil && !fmtr.SkipPrompts {
 					err = promptEnvVars(cmd, runnerClient, task)

--- a/internal/command/config_code_block.go
+++ b/internal/command/config_code_block.go
@@ -46,8 +46,7 @@ func (b *configBuilder) dir() string {
 	var dirs []string
 
 	doc := b.block.Document()
-	err := doc.FrontmatterError()
-	fmtr := doc.Frontmatter()
+	fmtr, err := doc.FrontmatterWithError()
 	if err == nil && fmtr != nil && fmtr.Cwd != "" {
 		dirs = append(dirs, fmtr.Cwd)
 	}
@@ -70,8 +69,7 @@ func (b *configBuilder) programPath() (programPath string) {
 	// If the language is a shell language, check frontmatter for shell overwrite.
 	if isShellLanguage(language) {
 		doc := b.block.Document()
-		fmtr := doc.Frontmatter()
-		err := doc.FrontmatterError()
+		fmtr, err := doc.FrontmatterWithError()
 		if err == nil && fmtr != nil && fmtr.Shell != "" {
 			programPath = fmtr.Shell
 		}

--- a/internal/command/config_code_block.go
+++ b/internal/command/config_code_block.go
@@ -45,7 +45,9 @@ func (b *configBuilder) Build() (*ProgramConfig, error) {
 func (b *configBuilder) dir() string {
 	var dirs []string
 
-	fmtr, err := b.block.Document().Frontmatter()
+	doc := b.block.Document()
+	err := doc.FrontmatterError()
+	fmtr := doc.Frontmatter()
 	if err == nil && fmtr != nil && fmtr.Cwd != "" {
 		dirs = append(dirs, fmtr.Cwd)
 	}
@@ -67,7 +69,9 @@ func (b *configBuilder) programPath() (programPath string) {
 
 	// If the language is a shell language, check frontmatter for shell overwrite.
 	if isShellLanguage(language) {
-		fmtr, err := b.block.Document().Frontmatter()
+		doc := b.block.Document()
+		fmtr := doc.Frontmatter()
+		err := doc.FrontmatterError()
 		if err == nil && fmtr != nil && fmtr.Shell != "" {
 			programPath = fmtr.Shell
 		}

--- a/internal/config/autoconfig/autoconfig.go
+++ b/internal/config/autoconfig/autoconfig.go
@@ -186,10 +186,12 @@ func getProjectFilters(c *config.Config) ([]project.Filter, error) {
 			}))
 		case config.FilterTypeDocument:
 			filters = append(filters, project.Filter(func(t project.Task) (bool, error) {
-				fmtr, err := t.CodeBlock.Document().Frontmatter()
+				doc := t.CodeBlock.Document()
+				err := doc.FrontmatterError()
 				if err != nil {
 					return false, err
 				}
+				fmtr := doc.Frontmatter()
 				if fmtr == nil {
 					return false, nil
 				}

--- a/internal/config/autoconfig/autoconfig.go
+++ b/internal/config/autoconfig/autoconfig.go
@@ -187,11 +187,10 @@ func getProjectFilters(c *config.Config) ([]project.Filter, error) {
 		case config.FilterTypeDocument:
 			filters = append(filters, project.Filter(func(t project.Task) (bool, error) {
 				doc := t.CodeBlock.Document()
-				err := doc.FrontmatterError()
+				fmtr, err := doc.FrontmatterWithError()
 				if err != nil {
 					return false, err
 				}
-				fmtr := doc.Frontmatter()
 				if fmtr == nil {
 					return false, nil
 				}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -491,10 +491,9 @@ func getCodeBlocksFromFile(path string) (document.CodeBlocks, error) {
 func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
-	fm := d.Frontmatter()
-	err := d.FrontmatterError()
+	fmtr, err := d.FrontmatterWithError()
 
-	if err == nil && fm != nil && !fm.Runme.IsEmpty() && fm.Runme.Session.GetID() != "" {
+	if err == nil && fmtr != nil && !fmtr.Runme.IsEmpty() && fmtr.Runme.Session.GetID() != "" {
 		return nil, nil
 	}
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -491,8 +491,10 @@ func getCodeBlocksFromFile(path string) (document.CodeBlocks, error) {
 func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 	d := document.New(data, identityResolver)
+	fm := d.Frontmatter()
+	err := d.FrontmatterError()
 
-	if f, err := d.Frontmatter(); err == nil && f != nil && !f.Runme.IsEmpty() && f.Runme.Session.GetID() != "" {
+	if err == nil && fm != nil && !fm.Runme.IsEmpty() && fm.Runme.Session.GetID() != "" {
 		return nil, nil
 	}
 

--- a/internal/runner/client/client.go
+++ b/internal/runner/client/client.go
@@ -277,7 +277,8 @@ func WrapWithCancelReader() RunnerOption {
 
 func ResolveDirectory(parentDir string, task project.Task) string {
 	// TODO(adamb): consider handling this error or add a comment it can be skipped.
-	fmtr, _ := task.CodeBlock.Document().Frontmatter()
+	doc := task.CodeBlock.Document()
+	fmtr := doc.Frontmatter()
 	if fmtr == nil {
 		fmtr = &document.Frontmatter{}
 	}

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -88,7 +88,9 @@ func (r *LocalRunner) setupSession() error {
 
 func (r *LocalRunner) newExecutable(task project.Task) (runner.Executable, error) {
 	block := task.CodeBlock
-	fmtr, err := task.CodeBlock.Document().Frontmatter()
+	doc := task.CodeBlock.Document()
+	fmtr := doc.Frontmatter()
+	err := doc.FrontmatterError()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/client/client_local.go
+++ b/internal/runner/client/client_local.go
@@ -89,8 +89,7 @@ func (r *LocalRunner) setupSession() error {
 func (r *LocalRunner) newExecutable(task project.Task) (runner.Executable, error) {
 	block := task.CodeBlock
 	doc := task.CodeBlock.Document()
-	fmtr := doc.Frontmatter()
-	err := doc.FrontmatterError()
+	fmtr, err := doc.FrontmatterWithError()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -182,8 +182,7 @@ func (r *RemoteRunner) ResolveProgram(ctx context.Context, mode runnerv1.Resolve
 func (r *RemoteRunner) RunTask(ctx context.Context, task project.Task) error {
 	block := task.CodeBlock
 	doc := task.CodeBlock.Document()
-	fmtr := doc.Frontmatter()
-	err := doc.FrontmatterError()
+	fmtr, err := doc.FrontmatterWithError()
 	if err != nil {
 		return err
 	}

--- a/internal/runner/client/client_remote.go
+++ b/internal/runner/client/client_remote.go
@@ -181,7 +181,9 @@ func (r *RemoteRunner) ResolveProgram(ctx context.Context, mode runnerv1.Resolve
 
 func (r *RemoteRunner) RunTask(ctx context.Context, task project.Task) error {
 	block := task.CodeBlock
-	fmtr, err := task.CodeBlock.Document().Frontmatter()
+	doc := task.CodeBlock.Document()
+	fmtr := doc.Frontmatter()
+	err := doc.FrontmatterError()
 	if err != nil {
 		return err
 	}

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -116,6 +116,10 @@ func (d *Document) splitAndParse() error {
 	return nil
 }
 
+func (d *Document) FrontMatterRaw() []byte {
+	return d.frontmatterRaw
+}
+
 // splitSource splits source into FrontMatter and content.
 // TODO(adamb): replace it with an extension to goldmark.
 // Example: https://github.com/abhinav/goldmark-frontmatter

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -116,7 +116,7 @@ func (d *Document) splitAndParse() error {
 	return nil
 }
 
-func (d *Document) FrontMatterRaw() []byte {
+func (d *Document) FrontmatterRaw() []byte {
 	return d.frontmatterRaw
 }
 

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -86,7 +86,8 @@ First paragraph
 		assert.Equal(t, []byte("First paragraph"), doc.Content())
 		assert.Equal(t, 20, doc.ContentOffset())
 
-		frontmatter, err := doc.Frontmatter()
+		frontmatter := doc.Frontmatter()
+		err = doc.FrontmatterError()
 		require.NoError(t, err)
 		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
 		require.NoError(t, err)
@@ -141,7 +142,8 @@ shell = "fish"
 				_, err := doc.Root()
 				require.NoError(t, err)
 
-				frontmatter, err := doc.Frontmatter()
+				frontmatter := doc.Frontmatter()
+				err = doc.FrontmatterError()
 				assert.NoError(t, err)
 				assert.Equal(t, "fish", frontmatter.Shell)
 			})
@@ -162,7 +164,8 @@ shell = "fish"
 		err := doc.Parse()
 		require.NoError(t, err)
 
-		frontmatter, err := doc.Frontmatter()
+		frontmatter := doc.Frontmatter()
+		err = doc.FrontmatterError()
 		assert.ErrorContains(t, err, "failed to parse frontmatter content: yaml: line 3: found unexpected end of stream")
 		assert.Nil(t, frontmatter)
 	})

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -86,8 +86,7 @@ First paragraph
 		assert.Equal(t, []byte("First paragraph"), doc.Content())
 		assert.Equal(t, 20, doc.ContentOffset())
 
-		frontmatter := doc.Frontmatter()
-		err = doc.FrontmatterError()
+		frontmatter, err := doc.FrontmatterWithError()
 		require.NoError(t, err)
 		marshaledFrontmatter, err := frontmatter.Marshal(testIdentityResolver.DocumentEnabled())
 		require.NoError(t, err)
@@ -142,8 +141,7 @@ shell = "fish"
 				_, err := doc.Root()
 				require.NoError(t, err)
 
-				frontmatter := doc.Frontmatter()
-				err = doc.FrontmatterError()
+				frontmatter, err := doc.FrontmatterWithError()
 				assert.NoError(t, err)
 				assert.Equal(t, "fish", frontmatter.Shell)
 			})
@@ -164,8 +162,7 @@ shell = "fish"
 		err := doc.Parse()
 		require.NoError(t, err)
 
-		frontmatter := doc.Frontmatter()
-		err = doc.FrontmatterError()
+		frontmatter, err := doc.FrontmatterWithError()
 		assert.ErrorContains(t, err, "failed to parse frontmatter content: yaml: line 3: found unexpected end of stream")
 		assert.Nil(t, frontmatter)
 	})

--- a/pkg/document/editor/editor.go
+++ b/pkg/document/editor/editor.go
@@ -18,19 +18,30 @@ const (
 	DocumentID     = "id"
 )
 
-func Deserialize(log *zap.Logger, data []byte, identityResolver *identity.IdentityResolver) (*Notebook, error) {
+type Options struct {
+	IdentityResolver *identity.IdentityResolver
+	LoggerInstance   *zap.Logger
+}
+
+func (o Options) Logger() *zap.Logger {
+	if o.LoggerInstance == nil {
+		o.LoggerInstance = zap.NewNop()
+	}
+	return o.LoggerInstance
+}
+
+func Deserialize(data []byte, opts Options) (*Notebook, error) {
 	// Deserialize content to cells.
-	doc := document.New(data, identityResolver)
+	doc := document.New(data, opts.IdentityResolver)
 	node, err := doc.Root()
 	if err != nil {
 		return nil, err
 	}
 
-	frontmatter := doc.Frontmatter()
-	fmErr := doc.FrontmatterError()
+	frontmatter, fmErr := doc.FrontmatterWithError()
 	// non-fatal error
 	if fmErr != nil {
-		log.Warn("failed to parse frontmatter", zap.Error(fmErr))
+		opts.Logger().Warn("failed to parse frontmatter", zap.Error(fmErr))
 	}
 
 	notebook := &Notebook{
@@ -43,23 +54,23 @@ func Deserialize(log *zap.Logger, data []byte, identityResolver *identity.Identi
 
 	// Additionally, put raw frontmatter in notebook's metadata, no matter invalid or valid
 	// TODO(adamb): handle the error.
-	if raw, err := frontmatter.Marshal(identityResolver.DocumentEnabled()); err == nil && len(raw) > 0 {
+	if raw, err := frontmatter.Marshal(opts.IdentityResolver.DocumentEnabled()); err == nil && len(raw) > 0 {
 		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)] = string(raw)
 	}
 	// if parsing frontmatter failed put unparsed frontmatter in notebook's metadata to avoid earsing it with "default frontmatter"
-	if raw := doc.FrontMatterRaw(); fmErr != nil && len(raw) > 0 {
+	if raw := doc.FrontmatterRaw(); fmErr != nil && len(raw) > 0 {
 		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)] = string(raw)
 	}
 
 	// Store internal ephemeral document ID if the document lifecycle ID is disabled.
-	if !identityResolver.DocumentEnabled() {
-		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, DocumentID)] = identityResolver.EphemeralDocumentID()
+	if !opts.IdentityResolver.DocumentEnabled() {
+		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, DocumentID)] = opts.IdentityResolver.EphemeralDocumentID()
 	}
 
 	return notebook, nil
 }
 
-func Serialize(log *zap.Logger, notebook *Notebook, outputMetadata *document.RunmeMetadata) ([]byte, error) {
+func Serialize(notebook *Notebook, outputMetadata *document.RunmeMetadata, opts Options) ([]byte, error) {
 	var result []byte
 	var err error
 	var frontmatter *document.Frontmatter
@@ -72,7 +83,7 @@ func Serialize(log *zap.Logger, notebook *Notebook, outputMetadata *document.Run
 		frontmatter, err = document.ParseFrontmatter(raw)
 		// non-fatal error
 		if err != nil {
-			log.Warn("failed to parse frontmatter", zap.Error(err))
+			opts.Logger().Warn("failed to parse frontmatter", zap.Error(err))
 		}
 	}
 

--- a/pkg/document/editor/editor_test.go
+++ b/pkg/document/editor/editor_test.go
@@ -197,6 +197,49 @@ A paragraph
 	)
 }
 
+func TestEditor_FrontmatterWithoutRunme(t *testing.T) {
+	data := []byte(`+++
+prop1 = 'val1'
+prop2 = 'val2'
++++
+
+# Example
+
+A paragraph
+`)
+	notebook, err := Deserialize(data, identityResolverNone)
+	require.NoError(t, err)
+	result, err := Serialize(notebook, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		string(data),
+		string(result),
+	)
+}
+
+func TestEditor_RetainInvalidFrontmatter(t *testing.T) {
+	data := []byte(`+++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++
+
+# Example
+
+A paragraph
+`)
+	notebook, err := Deserialize(data, identityResolverNone)
+	require.NoError(t, err)
+	result, err := Serialize(notebook, nil)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		string(data),
+		string(result),
+	)
+}
+
 func TestEditor_SessionOutput(t *testing.T) {
 	data := []byte(fmt.Sprintf(`+++
 prop1 = 'val1'

--- a/pkg/document/editor/editorservice/service.go
+++ b/pkg/document/editor/editorservice/service.go
@@ -27,7 +27,7 @@ func (s *parserServiceServer) Deserialize(_ context.Context, req *parserv1.Deser
 	s.logger.Info("Deserialize", zap.ByteString("source", req.Source[:min(len(req.Source), 64)]))
 
 	identityResolver := identity.NewResolver(fromProtoDeserializeReqOptionsToLifecycleIdentity(req.Options))
-	notebook, err := editor.Deserialize(s.logger, req.Source, identityResolver)
+	notebook, err := editor.Deserialize(req.Source, editor.Options{LoggerInstance: s.logger, IdentityResolver: identityResolver})
 	if err != nil {
 		s.logger.Info("failed to call Deserialize", zap.Error(err))
 		return nil, err
@@ -135,11 +135,10 @@ func (s *parserServiceServer) Serialize(_ context.Context, req *parserv1.Seriali
 
 	}
 
-	data, err := editor.Serialize(s.logger,
-		&editor.Notebook{
-			Cells:    cells,
-			Metadata: req.Notebook.Metadata,
-		}, outputMetadata)
+	data, err := editor.Serialize(&editor.Notebook{
+		Cells:    cells,
+		Metadata: req.Notebook.Metadata,
+	}, outputMetadata, editor.Options{LoggerInstance: s.logger})
 	if err != nil {
 		s.logger.Info("failed to call Serialize", zap.Error(err))
 		return nil, err

--- a/pkg/document/editor/editorservice/service.go
+++ b/pkg/document/editor/editorservice/service.go
@@ -27,7 +27,7 @@ func (s *parserServiceServer) Deserialize(_ context.Context, req *parserv1.Deser
 	s.logger.Info("Deserialize", zap.ByteString("source", req.Source[:min(len(req.Source), 64)]))
 
 	identityResolver := identity.NewResolver(fromProtoDeserializeReqOptionsToLifecycleIdentity(req.Options))
-	notebook, err := editor.Deserialize(req.Source, identityResolver)
+	notebook, err := editor.Deserialize(s.logger, req.Source, identityResolver)
 	if err != nil {
 		s.logger.Info("failed to call Deserialize", zap.Error(err))
 		return nil, err
@@ -135,10 +135,11 @@ func (s *parserServiceServer) Serialize(_ context.Context, req *parserv1.Seriali
 
 	}
 
-	data, err := editor.Serialize(&editor.Notebook{
-		Cells:    cells,
-		Metadata: req.Notebook.Metadata,
-	}, outputMetadata)
+	data, err := editor.Serialize(s.logger,
+		&editor.Notebook{
+			Cells:    cells,
+			Metadata: req.Notebook.Metadata,
+		}, outputMetadata)
 	if err != nil {
 		s.logger.Info("failed to call Serialize", zap.Error(err))
 		return nil, err

--- a/pkg/document/frontmatter.go
+++ b/pkg/document/frontmatter.go
@@ -190,16 +190,18 @@ func (d *Document) Frontmatter() *Frontmatter {
 	return d.frontmatter
 }
 
-func (d *Document) FrontmatterError() error {
+func (d *Document) FrontmatterWithError() (*Frontmatter, error) {
+	fmtr := d.Frontmatter()
+
 	if d.splitSourceErr != nil {
-		return d.splitSourceErr
+		return nil, d.splitSourceErr
 	}
 
 	if d.parseFrontmatterErr != nil {
-		return d.parseFrontmatterErr
+		return nil, d.parseFrontmatterErr
 	}
 
-	return nil
+	return fmtr, nil
 }
 
 func (d *Document) parseFrontmatter() {

--- a/pkg/document/frontmatter.go
+++ b/pkg/document/frontmatter.go
@@ -182,20 +182,24 @@ func (f *Frontmatter) ensureID() {
 	}
 }
 
-func (d *Document) Frontmatter() (*Frontmatter, error) {
+func (d *Document) Frontmatter() *Frontmatter {
 	d.splitSource()
-
-	if d.splitSourceErr != nil {
-		return nil, d.splitSourceErr
-	}
 
 	d.parseFrontmatter()
 
-	if d.parseFrontmatterErr != nil {
-		return nil, d.parseFrontmatterErr
+	return d.frontmatter
+}
+
+func (d *Document) FrontmatterError() error {
+	if d.splitSourceErr != nil {
+		return d.splitSourceErr
 	}
 
-	return d.frontmatter, nil
+	if d.parseFrontmatterErr != nil {
+		return d.parseFrontmatterErr
+	}
+
+	return nil
 }
 
 func (d *Document) parseFrontmatter() {

--- a/pkg/project/formatter.go
+++ b/pkg/project/formatter.go
@@ -15,11 +15,14 @@ import (
 	"github.com/stateful/runme/v3/pkg/document"
 	"github.com/stateful/runme/v3/pkg/document/editor"
 	"github.com/stateful/runme/v3/pkg/document/identity"
+	"go.uber.org/zap"
 )
 
 type funcOutput func(string, []byte) error
 
 func Format(files []string, basePath string, flatten bool, formatJSON bool, write bool, outputter funcOutput) error {
+	logger := zap.NewNop()
+
 	for _, relFile := range files {
 		data, err := readMarkdown(basePath, []string{relFile})
 		if err != nil {
@@ -30,7 +33,7 @@ func Format(files []string, basePath string, flatten bool, formatJSON bool, writ
 		identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 
 		if flatten {
-			notebook, err := editor.Deserialize(data, identityResolver)
+			notebook, err := editor.Deserialize(logger, data, identityResolver)
 			if err != nil {
 				return errors.Wrap(err, "failed to deserialize")
 			}
@@ -48,7 +51,7 @@ func Format(files []string, basePath string, flatten bool, formatJSON bool, writ
 					notebook.ForceLifecycleIdentities()
 				}
 
-				formatted, err = editor.Serialize(notebook, nil)
+				formatted, err = editor.Serialize(logger, notebook, nil)
 				if err != nil {
 					return errors.Wrap(err, "failed to serialize")
 				}

--- a/pkg/project/formatter.go
+++ b/pkg/project/formatter.go
@@ -15,14 +15,11 @@ import (
 	"github.com/stateful/runme/v3/pkg/document"
 	"github.com/stateful/runme/v3/pkg/document/editor"
 	"github.com/stateful/runme/v3/pkg/document/identity"
-	"go.uber.org/zap"
 )
 
 type funcOutput func(string, []byte) error
 
 func Format(files []string, basePath string, flatten bool, formatJSON bool, write bool, outputter funcOutput) error {
-	logger := zap.NewNop()
-
 	for _, relFile := range files {
 		data, err := readMarkdown(basePath, []string{relFile})
 		if err != nil {
@@ -33,7 +30,7 @@ func Format(files []string, basePath string, flatten bool, formatJSON bool, writ
 		identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 
 		if flatten {
-			notebook, err := editor.Deserialize(logger, data, identityResolver)
+			notebook, err := editor.Deserialize(data, editor.Options{IdentityResolver: identityResolver})
 			if err != nil {
 				return errors.Wrap(err, "failed to deserialize")
 			}
@@ -51,7 +48,7 @@ func Format(files []string, basePath string, flatten bool, formatJSON bool, writ
 					notebook.ForceLifecycleIdentities()
 				}
 
-				formatted, err = editor.Serialize(logger, notebook, nil)
+				formatted, err = editor.Serialize(notebook, nil, editor.Options{})
 				if err != nil {
 					return errors.Wrap(err, "failed to serialize")
 				}


### PR DESCRIPTION
Turns out people use templating languages and interpolation in frontmatter which makes it invalid unless rendered first. The idea of this PR is to pass-thru frontmatter when attempts to parsing it fail.

Fixes https://github.com/stateful/vscode-runme/issues/1455