### PR TITLE
Clear relationship between ephemeral and persistent lifecycle IDs

### DIFF
--- a/cmd/gqltool/main.go
+++ b/cmd/gqltool/main.go
@@ -11,10 +11,8 @@ import (
 	"github.com/stateful/runme/v3/internal/client/graphql"
 )
 
-var (
-	apiURL = flag.String("api-url", "http://localhost:4000", "The API base address")
-	// tokenDir = flag.String("token-dir", cmd.GetUserConfigHome(), "The directory with tokens")
-)
+// var tokenDir = flag.String("token-dir", cmd.GetUserConfigHome(), "The directory with tokens")
+var apiURL = flag.String("api-url", "http://localhost:4000", "The API base address")
 
 func init() {
 	flag.Parse()

--- a/internal/cmd/code_server.go
+++ b/internal/cmd/code_server.go
@@ -239,6 +239,7 @@ func runCodeServerCommand(cmd *cobra.Command, execFile string, routeToBuffer boo
 	return buffer.Bytes(), nil
 }
 
+//lint:ignore U1000 Ignore because it's only used in tests running in docker
 func getLatestExtensionVersion(experimental bool) (string, error) {
 	var tagName string
 
@@ -286,6 +287,7 @@ func getLatestExtensionVersion(experimental bool) (string, error) {
 	return tagName, nil
 }
 
+//lint:ignore U1000 Ignore because it's only used in tests running in docker
 func getExtensionURL(tagName string) (string, error) {
 	var arch string
 
@@ -322,6 +324,7 @@ func getExtensionURL(tagName string) (string, error) {
 	return downloadURL, nil
 }
 
+//lint:ignore U1000 Ignore because it's only used in tests running in docker
 func downloadVscodeExtension(dir string, experimental bool) (string, error) {
 	tagName, err := getLatestExtensionVersion(experimental)
 	if err != nil {

--- a/internal/cmd/code_server_test.go
+++ b/internal/cmd/code_server_test.go
@@ -1,4 +1,4 @@
-//go:test !darwin
+//go:build test_with_docker
 
 package cmd
 

--- a/internal/command/command_terminal.go
+++ b/internal/command/command_terminal.go
@@ -9,9 +9,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var introMsg = []byte(
-	" # Runme terminal: Upon exit, exported environment variables will roll up into your session." +
-		" Type 'save' to add this session to the notebook.\n\n",
+const (
+	introFirstLine  = "Runme terminal: Upon exit, exported environment variables will roll up into your session."
+	introSecondLine = "Type 'save' to add this session to the notebook."
+	envSourceCmd    = "runme beta env source --silent --insecure --export"
 )
 
 type terminalCommand struct {
@@ -53,12 +54,14 @@ func (c *terminalCommand) Start(ctx context.Context) (err error) {
 		}
 	}
 
-	if _, err := c.stdinWriter.Write([]byte(" eval $(runme beta env source --silent --insecure --export)\n alias save=\"exit\"\n clear\n")); err != nil {
+	if _, err := c.stdinWriter.Write([]byte(" eval $(" + envSourceCmd + ")\n alias save=\"exit\"\n clear\n")); err != nil {
 		return err
 	}
 
 	// todo(sebastian): good enough for prototype; it makes more sense to write this message at the TTY-level
-	_, err = c.stdinWriter.Write(introMsg)
+	_, err = c.stdinWriter.Write([]byte(
+		" # " + introFirstLine +
+			" " + introSecondLine + "\n\n"))
 
 	return err
 }

--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -682,9 +682,7 @@ func (r *runnerService) ResolveProgram(ctx context.Context, req *runnerv1.Resolv
 		return nil, err
 	}
 
-	var (
-		modifiedScriptBuf bytes.Buffer
-	)
+	var modifiedScriptBuf bytes.Buffer
 
 	script := req.GetScript()
 	if commands := req.GetCommands(); script == "" && len(commands.Lines) > 0 {

--- a/internal/runnerv2service/service_resolve_program.go
+++ b/internal/runnerv2service/service_resolve_program.go
@@ -26,9 +26,7 @@ func (r *runnerService) ResolveProgram(ctx context.Context, req *runnerv2.Resolv
 		return nil, err
 	}
 
-	var (
-		modifiedScriptBuf bytes.Buffer
-	)
+	var modifiedScriptBuf bytes.Buffer
 
 	script := req.GetScript()
 	if commands := req.GetCommands(); script == "" && len(commands.Lines) > 0 {

--- a/internal/telemetry/scarf.go
+++ b/internal/telemetry/scarf.go
@@ -19,8 +19,10 @@ const (
 	client = "Kernel"
 )
 
-type reporterFunc func() error
-type lookupEnvFunc func(key string) (string, bool)
+type (
+	reporterFunc  func() error
+	lookupEnvFunc func(key string) (string, bool)
+)
 
 var reporter reporterFunc
 

--- a/pkg/document/document_test.go
+++ b/pkg/document/document_test.go
@@ -81,7 +81,7 @@ First paragraph
 	))
 
 	t.Run("Parse_DefaultIdentity", func(t *testing.T) {
-		var defaultIdentityResolver = identity.NewResolver(identity.DefaultLifecycleIdentity)
+		defaultIdentityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
 		doc := New(data, defaultIdentityResolver)
 		err := doc.Parse()
 		require.NoError(t, err)

--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -163,8 +163,7 @@ func toCellsRec(
 
 			// In the future, we will include language detection (#77).
 			metadata := block.Attributes()
-			cellID := block.ID()
-			if cellID != "" {
+			if cellID := block.ID(); cellID != "" {
 				metadata[PrefixAttributeName(InternalAttributePrefix, "id")] = cellID
 			}
 			metadata[PrefixAttributeName(InternalAttributePrefix, "name")] = block.Name()

--- a/pkg/document/editor/editor.go
+++ b/pkg/document/editor/editor.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	FrontmatterKey = "frontmatter"
-	DocumentID     = "id"
+	CacheID        = "cacheId"
 	CellID         = "id"
 )
 
@@ -50,6 +50,8 @@ func Deserialize(data []byte, opts Options) (*Notebook, error) {
 		Frontmatter: frontmatter,
 		Metadata: map[string]string{
 			PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey): strconv.Itoa(doc.TrailingLineBreaksCount()),
+			// CacheID used for uniquely identifying documents in caches across vscode deserialization (issues) and serialization (retains).
+			PrefixAttributeName(InternalAttributePrefix, CacheID): opts.IdentityResolver.CacheID(),
 		},
 	}
 
@@ -61,11 +63,6 @@ func Deserialize(data []byte, opts Options) (*Notebook, error) {
 	// if parsing frontmatter failed put unparsed frontmatter in notebook's metadata to avoid earsing it with "default frontmatter"
 	if raw := doc.FrontmatterRaw(); fmErr != nil && len(raw) > 0 {
 		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, FrontmatterKey)] = string(raw)
-	}
-
-	// Store internal ephemeral document ID if the document lifecycle ID is disabled.
-	if !opts.IdentityResolver.DocumentEnabled() {
-		notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, DocumentID)] = opts.IdentityResolver.EphemeralDocumentID()
 	}
 
 	// Make ephemeral cell IDs permanent if the cell lifecycle ID is enabled.

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -97,13 +97,13 @@ func Test_IdentityUnspecified(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		if tt.hasExtraFrontmatter {
 			assert.True(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 3)
+			assert.Len(t, dResp.Notebook.Metadata, 4)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
 			assert.Contains(t, rawFrontmatter, "id: \"123\"\n")
 			assert.Contains(t, rawFrontmatter, "version: v")
 		} else {
 			assert.False(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 2)
+			assert.Len(t, dResp.Notebook.Metadata, 3)
 		}
 
 		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
@@ -139,7 +139,7 @@ func Test_IdentityAll(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 3)
+		assert.Len(t, dResp.Notebook.Metadata, 4)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")
@@ -180,7 +180,7 @@ func Test_IdentityDocument(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 3)
+		assert.Len(t, dResp.Notebook.Metadata, 4)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")
@@ -222,13 +222,13 @@ func Test_IdentityCell(t *testing.T) {
 
 		if tt.hasExtraFrontmatter {
 			assert.True(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 3)
+			assert.Len(t, dResp.Notebook.Metadata, 4)
 			assert.Contains(t, rawFrontmatter, "prop: value\n")
 			assert.Contains(t, rawFrontmatter, "id: \"123\"\n")
 			assert.Regexp(t, versionRegex, rawFrontmatter, "Wrong version")
 		} else {
 			assert.False(t, ok)
-			assert.Len(t, dResp.Notebook.Metadata, 2)
+			assert.Len(t, dResp.Notebook.Metadata, 3)
 		}
 
 		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
@@ -268,7 +268,7 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 
 	assert.True(t, ok)
-	assert.Len(t, dResp.Notebook.Metadata, 3)
+	assert.Len(t, dResp.Notebook.Metadata, 4)
 	assert.Contains(t, rawFrontmatter, "prop: value\n")
 	assert.NotContains(t, rawFrontmatter, "id: \"123\"\n")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")
@@ -307,7 +307,7 @@ func Test_RetainInvalidFrontmatter(t *testing.T) {
 	rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 
 	assert.True(t, ok)
-	assert.Len(t, dResp.Notebook.Metadata, 3)
+	assert.Len(t, dResp.Notebook.Metadata, 4)
 	assert.Contains(t, rawFrontmatter, "invalid frontmatter")
 	assert.NotContains(t, rawFrontmatter, "id: ")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -106,7 +106,7 @@ func Test_IdentityUnspecified(t *testing.T) {
 			assert.Len(t, dResp.Notebook.Metadata, 2)
 		}
 
-		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 		assert.NoError(t, err)
 		content := string(sResp.Result)
 
@@ -148,7 +148,7 @@ func Test_IdentityAll(t *testing.T) {
 		assert.Contains(t, rawFrontmatter, "id: "+testMockID)
 		assert.Contains(t, rawFrontmatter, "version: "+version.BaseVersion())
 
-		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 		assert.NoError(t, err)
 
 		content := string(sResp.Result)
@@ -156,7 +156,7 @@ func Test_IdentityAll(t *testing.T) {
 		assert.Contains(t, content, "runme:\n")
 		assert.Contains(t, content, "id: "+testMockID)
 		assert.Contains(t, content, "version: "+version.BaseVersion())
-		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
 		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 		assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 	}
@@ -189,7 +189,7 @@ func Test_IdentityDocument(t *testing.T) {
 		assert.Contains(t, rawFrontmatter, "id: "+testMockID)
 		assert.Regexpf(t, versionRegex, rawFrontmatter, "Wrong version")
 
-		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 		assert.NoError(t, err)
 
 		content := string(sResp.Result)
@@ -231,7 +231,7 @@ func Test_IdentityCell(t *testing.T) {
 			assert.Len(t, dResp.Notebook.Metadata, 2)
 		}
 
-		sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+		sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 		assert.NoError(t, err)
 
 		content := string(sResp.Result)
@@ -245,7 +245,7 @@ func Test_IdentityCell(t *testing.T) {
 			assert.NotRegexp(t, "^\n\n", content)
 		}
 
-		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
 		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 		assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 	}
@@ -273,7 +273,7 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	assert.NotContains(t, rawFrontmatter, "id: \"123\"\n")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")
 
-	sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+	sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 	assert.NoError(t, err)
 
 	content := string(sResp.Result)
@@ -285,7 +285,7 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	assert.Regexp(t, "^---\n", content)
 	assert.NotRegexp(t, "^\n\n", content)
 
-	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"foo\"}\n")
+	assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
 	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 	assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 }
@@ -312,7 +312,7 @@ func Test_RetainInvalidFrontmatter(t *testing.T) {
 	assert.NotContains(t, rawFrontmatter, "id: ")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")
 
-	sResp, err := serializeWithIdentityPersistence(client, dResp.Notebook, identity)
+	sResp, err := serializeWithoutOutputs(client, dResp.Notebook)
 	assert.NoError(t, err)
 
 	content := string(sResp.Result)
@@ -324,7 +324,7 @@ func Test_RetainInvalidFrontmatter(t *testing.T) {
 	assert.Regexp(t, "^\\+\\+\\+\n", content)
 	assert.NotRegexp(t, "^\n\n", content)
 
-	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"foo\"}\n")
+	assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
 	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 	assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 }
@@ -447,14 +447,8 @@ func deserialize(client parserv1.ParserServiceClient, content string, idt parser
 	)
 }
 
-func serializeWithIdentityPersistence(client parserv1.ParserServiceClient, notebook *parserv1.Notebook, idt parserv1.RunmeIdentity) (*parserv1.SerializeResponse, error) {
-	persistIdentityLikeExtension(notebook)
-	return client.Serialize(
-		context.Background(),
-		&parserv1.SerializeRequest{
-			Notebook: notebook,
-		},
-	)
+func serializeWithoutOutputs(client parserv1.ParserServiceClient, notebook *parserv1.Notebook) (*parserv1.SerializeResponse, error) {
+	return serializeWithOutputs(client, notebook, &parserv1.SerializeRequestOptions{})
 }
 
 func serializeWithOutputs(client parserv1.ParserServiceClient, notebook *parserv1.Notebook, options *parserv1.SerializeRequestOptions) (*parserv1.SerializeResponse, error) {
@@ -465,17 +459,4 @@ func serializeWithOutputs(client parserv1.ParserServiceClient, notebook *parserv
 			Options:  options,
 		},
 	)
-}
-
-// mimics what would happen on the extension side
-func persistIdentityLikeExtension(notebook *parserv1.Notebook) {
-	for _, cell := range notebook.Cells {
-		// todo(sebastian): preserve original id when they are set?
-		// if _, ok := cell.Metadata["id"]; ok {
-		// 	break
-		// }
-		if v, ok := cell.Metadata["runme.dev/id"]; ok {
-			cell.Metadata["id"] = v
-		}
-	}
 }

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -139,7 +139,7 @@ func Test_IdentityAll(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 2)
+		assert.Len(t, dResp.Notebook.Metadata, 3)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")
@@ -180,7 +180,7 @@ func Test_IdentityDocument(t *testing.T) {
 		rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 		assert.True(t, ok)
 
-		assert.Len(t, dResp.Notebook.Metadata, 2)
+		assert.Len(t, dResp.Notebook.Metadata, 3)
 
 		if tt.hasExtraFrontmatter {
 			assert.Contains(t, rawFrontmatter, "prop: value")
@@ -307,7 +307,7 @@ func Test_RetainInvalidFrontmatter(t *testing.T) {
 	rawFrontmatter, ok := dResp.Notebook.Metadata["runme.dev/frontmatter"]
 
 	assert.True(t, ok)
-	assert.Len(t, dResp.Notebook.Metadata, 2)
+	assert.Len(t, dResp.Notebook.Metadata, 3)
 	assert.Contains(t, rawFrontmatter, "invalid frontmatter")
 	assert.NotContains(t, rawFrontmatter, "id: ")
 	assert.NotRegexp(t, versionRegex, rawFrontmatter, "Wrong version")

--- a/pkg/document/identity/resolver.go
+++ b/pkg/document/identity/resolver.go
@@ -71,8 +71,8 @@ func (ir *IdentityResolver) DocumentEnabled() bool {
 	return ir.documentIdentity
 }
 
-// EphemeralDocumentID returns a new document ID which is not persisted.
-func (ir *IdentityResolver) EphemeralDocumentID() string {
+// CacheID returns a new document ID which is not persisted.
+func (ir *IdentityResolver) CacheID() string {
 	return ulid.GenerateID()
 }
 

--- a/pkg/document/identity/resolver.go
+++ b/pkg/document/identity/resolver.go
@@ -78,10 +78,6 @@ func (ir *IdentityResolver) EphemeralDocumentID() string {
 
 // GetCellID returns a cell ID and a boolean indicating if it's new or from attributes.
 func (ir *IdentityResolver) GetCellID(obj any, attributes map[string]string) (string, bool) {
-	if !ir.cellIdentity {
-		return "", false
-	}
-
 	// todo(sebastian): are invalid ulid's valid IDs?
 	// Check for a valid 'id' in attributes;
 	// if present and valid due to explicit cell identity cache and return it.

--- a/pkg/document/identity/resolver.go
+++ b/pkg/document/identity/resolver.go
@@ -23,7 +23,7 @@ const (
 	CellLifecycleIdentity
 )
 
-const DefaultLifecycleIdentity = AllLifecycleIdentity
+const DefaultLifecycleIdentity = UnspecifiedLifecycleIdentity
 
 var documentIdentities = &LifecycleIdentities{
 	AllLifecycleIdentity,

--- a/pkg/document/identity/resolver_test.go
+++ b/pkg/document/identity/resolver_test.go
@@ -58,8 +58,8 @@ func TestIdentityResolver(t *testing.T) {
 		assert.NotEmpty(t, id)
 	})
 
-	t.Run("EphemeralDocumentID", func(t *testing.T) {
+	t.Run("CacheID", func(t *testing.T) {
 		resolver := NewResolver(DefaultLifecycleIdentity)
-		assert.Len(t, resolver.EphemeralDocumentID(), 26)
+		assert.Len(t, resolver.CacheID(), 26)
 	})
 }

--- a/pkg/project/formatter.go
+++ b/pkg/project/formatter.go
@@ -5,22 +5,20 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
-	"github.com/stateful/runme/v3/internal/renderer/cmark"
-	"github.com/stateful/runme/v3/pkg/document"
 	"github.com/stateful/runme/v3/pkg/document/editor"
 	"github.com/stateful/runme/v3/pkg/document/identity"
 )
 
 type FuncOutput func(string, []byte) error
 
-func FormatFiles(files []string, flatten bool, formatJSON bool, write bool, outputter FuncOutput) error {
+func FormatFiles(files []string, identityResolver *identity.IdentityResolver, formatJSON bool, write bool, outputter FuncOutput) error {
 	for _, file := range files {
 		data, err := readMarkdown(file)
 		if err != nil {
 			return err
 		}
 
-		formatted, err := formatFile(data, flatten, formatJSON)
+		formatted, err := formatFile(data, identityResolver, formatJSON)
 		if err != nil {
 			return err
 		}
@@ -38,41 +36,41 @@ func FormatFiles(files []string, flatten bool, formatJSON bool, write bool, outp
 	return nil
 }
 
-func formatFile(data []byte, flatten bool, formatJSON bool) ([]byte, error) {
-	identityResolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
+func formatFile(data []byte, identityResolver *identity.IdentityResolver, formatJSON bool) ([]byte, error) {
 	var formatted []byte
 
-	if flatten {
-		notebook, err := editor.Deserialize(data, editor.Options{IdentityResolver: identityResolver})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to deserialize")
-		}
+	notebook, err := editor.Deserialize(data, editor.Options{IdentityResolver: identityResolver})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize")
+	}
 
-		if formatJSON {
-			var buf bytes.Buffer
-			enc := json.NewEncoder(&buf)
-			enc.SetIndent("", "  ")
-			if err := enc.Encode(notebook); err != nil {
-				return nil, errors.Wrap(err, "failed to encode to JSON")
-			}
-			formatted = buf.Bytes()
-		} else {
-			formatted, err = editor.Serialize(notebook, nil, editor.Options{IdentityResolver: identityResolver})
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to serialize")
-			}
+	if formatJSON {
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(notebook); err != nil {
+			return nil, errors.Wrap(err, "failed to encode to JSON")
 		}
+		formatted = buf.Bytes()
 	} else {
-		doc := document.New(data, identityResolver)
-		astNode, err := doc.RootAST()
+		formatted, err = editor.Serialize(notebook, nil, editor.Options{IdentityResolver: identityResolver})
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse source")
-		}
-		formatted, err = cmark.Render(astNode, data)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to render")
+			return nil, errors.Wrap(err, "failed to serialize")
 		}
 	}
+
+	// todo(sebastian): remove moving to beta? it's neither used nor maintained
+	// {
+	// 	doc := document.New(data, identityResolver)
+	// 	astNode, err := doc.RootAST()
+	// 	if err != nil {
+	// 		return nil, errors.Wrap(err, "failed to parse source")
+	// 	}
+	// 	formatted, err = cmark.Render(astNode, data)
+	// 	if err != nil {
+	// 		return nil, errors.Wrap(err, "failed to render")
+	// 	}
+	// }
 
 	return formatted, nil
 }


### PR DESCRIPTION
When we first introduced lifecycle identity, it was designed to turn persistence on or off at build time. The following changes will ideally allow clients to toggle persistence dynamically.

1. Always use ephemeral IDs if there are no persistent IDs in the document/node models.
2. Decide persistence exclusively at deserialization time in the Parser.

I have cleaned up `runme fmt` as part of these changes, changed to run `code-server` in docker-only (avoid rate limiting locally), and made runme terminal stop flaking when run inside of Docker.