### PR TITLE
Bring back proximity sorting

### DIFF
--- a/internal/cmd/beta/filepath.go
+++ b/internal/cmd/beta/filepath.go
@@ -2,10 +2,7 @@ package beta
 
 import (
 	"os"
-	"path/filepath"
 )
-
-var cwd = getCwd()
 
 func getCwd() string {
 	cwd, err := os.Getwd()
@@ -13,12 +10,4 @@ func getCwd() string {
 		cwd = "."
 	}
 	return cwd
-}
-
-func relativePathToCwd(path string) string {
-	relPath, err := filepath.Rel(cwd, path)
-	if err != nil {
-		relPath = path
-	}
-	return relPath
 }

--- a/internal/cmd/beta/list_cmd.go
+++ b/internal/cmd/beta/list_cmd.go
@@ -49,6 +49,8 @@ List all blocks from the "setup" and "teardown" categories:
 					}
 					logger.Info("found tasks", zap.Int("count", len(tasks)))
 
+					project.SortByProximity(tasks, getCwd())
+
 					argsFilter, err := createProjectFilterFromPatterns(args)
 					if err != nil {
 						return err
@@ -106,7 +108,7 @@ func renderTasksAsTableForCmd(cmd *cobra.Command, tasks []project.Task) error {
 		}
 
 		table.AddField(task.CodeBlock.Name())
-		table.AddField(relativePathToCwd(task.DocumentPath))
+		table.AddField(project.GetRelativePath(getCwd(), task.DocumentPath))
 		table.AddField(renderLineFromLines(task.CodeBlock.Lines()))
 		table.AddField(task.CodeBlock.Intro())
 		table.AddField(named)

--- a/internal/cmd/beta/print_cmd.go
+++ b/internal/cmd/beta/print_cmd.go
@@ -63,7 +63,7 @@ Print content of commands from the "setup" and "teardown" categories:
 
 func printTasksContent(w io.Writer, tasks []project.Task) error {
 	for _, t := range tasks {
-		_, err := w.Write([]byte("# " + relativePathToCwd(t.DocumentPath) + ":" + t.CodeBlock.Name() + "\n"))
+		_, err := w.Write([]byte("# " + project.GetRelativePath(getCwd(), t.DocumentPath) + ":" + t.CodeBlock.Name() + "\n"))
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -551,11 +551,3 @@ func captureVariable(cmd *cobra.Command, ip *prompt.InputParams) (string, error)
 
 	return val, nil
 }
-
-func getRelativePath(base string, documentPath string) string {
-	relPath, err := filepath.Rel(base, documentPath)
-	if err != nil {
-		relPath = documentPath
-	}
-	return relPath
-}

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -57,7 +57,7 @@ func listCmd() *cobra.Command {
 			for _, task := range tasks {
 				block := task.CodeBlock
 				lines := block.Lines()
-				relPath := getRelativePath(getCwd(), task.DocumentPath)
+				relPath := project.GetRelativePath(getCwd(), task.DocumentPath)
 				r := row{
 					Name:         block.Name(),
 					File:         relPath,

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -324,7 +324,7 @@ func (m tuiModel) View() string {
 				name += " (unnamed)"
 			}
 
-			relFilename := getRelativePath(getCwd(), task.DocumentPath)
+			relFilename := project.GetRelativePath(getCwd(), task.DocumentPath)
 			filename := ansi.Color(relFilename, "white+d")
 
 			if active {
@@ -334,7 +334,7 @@ func (m tuiModel) View() string {
 			intro := block.Intro()
 			words := strings.Split(intro, " ")
 			// todo(sebastian): this likely only works well for English
-			max := 9 - len(strings.Split(relFilename, fmt.Sprint(filepath.Separator)))
+			max := 9 - len(strings.Split(relFilename, string(filepath.Separator)))
 			if len(words) > max {
 				intro = strings.Join(words[:max], " ") + "..."
 			}

--- a/pkg/project/file.go
+++ b/pkg/project/file.go
@@ -4,11 +4,20 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 )
+
+func GetRelativePath(cwd, path string) string {
+	relPath, err := filepath.Rel(cwd, path)
+	if err != nil {
+		relPath = path
+	}
+	return relPath
+}
 
 func readMarkdown(source string) ([]byte, error) {
 	var (

--- a/pkg/project/task.go
+++ b/pkg/project/task.go
@@ -2,7 +2,10 @@ package project
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -73,6 +76,19 @@ func LoadTasks(ctx context.Context, p *Project) ([]Task, error) {
 	}
 
 	return result, err
+}
+
+// SortByProximity sorts tasks by promximity to the cwd
+func SortByProximity(tasks []Task, cwd string) {
+	slices.SortStableFunc(tasks, func(a, b Task) int {
+		aRelToCwd := GetRelativePath(cwd, a.DocumentPath)
+		bRelToCwd := GetRelativePath(cwd, b.DocumentPath)
+
+		aLevels := len(strings.Split(aRelToCwd, string(filepath.Separator)))
+		bLevels := len(strings.Split(bRelToCwd, string(filepath.Separator)))
+
+		return aLevels - bLevels
+	})
 }
 
 type Filter func(Task) (bool, error)

--- a/testdata/beta/find_repo_upward.txtar
+++ b/testdata/beta/find_repo_upward.txtar
@@ -47,8 +47,8 @@ echo root-ignored
 
 -- result-ls.txt --
 NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
-root-hello	../README.md	echo root-hello		Yes
 nested-hello	README.md	echo nested-hello		Yes
+root-hello	../README.md	echo root-hello		Yes
 -- result-print.txt --
 # ../README.md:root-hello
 echo root-hello

--- a/testdata/flags/relative.txtar
+++ b/testdata/flags/relative.txtar
@@ -76,9 +76,9 @@ say_hi()
 ```
 -- very/deeply/relative.txt --
 NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+count	sub.md	echo "1"	It can contain multiple lines too.	Yes
+again	../another.md	echo "Hello, runme! Again!"		Yes
+echo	nested/file.md	echo "Hello, runme!"		Yes
 hello-js	../../root.md	console.log("Hello, runme, from javascript!")	It can even run scripting languages.	Yes
 hello-js-cat	../../root.md	console.log("Hello, runme, from javascript!")	And it can even run a cell with a custom interpreter.	Yes
 hello-python	../../root.md	def say_hi():		Yes
-again	../another.md	echo "Hello, runme! Again!"		Yes
-echo	nested/file.md	echo "Hello, runme!"		Yes
-count	sub.md	echo "1"	It can contain multiple lines too.	Yes


### PR DESCRIPTION
We used to sort tasks by its file's distance in relation to the cwd. As the cwd changes in subdirs the sorting gets reprioritized. In other words, what's directly in the same directory or less levels removed is higher up. The task's name sorting within a file still reflects its positional order in the file.

I believe the sorting logic got lost when we migrated Project APIs. Here's the difference:

### New:
```
NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
configureNPM	CONTRIBUTING.md	npm config set @buf:registry https://buf.build/gen/npm/v1	make sure to configure your local npm to pull from Buf's registry (for GRPC dependencies.	Yes
setup	CONTRIBUTING.md	export GITHUB_REF_NAME=$(git branch --show-current)	then ensure to install all project dependencies. Note GitHub token is required to auto-dowload the latest runme binary. The branch ref name is optional, if it's not main pre-release binaries are being considered.	Yes
npm-watch	CONTRIBUTING.md	npm run watch	Then just run the watcher and you're off to the races.	Yes
build	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	To compile all extension files, run.	Yes
bundle	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	And then package the extension into a .vsix file.	Yes
test	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	The Runme project has several test stages that you can run individually or as a whole.	Yes
test:ci	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	When testing in CI environment, run.	Yes
test:format	CONTRIBUTING.md	npx prettier --check .	We use Prettier to keep the code style consistent.	Yes
test:format:fix	CONTRIBUTING.md	npx prettier --write .	You can fix any formatting errors via.	Yes
[...]
```

### Old:
```
NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
overwrite-stateful	.github/scripts/overwrites/stateful.md	export EXTENSION_NAME="platform"	To overwrite Runme's defaults to match Stateful's run following commands.	Yes
overwrite-reset	.github/scripts/overwrites/stateful.md	git checkout -f assets package*.json README.md	To clean up and revert back to Runme's defaults, run the following commands.	Yes
configureNPM	CONTRIBUTING.md	npm config set @buf:registry https://buf.build/gen/npm/v1	make sure to configure your local npm to pull from Buf's registry (for GRPC dependencies.	Yes
setup	CONTRIBUTING.md	export GITHUB_REF_NAME=$(git branch --show-current)	then ensure to install all project dependencies. Note GitHub token is required to auto-dowload the latest runme binary. The branch ref name is optional, if it's not main pre-release binaries are being considered.	Yes
npm-watch	CONTRIBUTING.md	npm run watch	Then just run the watcher and you're off to the races.	Yes
build	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	To compile all extension files, run.	Yes
bundle	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	And then package the extension into a .vsix file.	Yes
test	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	The Runme project has several test stages that you can run individually or as a whole.	Yes
test:ci	CONTRIBUTING.md	export NODE_OPTIONS="--experimental-specifier-resolution=node --max-old-space-size=8192"	When testing in CI environment, run.	Yes
[...]
```