### PR TITLE
Fix data races

### DIFF
--- a/.github/workflows/CI.md
+++ b/.github/workflows/CI.md
@@ -16,7 +16,7 @@ Run all tests with coverage reports.
 unset RUNME_SESSION_STRATEGY RUNME_TLS_DIR RUNME_SERVER_ADDR
 export SHELL="/bin/bash"
 export TZ="UTC"
-export TAGS="test_with_docker"
+export TAGS="docker_enabled"
 make test/coverage
 make test/coverage/func
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -42,12 +42,17 @@ dist/
 # Editor
 .idea
 
+# macOS
 .DS_Store
 
 # VSCode debugger
 __debug_bin*
 
+# Cover coverage
 cover.out
+
+# Ignore .env
+.env
 
 # Prevent git from interpreting internal/project/testdata/git-project as a submodule.
 internal/project/testdata/git-project/**/.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
             "--proto_path=/usr/local/include/protoc"
         ]
     },
-    "go.buildTags": "test_with_docker,test_with_txtar",
+    "go.buildTags": "docker_enabled,test_with_txtar",
     "makefile.configureOnOpen": false
     // Uncomment if you want to work on files in ./web.
     // "go.buildTags": "js,wasm",

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ wasm:
 test/execute: PKGS ?= "./..."
 test/execute: RUN ?= .*
 test/execute: RACE ?= false
-test/execute: TAGS ?= "" # e.g. TAGS="test_with_docker"
+test/execute: TAGS ?= "" # e.g. TAGS="docker_enabled"
 # It depends on the build target because the runme binary
 # is used for tests, for example, "runme env dump".
 test/execute: build
@@ -41,7 +41,7 @@ test/execute: build
 test/coverage: PKGS ?= "./..."
 test/coverage: RUN ?= .*
 test/coverage: GOCOVERDIR ?= "."
-test/coverage: TAGS ?= "" # e.g. TAGS="test_with_docker"
+test/coverage: TAGS ?= "" # e.g. TAGS="docker_enabled"
 # It depends on the build target because the runme binary
 # is used for tests, for example, "runme env dump".
 test/coverage: build
@@ -71,6 +71,7 @@ test-docker/cleanup:
 .PHONY: test-docker/run
 test-docker/run:
 	docker run --rm \
+		-e RUNME_TEST_ENV=docker \
 		-v $(shell pwd):/workspace \
 		-v dev.runme.test-env-gocache:/root/.cache/go-build \
 		runme-test-env:latest

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ lint:
 		./...
 	@staticcheck ./...
 	@gosec -quiet -exclude=G110,G204,G304,G404 -exclude-generated ./...
+	@go vet -stdmethods=false ./...
+	@go vet -vettool=$(shell go env GOPATH)/bin/checklocks ./...
 
 .PHONY: pre-commit
 pre-commit: build wasm test lint
@@ -120,6 +122,7 @@ install/dev:
 	go install github.com/icholy/gomajor@v0.13.1
 	go install github.com/stateful/go-proto-gql/protoc-gen-gql@latest
 	go install github.com/atombender/go-jsonschema@v0.16.0
+	go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@go
 
 .PHONY: install/goreleaser
 install/goreleaser:

--- a/internal/cmd/code_server_test.go
+++ b/internal/cmd/code_server_test.go
@@ -1,4 +1,4 @@
-//go:build test_with_docker
+//go:build docker_enabled
 
 package cmd
 

--- a/internal/command/command_docker_test.go
+++ b/internal/command/command_docker_test.go
@@ -1,4 +1,4 @@
-//go:build test_with_docker
+//go:build docker_enabled
 
 package command
 

--- a/internal/command/command_inline_shell_test.go
+++ b/internal/command/command_inline_shell_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestInlineShellCommand_CollectEnv(t *testing.T) {
-	t.Parallel()
-
 	t.Run("Fifo", func(t *testing.T) {
 		envCollectorUseFifo = true
 		testInlineShellCommandCollectEnv(t)

--- a/internal/command/command_terminal_test.go
+++ b/internal/command/command_terminal_test.go
@@ -4,7 +4,6 @@ package command
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"io"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/stateful/runme/v3/internal/sbuffer"
 	"github.com/stateful/runme/v3/internal/session"
 	runnerv2 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
 )
@@ -26,7 +26,7 @@ func TestTerminalCommand_EnvPropagation(t *testing.T) {
 	session, err := session.New()
 	require.NoError(t, err)
 	stdinR, stdinW := io.Pipe()
-	stdout := bytes.NewBuffer(nil)
+	stdout := sbuffer.New(nil)
 
 	factory := NewFactory(WithLogger(zaptest.NewLogger(t)))
 
@@ -66,13 +66,11 @@ func TestTerminalCommand_EnvPropagation(t *testing.T) {
 }
 
 func TestTerminalCommand_Intro(t *testing.T) {
-	t.Parallel()
-
 	session, err := session.New(session.WithSeedEnv(os.Environ()))
 	require.NoError(t, err)
 
 	stdinR, stdinW := io.Pipe()
-	stdout := bytes.NewBuffer(nil)
+	stdout := sbuffer.New(nil)
 
 	factory := NewFactory(WithLogger(zaptest.NewLogger(t)))
 

--- a/internal/command/command_terminal_test.go
+++ b/internal/command/command_terminal_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stateful/runme/v3/internal/sbuffer"
 	"github.com/stateful/runme/v3/internal/session"
+	"github.com/stateful/runme/v3/internal/testutils"
 	runnerv2 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
 )
 
@@ -63,7 +64,7 @@ func TestTerminalCommand_EnvPropagation(t *testing.T) {
 
 	// Wait for the prompt before sending the next command.
 	prompt := "$"
-	if os.Getenv("RUNME_TEST_ENV") == "docker" {
+	if testutils.IsDockerTestEnv() {
 		prompt = "#"
 	}
 	expectContainLines(ctx, t, stdout, []string{prompt})

--- a/internal/command/command_terminal_test.go
+++ b/internal/command/command_terminal_test.go
@@ -4,6 +4,7 @@ package command
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/stateful/runme/v3/internal/sbuffer"
@@ -28,7 +30,7 @@ func TestTerminalCommand_EnvPropagation(t *testing.T) {
 	stdinR, stdinW := io.Pipe()
 	stdout := sbuffer.New(nil)
 
-	factory := NewFactory(WithLogger(zaptest.NewLogger(t)))
+	factory := NewFactory(WithLogger(zap.NewNop()))
 
 	cmd, err := factory.Build(
 		&ProgramConfig{
@@ -56,8 +58,16 @@ func TestTerminalCommand_EnvPropagation(t *testing.T) {
 
 	_, err = stdinW.Write([]byte("export TEST_ENV=1\n"))
 	require.NoError(t, err)
+	// Give the shell some time to process the command.
+	time.Sleep(time.Second)
+
 	// Wait for the prompt before sending the next command.
-	expectContainLines(ctx, t, stdout, []string{"$"})
+	prompt := "$"
+	if os.Getenv("RUNME_TEST_ENV") == "docker" {
+		prompt = "#"
+	}
+	expectContainLines(ctx, t, stdout, []string{prompt})
+
 	_, err = stdinW.Write([]byte("exit\n"))
 	require.NoError(t, err)
 
@@ -101,32 +111,37 @@ func expectContainLines(ctx context.Context, t *testing.T, r io.Reader, expected
 	t.Helper()
 
 	hits := make(map[string]bool, len(expected))
+	buf := new(bytes.Buffer)
 	output := new(strings.Builder)
 
-	for {
-		buf := new(bytes.Buffer)
-		r := io.TeeReader(r, buf)
+	r = io.TeeReader(r, buf)
 
+	for {
 		scanner := bufio.NewScanner(r)
 		for scanner.Scan() {
-			_, _ = output.WriteString(scanner.Text())
-		}
-		require.NoError(t, scanner.Err())
+			line := scanner.Text()
+			if line == "" {
+				continue
+			}
 
-		for _, e := range expected {
-			if strings.Contains(output.String(), e) {
-				hits[e] = true
+			_, _ = output.WriteString(line)
+
+			for _, e := range expected {
+				if strings.Contains(line, e) {
+					hits[e] = true
+				}
+			}
+
+			if len(hits) == len(expected) {
+				return
 			}
 		}
-
-		if len(hits) == len(expected) {
-			return
-		}
+		require.NoError(t, scanner.Err())
 
 		select {
 		case <-time.After(100 * time.Millisecond):
 		case <-ctx.Done():
-			t.Fatalf("error waiting for line %q, instead read %q: %s", expected, buf.Bytes(), ctx.Err())
+			t.Fatalf("error waiting for line %q, instead read %q: %s", expected, buf.String(), ctx.Err())
 		}
 	}
 }

--- a/internal/command/command_unix_test.go
+++ b/internal/command/command_unix_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/stateful/runme/v3/internal/sbuffer"
 	"github.com/stateful/runme/v3/internal/session"
 	runnerv2 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
 	"github.com/stateful/runme/v3/pkg/document"
@@ -326,7 +329,7 @@ func TestCommand_SetWinsize(t *testing.T) {
 	t.Run("InlineInteractive", func(t *testing.T) {
 		t.Parallel()
 
-		stdout := bytes.NewBuffer(nil)
+		stdout := sbuffer.New(nil)
 
 		cmd, err := factory.Build(
 			&ProgramConfig{
@@ -355,7 +358,7 @@ func TestCommand_SetWinsize(t *testing.T) {
 	t.Run("Terminal", func(t *testing.T) {
 		t.Parallel()
 
-		stdout := bytes.NewBuffer(nil)
+		stdout := sbuffer.New(nil)
 		stdinR, stdinW := io.Pipe()
 
 		// Even if the [ProgramConfig] specifies that the command is non-interactive,
@@ -392,9 +395,19 @@ func TestCommand_SetWinsize(t *testing.T) {
 		_, err = stdinW.Write([]byte{0x04}) // EOT
 		require.NoError(t, err)
 		err = cmd.Wait(context.Background())
-		require.NoError(t, err, "command failed due to: %s", stdout.String())
-		require.Contains(t, stdout.String(), "56\r\n")
-		require.Contains(t, stdout.String(), "45\r\n")
+		stdoutStr := stdout.String()
+		require.NoError(
+			t,
+			err,
+			"command failed due to: %s", strings.Map(func(r rune) rune {
+				if unicode.IsGraphic(r) {
+					return r
+				}
+				return -1
+			}, stdoutStr),
+		)
+		require.Contains(t, stdoutStr, "56")
+		require.Contains(t, stdoutStr, "45")
 	})
 }
 

--- a/internal/command/command_unix_test.go
+++ b/internal/command/command_unix_test.go
@@ -383,7 +383,7 @@ func TestCommand_SetWinsize(t *testing.T) {
 
 		// TODO(adamb): on macOS is is not necessary, but on Linux
 		// we need to wait for the shell to start before we start sending commands.
-		time.Sleep(time.Second)
+		time.Sleep(time.Second * 3)
 
 		err = SetWinsize(cmd, &Winsize{Rows: 45, Cols: 56, X: 0, Y: 0})
 		require.NoError(t, err)
@@ -393,7 +393,8 @@ func TestCommand_SetWinsize(t *testing.T) {
 		require.NoError(t, err)
 		err = cmd.Wait(context.Background())
 		require.NoError(t, err, "command failed due to: %s", stdout.String())
-		require.Contains(t, stdout.String(), "56\r\n45\r\n")
+		require.Contains(t, stdout.String(), "56\r\n")
+		require.Contains(t, stdout.String(), "45\r\n")
 	})
 }
 

--- a/internal/command/command_virtual.go
+++ b/internal/command/command_virtual.go
@@ -29,7 +29,8 @@ type virtualCommand struct {
 
 	wg sync.WaitGroup // watch goroutines copying I/O
 
-	mu  sync.Mutex // protect err
+	mu sync.Mutex // protect err
+	// +checklocks:mu
 	err error
 }
 

--- a/internal/dockerexec/docker_test.go
+++ b/internal/dockerexec/docker_test.go
@@ -1,4 +1,4 @@
-//go:build test_with_docker
+//go:build docker_enabled
 
 package dockerexec
 

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -39,7 +39,8 @@ type command struct {
 	Stdout      io.Writer
 	Stderr      io.Writer
 
-	cmd     *exec.Cmd
+	cmd *exec.Cmd
+	// +checkatomic
 	cmdDone uint32
 
 	// pty and tty as pseud-terminal primary and secondary.
@@ -53,8 +54,10 @@ type command struct {
 
 	context context.Context
 	wg      sync.WaitGroup
-	mu      sync.Mutex
-	err     error
+
+	mu sync.Mutex
+	// +checklocks:mu
+	err error
 
 	logger *zap.Logger
 }

--- a/internal/runnerv2service/execution.go
+++ b/internal/runnerv2service/execution.go
@@ -35,7 +35,8 @@ const (
 var opininatedEnvVarNamingRegexp = regexp.MustCompile(`^[A-Z_][A-Z0-9_]{1}[A-Z0-9_]*[A-Z][A-Z0-9_]*$`)
 
 type buffer struct {
-	mu     *sync.Mutex
+	mu *sync.Mutex
+	// +checklocks:mu
 	b      *bytes.Buffer
 	closed *atomic.Bool
 	close  chan struct{}

--- a/internal/runnerv2service/service_execute_test.go
+++ b/internal/runnerv2service/service_execute_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -1092,7 +1093,8 @@ func testStartRunnerServiceServer(t *testing.T) (
 
 	server := grpc.NewServer()
 
-	runnerService, err := NewRunnerService(factory, logger)
+	// Using nop logger to avoid data race.
+	runnerService, err := NewRunnerService(factory, zap.NewNop())
 	require.NoError(t, err)
 	runnerv2.RegisterRunnerServiceServer(server, runnerService)
 

--- a/internal/sbuffer/safe_buffer.go
+++ b/internal/sbuffer/safe_buffer.go
@@ -1,0 +1,43 @@
+package sbuffer
+
+import (
+	"bytes"
+	"sync"
+)
+
+type Buffer struct {
+	// +checklocks:mu
+	b  *bytes.Buffer
+	mu *sync.RWMutex
+}
+
+func New(buf []byte) *Buffer {
+	return &Buffer{
+		b:  bytes.NewBuffer(buf),
+		mu: &sync.RWMutex{},
+	}
+}
+
+func (b *Buffer) Bytes() []byte {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.b.Bytes()
+}
+
+func (b *Buffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *Buffer) WriteString(s string) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.WriteString(s)
+}
+
+func (b *Buffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Read(p)
+}

--- a/internal/sbuffer/safe_buffer.go
+++ b/internal/sbuffer/safe_buffer.go
@@ -24,6 +24,18 @@ func (b *Buffer) Bytes() []byte {
 	return b.b.Bytes()
 }
 
+func (b *Buffer) String() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.b.String()
+}
+
+func (b *Buffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Read(p)
+}
+
 func (b *Buffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -34,10 +46,4 @@ func (b *Buffer) WriteString(s string) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.b.WriteString(s)
-}
-
-func (b *Buffer) Read(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.b.Read(p)
 }

--- a/internal/session/env_store_map.go
+++ b/internal/session/env_store_map.go
@@ -7,7 +7,8 @@ import (
 )
 
 type EnvStoreMap struct {
-	mu    sync.RWMutex
+	mu sync.RWMutex
+	// +checklocks:mu
 	items map[string]string
 }
 

--- a/internal/testutils/env.go
+++ b/internal/testutils/env.go
@@ -1,0 +1,10 @@
+package testutils
+
+import "os"
+
+// IsDockerTestEnv returns true if the test is running in a Docker environment.
+// Check out the Makefile's "test-docker/run" target where "RUNME_TEST_ENV"
+// is set to "docker".
+func IsDockerTestEnv() bool {
+	return os.Getenv("RUNME_TEST_ENV") == "docker"
+}


### PR DESCRIPTION
This PR adds `go vet` call, including [`checklocks`](https://pkg.go.dev/gvisor.dev/gvisor/tools/checklocks), in `make lint`. It also fixes data races found using `RACE=true make test/execute`.

Retrying reverted https://github.com/stateful/runme/pull/694.