### PR TITLE
Improve performance of remote exec in runnerv2

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -111,3 +111,9 @@ echo "Tag A,B"
 ```sh {"tag":"a,b,c","id":"01HF7BT3HD84GWTQB8ZY0GBA06","name":"c"}
 echo "Tag A,B,C"
 ```
+
+## Large files
+
+```sh {"name": "generate"}
+gunzip --stdout ./internal/command/testdata/users_1m.json.gz
+```

--- a/internal/cmd/beta/run_cmd.go
+++ b/internal/cmd/beta/run_cmd.go
@@ -177,11 +177,13 @@ func runCodeBlock(
 
 	cfg.Mode = runnerv2.CommandMode_COMMAND_MODE_CLI
 
-	execInfo := &rcontext.ExecutionInfo{
-		KnownName: block.Name(),
-		KnownID:   block.ID(),
-	}
-	ctx = rcontext.ContextWithExecutionInfo(ctx, execInfo)
+	ctx = rcontext.WithExecutionInfo(
+		ctx,
+		&rcontext.ExecutionInfo{
+			KnownName: block.Name(),
+			KnownID:   block.ID(),
+		},
+	)
 
 	cmd, err := factory.Build(cfg, options)
 	if err != nil {

--- a/internal/owl/store.go
+++ b/internal/owl/store.go
@@ -698,12 +698,12 @@ func (s *Store) LoadEnvs(source string, envs ...string) error {
 	return nil
 }
 
-func (s *Store) Update(context context.Context, newOrUpdated, deleted []string) error {
+func (s *Store) Update(ctx context.Context, newOrUpdated, deleted []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	execRef := "[execution]"
-	if execInfo, ok := context.Value(rcontext.ExecutionInfoKey).(*rcontext.ExecutionInfo); ok {
+	if execInfo, ok := rcontext.ExecutionInfoFromContext(ctx); ok {
 		execRef = fmt.Sprintf("#%s", execInfo.KnownID)
 		if execInfo.KnownName != "" {
 			execRef = fmt.Sprintf("#%s", execInfo.KnownName)

--- a/internal/runner/context/exec_info.go
+++ b/internal/runner/context/exec_info.go
@@ -2,9 +2,9 @@ package runner
 
 import "context"
 
-type runnerContextKey struct{}
+type contextKey struct{ string }
 
-var ExecutionInfoKey = &runnerContextKey{}
+var executionInfoKey = &contextKey{"ExecutionInfo"}
 
 type ExecutionInfo struct {
 	ExecContext string
@@ -13,6 +13,11 @@ type ExecutionInfo struct {
 	RunID       string
 }
 
-func ContextWithExecutionInfo(ctx context.Context, execInfo *ExecutionInfo) context.Context {
-	return context.WithValue(ctx, ExecutionInfoKey, execInfo)
+func WithExecutionInfo(ctx context.Context, execInfo *ExecutionInfo) context.Context {
+	return context.WithValue(ctx, executionInfoKey, execInfo)
+}
+
+func ExecutionInfoFromContext(ctx context.Context) (*ExecutionInfo, bool) {
+	execInfo, ok := ctx.Value(executionInfoKey).(*ExecutionInfo)
+	return execInfo, ok
 }

--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -228,7 +228,7 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 		KnownName: req.GetKnownName(),
 		KnownID:   req.GetKnownId(),
 	}
-	ctx := rcontext.ContextWithExecutionInfo(srv.Context(), execInfo)
+	ctx := rcontext.WithExecutionInfo(srv.Context(), execInfo)
 
 	if req.KnownId != "" {
 		logger = logger.With(zap.String("knownID", req.KnownId))
@@ -351,9 +351,8 @@ func (r *runnerService) Execute(srv runnerv1.RunnerService_ExecuteServer) error 
 	}
 
 	cmdCtx := ctx
-
 	if req.Background {
-		cmdCtx = rcontext.ContextWithExecutionInfo(context.Background(), execInfo)
+		cmdCtx = rcontext.WithExecutionInfo(context.Background(), execInfo)
 	}
 
 	if err := cmd.StartWithOpts(cmdCtx, &startOpts{}); err != nil {

--- a/internal/runnerv2service/buffer.go
+++ b/internal/runnerv2service/buffer.go
@@ -1,0 +1,84 @@
+package runnerv2service
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// msgBufferSize limits the size of data chunks
+	// sent by the handler to clients. It's smaller
+	// intentionally as typically the messages are
+	// small.
+	// In the future, it might be worth to implement
+	// variable-sized buffers.
+	msgBufferSize = 16 * 1024 * 1024 // 16 MiB
+)
+
+// buffer is a thread-safe buffer that returns EOF
+// only when it's closed.
+type buffer struct {
+	mu *sync.Mutex
+	// +checklocks:mu
+	b      *bytes.Buffer
+	closed *atomic.Bool
+	close  chan struct{}
+	more   chan struct{}
+}
+
+var _ io.WriteCloser = (*buffer)(nil)
+
+func newBuffer(size int) *buffer {
+	return &buffer{
+		mu:     &sync.Mutex{},
+		b:      bytes.NewBuffer(make([]byte, 0, size)),
+		closed: &atomic.Bool{},
+		close:  make(chan struct{}),
+		more:   make(chan struct{}),
+	}
+}
+
+func (b *buffer) Write(p []byte) (int, error) {
+	if b.closed.Load() {
+		return 0, errors.New("closed")
+	}
+
+	b.mu.Lock()
+	n, err := b.b.Write(p)
+	b.mu.Unlock()
+
+	select {
+	case b.more <- struct{}{}:
+	default:
+	}
+
+	return n, err
+}
+
+func (b *buffer) Close() error {
+	if b.closed.CompareAndSwap(false, true) {
+		close(b.close)
+	}
+	return nil
+}
+
+func (b *buffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	n, err := b.b.Read(p)
+	b.mu.Unlock()
+
+	if err != nil && errors.Is(err, io.EOF) && !b.closed.Load() {
+		select {
+		case <-b.more:
+		case <-b.close:
+			return n, io.EOF
+		}
+		return n, nil
+	}
+
+	return n, err
+}

--- a/internal/runnerv2service/convert.go
+++ b/internal/runnerv2service/convert.go
@@ -1,0 +1,30 @@
+package runnerv2service
+
+import (
+	"github.com/stateful/runme/v3/internal/session"
+	runnerv2 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
+	"github.com/stateful/runme/v3/pkg/project"
+)
+
+func convertSessionToProtoSession(sess *session.Session) *runnerv2.Session {
+	return &runnerv2.Session{
+		Id:  sess.ID,
+		Env: sess.GetAllEnv(),
+		// Metadata: sess.Metadata,
+	}
+}
+
+// TODO(adamb): this function should not return nil project and nil error at the same time.
+func convertProtoProjectToProject(runnerProj *runnerv2.Project) (*project.Project, error) {
+	if runnerProj == nil {
+		return nil, nil
+	}
+
+	opts := project.DefaultProjectOptions[:]
+
+	if runnerProj.EnvLoadOrder != nil {
+		opts = append(opts, project.WithEnvFilesReadOrder(runnerProj.EnvLoadOrder))
+	}
+
+	return project.NewDirProject(runnerProj.Root, opts...)
+}

--- a/internal/runnerv2service/execution.go
+++ b/internal/runnerv2service/execution.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"sync"
-	"sync/atomic"
 	"syscall"
+	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
 
 	"github.com/stateful/runme/v3/internal/command"
 	"github.com/stateful/runme/v3/internal/rbuffer"
@@ -22,90 +22,22 @@ import (
 	"github.com/stateful/runme/v3/pkg/project"
 )
 
-const (
-	// msgBufferSize limits the size of data chunks
-	// sent by the handler to clients. It's smaller
-	// intentionally as typically the messages are
-	// small.
-	// In the future, it might be worth to implement
-	// variable-sized buffers.
-	msgBufferSize = 2 * 1024 * 1024 // 2 MiB
-)
-
 var opininatedEnvVarNamingRegexp = regexp.MustCompile(`^[A-Z_][A-Z0-9_]{1}[A-Z0-9_]*[A-Z][A-Z0-9_]*$`)
 
-type buffer struct {
-	mu *sync.Mutex
-	// +checklocks:mu
-	b      *bytes.Buffer
-	closed *atomic.Bool
-	close  chan struct{}
-	more   chan struct{}
-}
-
-var _ io.WriteCloser = (*buffer)(nil)
-
-func newBuffer() *buffer {
-	return &buffer{
-		mu:     &sync.Mutex{},
-		b:      bytes.NewBuffer(make([]byte, 0, msgBufferSize)),
-		closed: &atomic.Bool{},
-		close:  make(chan struct{}),
-		more:   make(chan struct{}),
-	}
-}
-
-func (b *buffer) Write(p []byte) (int, error) {
-	if b.closed.Load() {
-		return 0, errors.New("closed")
-	}
-
-	b.mu.Lock()
-	n, err := b.b.Write(p)
-	b.mu.Unlock()
-
-	select {
-	case b.more <- struct{}{}:
-	default:
-	}
-
-	return n, err
-}
-
-func (b *buffer) Close() error {
-	if b.closed.CompareAndSwap(false, true) {
-		close(b.close)
-	}
-	return nil
-}
-
-func (b *buffer) Read(p []byte) (int, error) {
-	b.mu.Lock()
-	n, err := b.b.Read(p)
-	b.mu.Unlock()
-
-	if err != nil && errors.Is(err, io.EOF) && !b.closed.Load() {
-		select {
-		case <-b.more:
-		case <-b.close:
-			return n, io.EOF
-		}
-		return n, nil
-	}
-
-	return n, err
+func matchesOpinionatedEnvVarNaming(knownName string) bool {
+	return opininatedEnvVarNamingRegexp.MatchString(knownName)
 }
 
 type execution struct {
-	Cmd              command.Command
+	Cmd command.Command
+
 	knownName        string
 	logger           *zap.Logger
 	session          *session.Session
-	stdin            io.Reader
-	stdinWriter      io.WriteCloser
-	stdout           *buffer
-	stderr           *buffer
 	storeStdoutInEnv bool
+
+	stdinR, stdoutR, stderrR io.Reader
+	stdinW, stdoutW, stderrW io.WriteCloser
 }
 
 func newExecution(
@@ -115,22 +47,24 @@ func newExecution(
 	logger *zap.Logger,
 	storeStdoutInEnv bool,
 ) (*execution, error) {
+	logger = logger.Named("execution")
+
 	cmdFactory := command.NewFactory(
-		command.WithLogger(logger),
 		command.WithProject(proj),
+		command.WithLogger(logger),
 	)
 
-	stdin, stdinWriter := io.Pipe()
-	stdout := newBuffer()
-	stderr := newBuffer()
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
 
 	cmdOptions := command.CommandOptions{
 		EnableEcho:  true,
 		Session:     session,
-		StdinWriter: stdinWriter,
-		Stdin:       stdin,
-		Stdout:      stdout,
-		Stderr:      stderr,
+		StdinWriter: stdinW,
+		Stdin:       stdinR,
+		Stdout:      stdoutW,
+		Stderr:      stderrW,
 	}
 
 	cmd, err := cmdFactory.Build(cfg, cmdOptions)
@@ -139,133 +73,204 @@ func newExecution(
 	}
 
 	exec := &execution{
-		Cmd:              cmd,
+		Cmd: cmd,
+
 		knownName:        cfg.GetKnownName(),
 		logger:           logger,
 		session:          session,
-		stdin:            stdin,
-		stdinWriter:      stdinWriter,
-		stdout:           stdout,
-		stderr:           stderr,
 		storeStdoutInEnv: storeStdoutInEnv,
-	}
 
+		stdinR:  stdinR,
+		stdinW:  stdinW,
+		stdoutR: stdoutR,
+		stdoutW: stdoutW,
+		stderrR: stderrR,
+		stderrW: stderrW,
+	}
 	return exec, nil
 }
 
-func (e *execution) Wait(ctx context.Context, sender sender) (int, error) {
-	lastStdout := io.Discard
+func (e *execution) closeIO() {
+	err := e.stdinW.Close()
+	e.logger.Info("closed stdin writer", zap.Error(err))
+
+	err = e.stdoutW.Close()
+	e.logger.Info("closed stdout writer", zap.Error(err))
+
+	err = e.stderrW.Close()
+	e.logger.Info("closed stderr writer", zap.Error(err))
+}
+
+func (e *execution) storeOutputInEnv(ctx context.Context, r io.Reader) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		e.logger.Warn("failed to read last output", zap.Error(err))
+		return
+	}
+
+	sanitized := bytes.ReplaceAll(b, []byte{'\000'}, nil)
+	env := command.CreateEnv(command.StoreStdoutEnvName, string(sanitized))
+	if err := e.session.SetEnv(ctx, env); err != nil {
+		e.logger.Warn("failed to store last output", zap.Error(err))
+	}
+
+	if e.knownName != "" && matchesOpinionatedEnvVarNaming(e.knownName) {
+		if err := e.session.SetEnv(ctx, e.knownName+"="+string(sanitized)); err != nil {
+			e.logger.Warn("failed to store output under known name", zap.String("known_name", e.knownName), zap.Error(err))
+		}
+	}
+}
+
+func (e *execution) Wait(ctx context.Context, sender runnerv2.RunnerService_ExecuteServer) (int, error) {
+	envStdout := io.Discard
 	if e.storeStdoutInEnv {
 		b := rbuffer.NewRingBuffer(session.MaxEnvSizeInBytes - len(command.StoreStdoutEnvName) - 1)
 		defer func() {
 			_ = b.Close()
 			e.storeOutputInEnv(ctx, b)
 		}()
-		lastStdout = b
+		envStdout = b
 	}
 
-	firstStdoutSent := false
-	errc := make(chan error, 2)
-
+	readSendDone := make(chan error, 2)
 	go func() {
-		errc <- readSendLoop(
-			e.stdout,
+		mimetypeDetected := false
+
+		readSendDone <- e.readSendLoop(
 			sender,
+			e.stdoutR,
 			func(b []byte) *runnerv2.ExecuteResponse {
-				if len(b) == 0 {
-					return nil
+				if _, err := envStdout.Write(b); err != nil {
+					e.logger.Warn("failed to write to envStdout writer", zap.Error(err))
+					envStdout = io.Discard
 				}
 
-				_, err := lastStdout.Write(b)
-				if err != nil {
-					e.logger.Warn("failed to write last output", zap.Error(err))
+				response := &runnerv2.ExecuteResponse{
+					StdoutData: b,
 				}
 
-				resp := &runnerv2.ExecuteResponse{StdoutData: b}
-
-				if !firstStdoutSent {
-					if detected := mimetype.Detect(b); detected != nil {
-						e.logger.Info("detected MIME type", zap.String("mime", detected.String()))
-						resp.MimeType = detected.String()
+				if !mimetypeDetected {
+					if detected := mimetype.Detect(response.StdoutData); detected != nil {
+						mimetypeDetected = true
+						response.MimeType = detected.String()
+						e.logger.Debug("detected MIME type", zap.String("mime", detected.String()))
+					} else {
+						e.logger.Debug("failed to detect MIME type")
 					}
 				}
-				firstStdoutSent = true
 
-				e.logger.Debug("sending stdout data", zap.Int("len", len(resp.StdoutData)))
-
-				return resp
+				return response
 			},
-			e.logger.With(zap.String("source", "stdout")),
+			e.logger.Named("readSendLoop.stdout"),
 		)
 	}()
 	go func() {
-		errc <- readSendLoop(
-			e.stderr,
+		readSendDone <- e.readSendLoop(
 			sender,
+			e.stderrR,
 			func(b []byte) *runnerv2.ExecuteResponse {
-				if len(b) == 0 {
-					return nil
+				return &runnerv2.ExecuteResponse{
+					StderrData: b,
 				}
-				resp := &runnerv2.ExecuteResponse{StderrData: b}
-				e.logger.Debug("sending stderr data", zap.Any("resp", resp))
-				return resp
 			},
-			e.logger.With(zap.String("source", "stderr")),
+			e.logger.Named("readSendLoop.stderr"),
 		)
 	}()
 
 	waitErr := e.Cmd.Wait(ctx)
 	exitCode := exitCodeFromErr(waitErr)
-
 	e.logger.Info("command finished", zap.Int("exitCode", exitCode), zap.Error(waitErr))
 
 	e.closeIO()
 
-	// If waitErr is not nil, only log the errors but return waitErr.
 	if waitErr != nil {
-		handlerErrors := 0
-
-	readSendHandlerForWaitErr:
-		select {
-		case err := <-errc:
-			handlerErrors++
-			e.logger.Info("readSendLoop finished; ignoring any errors because there was a wait error", zap.Error(err))
-			// Wait for both errors, or nils.
-			if handlerErrors < 2 {
-				goto readSendHandlerForWaitErr
-			}
-		case <-ctx.Done():
-			e.logger.Info("context canceled while waiting for the readSendLoop finish; ignoring any errors because there was a wait error")
-		}
 		return exitCode, waitErr
 	}
 
-	// If waitErr is nil, wait for the readSendLoop to finish,
-	// or the context being canceled.
+	readSendLoopsFinished := 0
+
+finalWait:
 	select {
-	case err1 := <-errc:
-		// Wait for both errors, or nils.
-		select {
-		case err2 := <-errc:
-			if err2 != nil {
-				e.logger.Info("another error from readSendLoop; won't be returned", zap.Error(err2))
-			}
-		case <-ctx.Done():
-		}
-		return exitCode, err1
 	case <-ctx.Done():
+		e.logger.Info("context done", zap.Error(ctx.Err()))
 		return exitCode, ctx.Err()
+	case err := <-readSendDone:
+		if err != nil {
+			e.logger.Info("readSendCtx done", zap.Error(err))
+		}
+		readSendLoopsFinished++
+		if readSendLoopsFinished < 2 {
+			goto finalWait
+		}
+		return exitCode, err
+	}
+}
+
+func (e *execution) readSendLoop(
+	sender runnerv2.RunnerService_ExecuteServer,
+	src io.Reader,
+	cb func([]byte) *runnerv2.ExecuteResponse,
+	logger *zap.Logger,
+) error {
+	// Limit to 30 sends per second. This is typically quite enough
+	// for interactive commands and streaming the output.
+	const sendsPerSecond = 30
+
+	// This is a thread-safe buffer.
+	// Data from `src` is copied to this buffer
+	// in a goroutine and then read from it
+	// in the main loop.
+	buf := newBuffer(msgBufferSize)
+
+	// Copy from src to buffer.
+	go func() {
+		n, err := io.Copy(buf, src)
+		logger.Debug("copied from source to buffer", zap.Int64("count", n), zap.Error(err))
+		_ = buf.Close() // always nil
+	}()
+
+	data := make([]byte, msgBufferSize)
+
+	for {
+		eof := false
+		n, err := buf.Read(data)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				return errors.WithStack(err)
+			}
+			eof = true
+		}
+		logger.Debug("read", zap.Int("n", n), zap.Bool("eof", eof))
+		if n == 0 {
+			if eof {
+				return nil
+			}
+			continue
+		}
+
+		readTime := time.Now()
+
+		response := cb(data[:n])
+		if err := sender.Send(response); err != nil {
+			return errors.WithStack(err)
+		}
+
+		if n < msgBufferSize {
+			time.Sleep(time.Second/sendsPerSecond - time.Since(readTime))
+		}
 	}
 }
 
 func (e *execution) Write(p []byte) (int, error) {
-	n, err := e.stdinWriter.Write(p)
+	n, err := e.stdinW.Write(p)
+
+	e.logger.Debug("wrote to stdin", zap.Int("payload", len(p)), zap.Int("n", n), zap.Error(err))
 
 	// Close stdin writer for non-interactive commands after handling the initial request.
 	// Non-interactive commands do not support sending data continuously and require that
 	// the stdin writer to be closed to finish processing the input.
 	if ok := e.Cmd.Interactive(); !ok {
-		if closeErr := e.stdinWriter.Close(); closeErr != nil {
+		if closeErr := e.stdinW.Close(); closeErr != nil {
 			e.logger.Info("failed to close native command stdin writer", zap.Error(closeErr))
 			if err == nil {
 				err = closeErr
@@ -293,6 +298,8 @@ func (e *execution) SetWinsize(size *runnerv2.Winsize) error {
 }
 
 func (e *execution) Stop(stop runnerv2.ExecuteStop) (err error) {
+	e.logger.Info("stopping program", zap.Any("stop", stop))
+
 	switch stop {
 	case runnerv2.ExecuteStop_EXECUTE_STOP_UNSPECIFIED:
 		// continue
@@ -304,81 +311,6 @@ func (e *execution) Stop(stop runnerv2.ExecuteStop) (err error) {
 		err = errors.New("unknown stop signal")
 	}
 	return
-}
-
-func (e *execution) closeIO() {
-	err := e.stdinWriter.Close()
-	e.logger.Info("closed stdin writer", zap.Error(err))
-
-	err = e.stdout.Close()
-	e.logger.Info("closed stdout writer", zap.Error(err))
-
-	err = e.stderr.Close()
-	e.logger.Info("closed stderr writer", zap.Error(err))
-}
-
-func (e *execution) storeOutputInEnv(ctx context.Context, r io.Reader) {
-	b, err := io.ReadAll(r)
-	if err != nil {
-		e.logger.Warn("failed to read last output", zap.Error(err))
-		return
-	}
-
-	sanitized := bytes.ReplaceAll(b, []byte{'\000'}, nil)
-	env := command.CreateEnv(command.StoreStdoutEnvName, string(sanitized))
-	if err := e.session.SetEnv(ctx, env); err != nil {
-		e.logger.Warn("failed to store last output", zap.Error(err))
-	}
-
-	if e.knownName != "" && matchesOpinionatedEnvVarNaming(e.knownName) {
-		if err := e.session.SetEnv(ctx, e.knownName+"="+string(sanitized)); err != nil {
-			e.logger.Warn("failed to store output under known name", zap.String("known_name", e.knownName), zap.Error(err))
-		}
-	}
-}
-
-func matchesOpinionatedEnvVarNaming(knownName string) bool {
-	return opininatedEnvVarNamingRegexp.MatchString(knownName)
-}
-
-type sender interface {
-	Send(*runnerv2.ExecuteResponse) error
-}
-
-func readSendLoop(
-	reader io.Reader,
-	sender sender,
-	fn func([]byte) *runnerv2.ExecuteResponse,
-	logger *zap.Logger,
-) error {
-	buf := make([]byte, msgBufferSize)
-
-	for {
-		eof := false
-		n, err := reader.Read(buf)
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				return errors.WithStack(err)
-			}
-			eof = true
-		}
-
-		logger.Info("readSendLoop", zap.Int("n", n))
-
-		if n == 0 && eof {
-			return nil
-		}
-
-		msg := fn(buf[:n])
-		if msg == nil {
-			continue
-		}
-
-		err = sender.Send(msg)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-	}
 }
 
 func exitCodeFromErr(err error) int {

--- a/internal/runnerv2service/service.go
+++ b/internal/runnerv2service/service.go
@@ -68,6 +68,7 @@ func (r *runnerService) getOrCreateSessionFromRequest(req requestWithSession, pr
 		found bool
 	)
 
+	// TODO(adamb): this should come from the runme.yaml in the future.
 	seedEnv := os.Environ()
 
 	switch req.GetSessionStrategy() {

--- a/internal/runnerv2service/service_sessions.go
+++ b/internal/runnerv2service/service_sessions.go
@@ -11,31 +11,7 @@ import (
 	rcontext "github.com/stateful/runme/v3/internal/runner/context"
 	"github.com/stateful/runme/v3/internal/session"
 	runnerv2 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
-	"github.com/stateful/runme/v3/pkg/project"
 )
-
-func convertSessionToRunnerv2alpha1Session(sess *session.Session) *runnerv2.Session {
-	return &runnerv2.Session{
-		Id:  sess.ID,
-		Env: sess.GetAllEnv(),
-		// Metadata: sess.Metadata,
-	}
-}
-
-// TODO(adamb): this function should not return nil project and nil error at the same time.
-func convertProtoProjectToProject(runnerProj *runnerv2.Project) (*project.Project, error) {
-	if runnerProj == nil {
-		return nil, nil
-	}
-
-	opts := project.DefaultProjectOptions[:]
-
-	if runnerProj.EnvLoadOrder != nil {
-		opts = append(opts, project.WithEnvFilesReadOrder(runnerProj.EnvLoadOrder))
-	}
-
-	return project.NewDirProject(runnerProj.Root, opts...)
-}
 
 func (r *runnerService) CreateSession(ctx context.Context, req *runnerv2.CreateSessionRequest) (*runnerv2.CreateSessionResponse, error) {
 	r.logger.Info("running CreateSession in runnerService")
@@ -75,7 +51,7 @@ func (r *runnerService) CreateSession(ctx context.Context, req *runnerv2.CreateS
 	r.logger.Debug("created session", zap.String("id", sess.ID), zap.Bool("owl", owl), zap.Int("seed_env_len", len(seedEnv)))
 
 	return &runnerv2.CreateSessionResponse{
-		Session: convertSessionToRunnerv2alpha1Session(sess),
+		Session: convertSessionToProtoSession(sess),
 	}, nil
 }
 
@@ -88,7 +64,7 @@ func (r *runnerService) GetSession(_ context.Context, req *runnerv2.GetSessionRe
 	}
 
 	return &runnerv2.GetSessionResponse{
-		Session: convertSessionToRunnerv2alpha1Session(sess),
+		Session: convertSessionToProtoSession(sess),
 	}, nil
 }
 
@@ -99,7 +75,7 @@ func (r *runnerService) ListSessions(_ context.Context, req *runnerv2.ListSessio
 
 	runnerSessions := make([]*runnerv2.Session, 0, len(sessions))
 	for _, s := range sessions {
-		runnerSessions = append(runnerSessions, convertSessionToRunnerv2alpha1Session(s))
+		runnerSessions = append(runnerSessions, convertSessionToProtoSession(s))
 	}
 
 	return &runnerv2.ListSessionsResponse{Sessions: runnerSessions}, nil
@@ -117,7 +93,7 @@ func (r *runnerService) UpdateSession(ctx context.Context, req *runnerv2.UpdateS
 		return nil, err
 	}
 
-	return &runnerv2.UpdateSessionResponse{Session: convertSessionToRunnerv2alpha1Session(sess)}, nil
+	return &runnerv2.UpdateSessionResponse{Session: convertSessionToProtoSession(sess)}, nil
 }
 
 func (r *runnerService) DeleteSession(_ context.Context, req *runnerv2.DeleteSessionRequest) (*runnerv2.DeleteSessionResponse, error) {
@@ -138,7 +114,7 @@ type updateRequest interface {
 }
 
 func (r *runnerService) updateSession(ctx context.Context, sess *session.Session, req updateRequest) error {
-	ctx = rcontext.ContextWithExecutionInfo(ctx, &rcontext.ExecutionInfo{
+	ctx = rcontext.WithExecutionInfo(ctx, &rcontext.ExecutionInfo{
 		ExecContext: "request",
 	})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,9 +23,7 @@ import (
 	"github.com/stateful/runme/v3/pkg/document/editor/editorservice"
 )
 
-const (
-	maxMsgSize = 4 * 1024 * 1024 // 4 MiB
-)
+const maxMsgSize = 32 * 1024 * 1024 // 32 MiB
 
 type Config struct {
 	Address    string

--- a/internal/testutils/grpc.go
+++ b/internal/testutils/grpc.go
@@ -42,6 +42,8 @@ func newGRPCClient[T any](
 			return lis.Dial()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		// Set the maximum message size to 32 MiB and align it with [server.Server].
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(32*1024*1024)),
 	)
 	if err != nil {
 		var result T

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -37,6 +37,7 @@ func LoadClientConfig(certFile, keyFile string) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      certPool,
 		MinVersion:   tls.VersionTLS12,
+		NextProtos:   []string{"h2"},
 	}, nil
 }
 


### PR DESCRIPTION
This PR refactors the `runnerv2service` package to speed up the performance of executing programs producing large output.

### Test

`cat` a large file and pipe the output to `/dev/null`. As the execution goes through the server, the execution involves marshaling and unmarshaling to Protobuf.

#### This PR

```
time ./runme beta run --remote generate | cat - >/dev/null
./runme beta run --remote generate  0.70s user 0.64s system 33% cpu 3.973 total
cat - > /dev/null  0.01s user 0.06s system 1% cpu 3.972 total
```

#### Main

```
time ./runme beta run --remote generate | cat - >/dev/null
./runme beta run --remote generate  5.58s user 6.89s system 146% cpu 8.537 total
cat - > /dev/null  0.21s user 1.04s system 14% cpu 8.536 total
```

We have a speed increase of over 2x.
