### PR TITLE
Allow multiple args for interpreters

### DIFF
--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -668,7 +668,7 @@ func parseFileProgram(programPath string) (program string, args []string) {
 	}
 
 	if len(parts) > 1 {
-		args = []string{parts[1]}
+		args = strings.Split(parts[1], " ")
 	}
 
 	return

--- a/internal/runner/command_test.go
+++ b/internal/runner/command_test.go
@@ -168,6 +168,35 @@ func Test_command(t *testing.T) {
 		assert.Equal(t, "", string(data))
 	})
 
+	t.Run("DenoWithArgs", func(t *testing.T) {
+		t.Parallel()
+
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+
+		cmd, err := newCommand(
+			context.Background(),
+			&commandConfig{
+				ProgramName: "deno run --allow-all",
+				LanguageID:  "ts",
+				Stdout:      stdout,
+				Stderr:      stderr,
+				CommandMode: CommandModeTempFile,
+				Script:      "console.log('1'); console.log('2')",
+				Logger:      testCreateLogger(t),
+			},
+		)
+		require.NoError(t, err)
+		require.NoError(t, cmd.Start(context.Background()))
+		require.NoError(t, cmd.Wait())
+		data, err := io.ReadAll(stdout)
+		assert.NoError(t, err)
+		assert.Equal(t, "1\n2\n", string(data))
+		data, err = io.ReadAll(stderr)
+		assert.NoError(t, err)
+		assert.Equal(t, "", string(data))
+	})
+
 	t.Run("Nonexec resorts to cat", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
This is a bug where we only expect one argument. Downstream, the OS libraries expect arguments to be passed as an array.

This PR fixes this. Please see the test case.