### PR TITLE
Cleanup: Remove the ai-logs flag.

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -36,7 +36,6 @@ func serverCmd() *cobra.Command {
 		devMode      bool
 		enableRunner bool
 		tlsDir       string
-		enableAILogs bool
 	)
 
 	cmd := cobra.Command{

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -142,11 +142,8 @@ The kernel is used to run long running processes like shells and interacting wit
 	cmd.Flags().StringVarP(&addr, "address", "a", defaultAddr, "Address to create unix (unix:///path/to/socket) or IP socket (localhost:7890)")
 	cmd.Flags().BoolVar(&devMode, "dev", false, "Enable development mode")
 	cmd.Flags().BoolVar(&enableRunner, "runner", true, "Enable runner service (legacy, defaults to true)")
-	// The AIFlag is no longer used, we can remove it as soon as the option has been removed from the frontend.
-	cmd.Flags().BoolVar(&enableAILogs, "ai-logs", false, "Enable logs to support training an AI")
 	cmd.Flags().StringVar(&tlsDir, "tls", defaultTLSDir, "Directory in which to generate TLS certificates & use for all incoming and outgoing messages")
 	cmd.Flags().StringVar(&configDir, configDirF, GetUserConfigHome(), "Sets the configuration directory.")
 	_ = cmd.Flags().MarkHidden("runner")
-	_ = cmd.Flags().MarkDeprecated("ai-logs", "This flag is no longer used.")
 	return &cmd
 }


### PR DESCRIPTION
* This flag is deprecated and no longer used.
* The frontend should have stopped using this flag starting in 3.7.5
* The frontend is now up to 3.8.5
* So we should be good to remove this flag because the frontend should no longer be setting it.

* Related to https://github.com/jlewi/foyle/issues/211