### PR TITLE
fix: shell dry-run output should be runable

### DIFF
--- a/internal/runner/shell.go
+++ b/internal/runner/shell.go
@@ -40,7 +40,7 @@ func (s Shell) DryRun(ctx context.Context, w io.Writer) {
 	var b bytes.Buffer
 
 	_, _ = b.WriteString(fmt.Sprintf("#!%s\n\n", s.ProgramPath()))
-	_, _ = b.WriteString(fmt.Sprintf("// run in %q\n\n", s.Dir))
+	_, _ = b.WriteString(fmt.Sprintf("# run in %q\n\n", s.Dir))
 	_, _ = b.WriteString(prepareScriptFromCommands(s.Cmds, s.ShellType()))
 
 	_, err := w.Write(b.Bytes())


### PR DESCRIPTION
I've redirected the output of `runme run --dry-run` into a file.
The code block was of bash type and the file nicely starts with shebang:

```
#!/usr/local/bin/bash

// run in "/Users/lalyos/somedir"

set -e -o pipefail
echo hello
```
but the `run id "dir"` line supposed to be a comment, but the syntaxt doesn't fit shell syntax. 
