### PR TITLE
Avoid warning for GOCOVERDIR not set

### DIFF
--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -1,5 +1,8 @@
 ---
 cwd: ../..
+runme:
+  id: 01JAGWRDZSF2NHJA774WHDDD1V
+  version: v3
 shell: bash
 skipPrompts: true
 ---
@@ -8,10 +11,13 @@ skipPrompts: true
 
 Run all tests with coverage reports.
 
-```sh {"id":"01J5XTG2WKVR4WG7B2FNPF6VZT","name":"ci-test"}
+```sh {"id":"01J5XTG2WKVR4WG7B2FNPF6VZT","name":"ci-test","promptEnv":"no"}
+unset RUNME_SESSION_STRATEGY RUNME_TLS_DIR RUNME_SERVER_ADDR
 export SHELL="/bin/bash"
 export TZ="UTC"
-TAGS="test_with_docker" make test/coverage
+export GOCOVERDIR="."
+export TAGS="test_with_docker"
+make test/coverage
 make test/coverage/func
 ```
 

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -25,5 +25,6 @@ Run parser/serializer against a large quantity of markdown files.
 
 ```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-parser","promptEnv":"no"}
 export GOPATH="$(go env GOPATH)"
+echo "GOPATH=$GOPATH"
 make test/parser
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -28,5 +28,4 @@ export GOPATH="$(go env GOPATH)"
 export NUM_OF_FILES=$(find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | wc -l | tr -d "    ")
 echo "Checking $NUM_OF_FILES files inside GOPATH=$GOPATH"
 make test/parser
-exit 1
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -26,5 +26,6 @@ Run parser/serializer against a large quantity of markdown files.
 ```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-parser","promptEnv":"no"}
 export GOPATH="$(go env GOPATH)"
 echo "GOPATH=$GOPATH"
-make test/parser
+find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq
+#make test/parser
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -25,7 +25,7 @@ Run parser/serializer against a large quantity of markdown files.
 
 ```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-parser","promptEnv":"no"}
 export GOPATH="$(go env GOPATH)"
-echo "GOPATH=$GOPATH"
-find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | wc -l
-#make test/parser
+export NUM_OF_FILES=$(find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | wc -l | tr -d "    ")
+echo "Checking $NUM_OF_FILES files inside GOPATH=$GOPATH"
+make test/parser
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -23,6 +23,7 @@ make test/coverage/func
 
 Run parser/serializer against a large quantity of markdown files.
 
-```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-robustness"}
-make test/robustness
+```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-parser","promptEnv":"no"}
+export GOPATH="$(go env GOPATH)"
+make test/parser
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -28,4 +28,5 @@ export GOPATH="$(go env GOPATH)"
 export NUM_OF_FILES=$(find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | wc -l | tr -d "    ")
 echo "Checking $NUM_OF_FILES files inside GOPATH=$GOPATH"
 make test/parser
+exit 1
 ```

--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -26,6 +26,6 @@ Run parser/serializer against a large quantity of markdown files.
 ```sh {"id":"01J5XXFEGPJ5ZJZERQ5YGBBRN8","name":"ci-test-parser","promptEnv":"no"}
 export GOPATH="$(go env GOPATH)"
 echo "GOPATH=$GOPATH"
-find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq
+find "$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | wc -l
 #make test/parser
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Node version
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,8 @@ jobs:
         with:
           workflows: test-docker
 
-  build-and-robustness-test:
-    name: Test parser against vast amount of READMEs
+  build-and-parser-test:
+    name: Test parser against vast amount of Markdowns
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,7 +126,7 @@ jobs:
         with:
           workflows: |
             build
-            ci-test-robustness
+            ci-test-parser
         timeout-minutes: 5
       - name: Debug Build
         uses: stateful/vscode-server-action@v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,17 +111,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ">=1.22"
-      - name: Install dependencies
-        run: make install/dev
-      - name: Build
+      - name: Setup & build
         uses: stateful/runme-action@v2
         with:
-          workflows: build
+          workflows: |
+            setup
+            build
       - name: Test parser
         uses: stateful/runme-action@v2
         with:
           workflows: |
-            build
             ci-test-parser
         timeout-minutes: 5
       - name: Debug Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Test
-        run: make test-docker
-      - name: Test parser
         uses: stateful/runme-action@v2
         with:
           workflows: test-docker

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,10 @@ test-docker/run:
 test/update-snapshots:
 	@TZ=UTC UPDATE_SNAPSHOTS=true go test ./...
 
-.PHONY: test/robustness
-test/robustness:
+.PHONY: test/parser
+test/parser:
 	./runme --version
-	find "$$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | xargs dirname | uniq | xargs -n1 -I {} ./runme fmt --project {} > /dev/null
+	find "$$GOPATH/pkg/mod/github.com" -name "*.md" | grep -v "\/\." | grep -v glamour | xargs dirname | uniq | xargs -n1 -I {} ./runme fmt --project {} > /dev/null
 
 .PHONY: coverage/html
 test/coverage/html:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test/coverage: TAGS ?= "" # e.g. TAGS="test_with_docker"
 # It depends on the build target because the runme binary
 # is used for tests, for example, "runme env dump".
 test/coverage: build
-	TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=90s -covermode=atomic -coverprofile=cover.out -coverpkg=./... $(PKGS)
+	TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=180s -covermode=atomic -coverprofile=cover.out -coverpkg=./... $(PKGS)
 
 .PHONY: test
 test: test/execute

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test-docker: test-docker/setup test-docker/run
 .PHONY: test-docker/setup
 test-docker/setup:
 	docker build \
+		--progress=plain \
 		-t runme-test-env:latest \
 		-f ./docker/runme-test-env.Dockerfile .
 	docker volume create dev.runme.test-env-gocache

--- a/pkg/document/parser_frontmatter.go
+++ b/pkg/document/parser_frontmatter.go
@@ -24,7 +24,7 @@ func parseRawFrontmatter(l *itemParser, delimiter byte) parserStateFunc {
 		if !wasEndOfLine {
 			r = l.next()
 			if r == eof {
-				l.errorf("got EOF while looking for the end of the front matter delimiter")
+				l.errorf("got EOF while looking for the end of the frontmatter delimiter")
 				return nil
 			}
 		}
@@ -56,7 +56,7 @@ func parseRawFrontmatterJSON(l *itemParser) parserStateFunc {
 
 		switch {
 		case r == eof:
-			l.errorf("got EOF while looking for the end of the JSON front matter")
+			l.errorf("got EOF while looking for the end of the JSON frontmatter")
 			return nil
 		case r == '{':
 			if !inQuote {

--- a/pkg/project/formatter.go
+++ b/pkg/project/formatter.go
@@ -28,7 +28,7 @@ func FormatFiles(files []string, options *FormatOptions) error {
 
 		formatted, err := formatFile(data, options)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to format %s", file)
 		}
 
 		if options.Write {


### PR DESCRIPTION
1. The warning interferes with textar CLI test cases.
2. Unbreak parser CI