### PR TITLE
Allow code blocks to be selectively rendered as markdown

### DIFF
--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -159,10 +159,34 @@ func toCellsRec(
 			}
 
 		case *document.CodeBlock:
+			metadata := block.Attributes()
+			transform := true
+
+			t, tOk := metadata["transform"]
+			s, err := strconv.ParseBool(t)
+
+			if !tOk {
+				transform = true
+			} else if err == nil {
+				transform = s
+			}
+
+			// mermaid's an exception if attr wasn't explicitly set
+			if block.Language() == "mermaid" && !tOk {
+				transform = false
+			}
+
+			if !transform {
+				*cells = append(*cells, &Cell{
+					Kind:  MarkupKind,
+					Value: fmtValue(block.Value()),
+				})
+				break
+			}
+
 			textRange := block.TextRange()
 
 			// In the future, we will include language detection (#77).
-			metadata := block.Attributes()
 			if cellID := block.ID(); cellID != "" {
 				metadata[PrefixAttributeName(InternalAttributePrefix, "id")] = cellID
 			}

--- a/pkg/document/editor/editor_test.go
+++ b/pkg/document/editor/editor_test.go
@@ -593,3 +593,85 @@ A paragraph
 		)
 	})
 }
+
+func TestEditor_CodeBlockTransformation(t *testing.T) {
+	t.Run("MermaidException", func(t *testing.T) {
+		data := []byte("```mermaid\ngraph TD;\nA-->B;\nB-->C;\n```")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.EqualValues(t, MarkupKind, notebook.Cells[0].Kind)
+
+		newData, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(newData),
+		)
+	})
+
+	t.Run("MermaidForceTransformation", func(t *testing.T) {
+		data := []byte("```mermaid {\"transform\":\"true\"}\ngraph TD;\nA-->B;\nB-->C;\n```")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.EqualValues(t, CodeKind, notebook.Cells[0].Kind)
+
+		newData, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(newData),
+		)
+	})
+
+	t.Run("UnsetDefault", func(t *testing.T) {
+		data := []byte("```javascript\nconsole.log('test');\n```")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.EqualValues(t, CodeKind, notebook.Cells[0].Kind)
+
+		newData, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(newData),
+		)
+	})
+
+	t.Run("InvalidUsesDefault", func(t *testing.T) {
+		data := []byte("```javascript {\"transform\":\"abcdefg\"}\nconsole.log('test');\n```")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.EqualValues(t, CodeKind, notebook.Cells[0].Kind)
+
+		newData, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(newData),
+		)
+	})
+
+	t.Run("False", func(t *testing.T) {
+		data := []byte("```javascript {\"transform\":\"false\"}\nconsole.log('test');\n```")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.EqualValues(t, MarkupKind, notebook.Cells[0].Kind)
+
+		newData, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(newData),
+		)
+	})
+}


### PR DESCRIPTION
This PR allows more control over how code blocks are being rendered.

1. Introduce new annotation `transform` which defaults to `true`. If set to `false` code blocks will be deserialized as markdown.
2. Make exception for `mermaid` in `languageID` which can be overwritten with `transform: true`

This unlocks Mermaid diagram support in the notebooks.