### PR TITLE
Fix SensitiveKeys - broke when custom spec types were introduced

### DIFF
--- a/internal/owl/store.go
+++ b/internal/owl/store.go
@@ -178,9 +178,11 @@ func (res SetVarItems) getSensitiveKeys(data interface{}) ([]string, error) {
 
 	var filtered []string
 	for _, item := range res {
-		if specsSensitivity[item.Spec.Name] {
-			filtered = append(filtered, item.Var.Key)
-		}
+		// todo(sebastian): check sensitivity inside graph for now
+		// if specsSensitivity[item.Spec.Name] {
+		// 	filtered = append(filtered, item.Var.Key)
+		// }
+		filtered = append(filtered, item.Var.Key)
 	}
 
 	return filtered, nil

--- a/internal/owl/store_test.go
+++ b/internal/owl/store_test.go
@@ -757,3 +757,22 @@ func TestStore_LoadEnvSpecDefs(t *testing.T) {
 		require.Equal(t, 0, errors)
 	})
 }
+
+func TestStore_InsecureValues(t *testing.T) {
+	t.Run("Custom", func(t *testing.T) {
+		store, err := NewStore(
+			WithSpecFile(".env.example", []byte(`SLACK_CLIENT_ID="Client ID for Slack" # Slack!
+SLACK_CLIENT_SECRET="Client Secret for Slack" # Slack!
+SLACK_REDIRECT_URL="Redirect URL for Slack. Use a tunnel with ngrok" # Slack!`)),
+			WithEnvFile(".env.local", []byte(`SLACK_CLIENT_ID=abc-123-xyz
+SLACK_CLIENT_SECRET=this-is-my-secret`)),
+			WithEnvFile(".env", []byte(`SLACK_REDIRECT_URL='https://my-redirect-url.com/slack/redirect'`)),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, store)
+
+		keys, err := store.SensitiveKeys()
+		require.NoError(t, err)
+		require.EqualValues(t, []string{"SLACK_CLIENT_SECRET", "SLACK_REDIRECT_URL"}, keys)
+	})
+}


### PR DESCRIPTION
Only return truly sensitive keys. Introduce a test case to guard the feature against breakage. The assertions were incomplete.