### PR TITLE
Unescape shell literal if it's not a placeholder

### DIFF
--- a/internal/command/program_resolver.go
+++ b/internal/command/program_resolver.go
@@ -254,7 +254,12 @@ func (r *ProgramResolver) findOriginalValue(decl *syntax.DeclClause) (string, bo
 		return true
 	})
 
-	return strings.Join(fragments, " "), isPlaceholder
+	v := strings.Join(fragments, " ")
+	if !isPlaceholder {
+		v = unescapeShellLiteral(v)
+	}
+
+	return v, isPlaceholder
 }
 
 func (r *ProgramResolver) findEnvValue(name string) (string, bool) {
@@ -377,4 +382,16 @@ func (r *ProgramResolver) hasExpr(node syntax.Node) (found bool) {
 		}
 	})
 	return
+}
+
+func unescapeShellLiteral(escaped string) string {
+	replacer := strings.NewReplacer(
+		`\(`, `(`,
+		`\)`, `)`,
+		`\{`, `{`,
+		`\}`, `}`,
+		`\[`, `[`,
+		`\]`, `]`,
+	)
+	return replacer.Replace(escaped)
 }


### PR DESCRIPTION
Prompt messages are unquoted which requires them to be valid shell. Any values not quoted become prompt messages and are exclusively for human consumption. This is why we're removing backslashes from any form of parentheses.

Fixes #709.