### PR TITLE
Retain markdown's fenced code block encoding format

### DIFF
--- a/internal/cmd/beta/beta_cmd.go
+++ b/internal/cmd/beta/beta_cmd.go
@@ -59,7 +59,6 @@ All commands use the runme.yaml configuration file.`,
 
 				return nil
 			})
-
 			// Print the error to stderr but don't return it because error modes
 			// are neither fully baked yet nor ready for users to consume.
 			if err != nil {

--- a/pkg/document/attributes.go
+++ b/pkg/document/attributes.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-// Attributes impl [AttributesStore] containing a set of key-value pairs applicable to [Cell]s.
+// Attributes stores the attributes of a code block along with the format.
 // More: https://docs.runme.dev/configuration/cell-level
 type Attributes struct {
 	Format string
@@ -21,6 +21,7 @@ type Attributes struct {
 }
 
 // NewAttributes creates a new [Attributes] instance.
+// Check out the [NewAttributesWithFormat] function for more options.
 func NewAttributes(items map[string]string) *Attributes {
 	return NewAttributesWithFormat(items, "json")
 }
@@ -163,8 +164,9 @@ func (p *jsonAttrParserWriter) Write(w io.Writer, attr *Attributes) error {
 type htmlAttrParserWriter struct{}
 
 func (p *htmlAttrParserWriter) Parse(raw []byte) (*Attributes, error) {
-	rawAttributes := extractAttributes(raw)
-	attrMap := p.parseRawAttributes(rawAttributes)
+	rawAttr := extractAttributes(raw)
+	rawAttr = bytes.Trim(rawAttr, "{}")
+	attrMap := p.parseRawAttributes(rawAttr)
 	return NewAttributesWithFormat(attrMap, "html"), nil
 }
 
@@ -187,9 +189,6 @@ func (p *htmlAttrParserWriter) Write(w io.Writer, attr *Attributes) error {
 }
 
 func (*htmlAttrParserWriter) parseRawAttributes(raw []byte) map[string]string {
-	// TODO(adamb): consider to pass value without "{" and "}".
-	raw = bytes.Trim(raw, "{}")
-
 	items := bytes.Split(raw, []byte{' '})
 	if len(items) == 0 {
 		return nil

--- a/pkg/document/attributes.go
+++ b/pkg/document/attributes.go
@@ -8,71 +8,136 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/yuin/goldmark/ast"
 	"go.uber.org/multierr"
 )
 
-type Attributes map[string]string
-
-type attributeParser interface {
-	Parse(raw []byte) (Attributes, error)
-	Write(attr Attributes, w io.Writer) error
+var _defaultAttributeParserWriter = &multiParserWriter{
+	parsers: []attributesParserWriter{
+		&jsonParserWriter{},
+		&htmlAttributesParserWriter{},
+	},
+	writer: &jsonParserWriter{},
 }
 
-func getRawAttributes(source []byte) []byte {
-	start, stop := -1, -1
+// Attributes represents a set of key-value pairs applicable to [Cell]s.
+// More: https://docs.runme.dev/configuration/cell-level
+type Attributes map[string]string
 
-	for i := 0; i < len(source); i++ {
-		if start == -1 && source[i] == '{' && i+1 < len(source) && source[i+1] != '}' {
-			start = i + 1
-		}
-		if stop == -1 && source[i] == '}' {
-			stop = i
-			break
+// WriteAttributes writes [Attributes] to [io.Writer].
+func WriteAttributes(w io.Writer, attr Attributes) error {
+	return _defaultAttributeParserWriter.Write(w, attr)
+}
+
+// parseAttributes parses [Attributes] from raw bytes.
+func parseAttributes(raw []byte) (Attributes, error) {
+	return _defaultAttributeParserWriter.Parse(raw)
+}
+
+type attributesParserWriter interface {
+	Parse([]byte) (Attributes, error)
+	Write(io.Writer, Attributes) error
+}
+
+func newAttributesFromFencedCodeBlock(
+	node *ast.FencedCodeBlock,
+	source []byte,
+) (Attributes, error) {
+	attributes := make(map[string]string)
+
+	if node.Info == nil {
+		return attributes, nil
+	}
+
+	content := node.Info.Value(source)
+
+	rawAttributes := extractAttributes(content)
+	if len(rawAttributes) > 0 {
+		var err error
+		attributes, err = parseAttributes(rawAttributes)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	if start >= 0 && stop >= 0 {
-		return bytes.TrimSpace(source[start-1 : stop+1])
+	return attributes, nil
+}
+
+// jsonParserWriter parses all values as strings.
+//
+// The correct format is as follows:
+//
+//	{ key: "value", hello: "world", string_value: "2" }
+type jsonParserWriter struct{}
+
+func (p *jsonParserWriter) Parse(raw []byte) (Attributes, error) {
+	// Parse first to a generic map.
+	parsed := make(map[string]interface{})
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, errors.WithStack(err)
 	}
+
+	result := make(Attributes, len(parsed))
+
+	// Convert all values to strings.
+	for k, v := range parsed {
+		if strVal, ok := v.(string); ok {
+			result[k] = strVal
+		} else {
+			if stringified, err := json.Marshal(v); err == nil {
+				result[k] = string(stringified)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (p *jsonParserWriter) Write(w io.Writer, attr Attributes) error {
+	// TODO: name at front...
+	res, err := json.Marshal(attr)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = w.Write(bytes.TrimSpace(res))
+	return errors.WithStack(err)
+}
+
+// htmlAttributesParserWriter parses and writes options as HTML attributes.
+//
+// For example:
+//
+//	{ key=value hello=world string_value=2 }
+//
+// Deprecated: Use the JSON parser instead.
+type htmlAttributesParserWriter struct{}
+
+func (p *htmlAttributesParserWriter) Parse(raw []byte) (Attributes, error) {
+	rawAttributes := extractAttributes(raw)
+	return p.parseRawAttributes(rawAttributes), nil
+}
+
+func (p *htmlAttributesParserWriter) Write(w io.Writer, attr Attributes) error {
+	keys := p.getSortedKeys(attr)
+
+	_, _ = w.Write([]byte{'{'})
+	i := 0
+	for _, k := range keys {
+		if i == 0 {
+			_, _ = w.Write([]byte{' '})
+		}
+		v := attr[k]
+		_, _ = w.Write([]byte(fmt.Sprintf("%s=%s ", k, v)))
+		i++
+	}
+	_, _ = w.Write([]byte{'}'})
 
 	return nil
 }
 
-func getAttributes(node *ast.FencedCodeBlock, source []byte, parser attributeParser) (Attributes, error) {
-	attributes := make(map[string]string)
-
-	if node.Info != nil {
-		codeBlockInfo := node.Info.Text(source)
-		rawAttrs := getRawAttributes(codeBlockInfo)
-
-		if len(bytes.TrimSpace(rawAttrs)) > 0 {
-			attr, err := parser.Parse(rawAttrs)
-			if err != nil {
-				return nil, err
-			}
-
-			attributes = attr
-		}
-	}
-	return attributes, nil
-}
-
-// Original attribute language used by runme prior to v1.3.0
-//
-// Only supports strings, and does not support spaces. Example:
-//
-// { key=value hello=world string_value=2 }
-//
-// Pioneered by Adam Babik
-type babikMLParser struct{}
-
-func (p *babikMLParser) Parse(raw []byte) (Attributes, error) {
-	return p.parseRawAttributes(p.rawAttributes(raw)), nil
-}
-
-func (*babikMLParser) parseRawAttributes(source []byte) map[string]string {
-	items := bytes.Split(source, []byte{' '})
+func (*htmlAttributesParserWriter) parseRawAttributes(raw []byte) map[string]string {
+	items := bytes.Split(raw, []byte{' '})
 	if len(items) == 0 {
 		return nil
 	}
@@ -90,27 +155,7 @@ func (*babikMLParser) parseRawAttributes(source []byte) map[string]string {
 	return result
 }
 
-func (*babikMLParser) rawAttributes(source []byte) []byte {
-	start, stop := -1, -1
-
-	for i := 0; i < len(source); i++ {
-		if start == -1 && source[i] == '{' && i+1 < len(source) && source[i+1] != '}' {
-			start = i + 1
-		}
-		if stop == -1 && source[i] == '}' {
-			stop = i
-			break
-		}
-	}
-
-	if start >= 0 && stop >= 0 {
-		return bytes.TrimSpace(source[start:stop])
-	}
-
-	return nil
-}
-
-func (*babikMLParser) sortedAttrs(attr Attributes) []string {
+func (*htmlAttributesParserWriter) getSortedKeys(attr Attributes) []string {
 	keys := make([]string, 0, len(attr))
 
 	for k := range attr {
@@ -136,98 +181,48 @@ func (*babikMLParser) sortedAttrs(attr Attributes) []string {
 	return keys
 }
 
-func (p *babikMLParser) Write(attr Attributes, w io.Writer) error {
-	keys := p.sortedAttrs(attr)
-
-	_, _ = w.Write([]byte{'{', ' '})
-	i := 0
-	for _, k := range keys {
-		v := attr[k]
-		_, _ = w.Write([]byte(fmt.Sprintf("%s=%v", k, v)))
-		i++
-		if i < len(keys) {
-			_, _ = w.Write([]byte{' '})
-		}
-	}
-	_, _ = w.Write([]byte{' ', '}'})
-
-	return nil
+// multiParserWriter parses attributes using the provided parsers
+// in the order they are provided. If a parser fails, the next one
+// is used.
+// Writer is used to write the attributes back.
+type multiParserWriter struct {
+	parsers []attributesParserWriter
+	writer  attributesParserWriter
 }
 
-// JSON parser
-//
-// Example:
-//
-// { key: "value", hello: "world", string_value: "2" }
-type jsonParser struct{}
-
-func (p *jsonParser) Parse(raw []byte) (Attributes, error) {
-	bytes := raw
-
-	parsedAttr := make(map[string]interface{})
-
-	if err := json.Unmarshal(bytes, &parsedAttr); err != nil {
-		return nil, err
-	}
-
-	attr := make(Attributes, len(parsedAttr))
-
-	for k, v := range parsedAttr {
-		if strVal, ok := v.(string); ok {
-			attr[k] = strVal
-		} else {
-			if stringified, err := json.Marshal(v); err == nil {
-				attr[k] = string(stringified)
-			}
-		}
-	}
-
-	return attr, nil
-}
-
-func (p *jsonParser) Write(attr Attributes, w io.Writer) error {
-	// TODO: name at front...
-	res, err := json.Marshal(attr)
-	if err != nil {
-		return err
-	}
-
-	res = bytes.TrimSpace(res)
-
-	_, _ = w.Write(res)
-
-	return nil
-}
-
-// failoverAttributeParser tries to parse attributes using one of the provided ordered parsers
-// until it finds a non-failing one.
-// Attributes are written using the provided writer.
-type failoverAttributeParser struct {
-	parsers []attributeParser
-	writer  attributeParser
-}
-
-func newFailoverAttributeParser(parsers []attributeParser, writer attributeParser) *failoverAttributeParser {
-	return &failoverAttributeParser{
-		parsers,
-		writer,
-	}
-}
-
-func (p *failoverAttributeParser) Parse(raw []byte) (attr Attributes, finalErr error) {
+func (p *multiParserWriter) Parse(raw []byte) (_ Attributes, finalErr error) {
 	for _, parser := range p.parsers {
 		attr, err := parser.Parse(raw)
-
 		if err == nil {
 			return attr, nil
 		}
-
 		finalErr = multierr.Append(finalErr, err)
 	}
-
 	return
 }
 
-func (p *failoverAttributeParser) Write(attr Attributes, w io.Writer) error {
-	return p.writer.Write(attr, w)
+func (p *multiParserWriter) Write(w io.Writer, attr Attributes) error {
+	return p.writer.Write(w, attr)
+}
+
+// extractAttributes extracts attributes from the source
+// by finding the first `{` and last `}` characters.
+func extractAttributes(source []byte) []byte {
+	start, stop := -1, -1
+
+	for i := 0; i < len(source); i++ {
+		if start == -1 && source[i] == '{' && i+1 < len(source) && source[i+1] != '}' {
+			start = i + 1
+		}
+		if stop == -1 && source[i] == '}' {
+			stop = i
+			break
+		}
+	}
+
+	if start >= 0 && stop >= 0 {
+		return bytes.TrimSpace(source[start-1 : stop+1])
+	}
+
+	return nil
 }

--- a/pkg/document/block.go
+++ b/pkg/document/block.go
@@ -53,7 +53,7 @@ const (
 )
 
 type CodeBlock struct {
-	attributes    AttributeStore
+	attributes    *Attributes
 	document      *Document
 	encoding      CodeBlockEncoding
 	id            string
@@ -97,9 +97,9 @@ func newCodeBlock(
 		return nil, err
 	}
 
-	id, hasID := identityResolver.GetCellID(fenced, attributes.Items())
+	id, hasID := identityResolver.GetCellID(fenced, attributes.Items)
 
-	name, hasName := getName(fenced, source, nameResolver, attributes.Items())
+	name, hasName := getName(fenced, source, nameResolver, attributes.Items)
 
 	value, err := render(fenced, source)
 	if err != nil {
@@ -124,45 +124,30 @@ func newCodeBlock(
 
 func (b *CodeBlock) FencedEncoding() bool { return b.encoding == Fenced }
 
-func (b *CodeBlock) Attributes() AttributeStore { return b.attributes }
+func (b *CodeBlock) Attributes() *Attributes { return b.attributes }
 
 func (b *CodeBlock) Background() bool {
-	items := b.Attributes().Items()
-	val, _ := strconv.ParseBool(items["background"])
+	val, _ := strconv.ParseBool(b.Attributes().Items["background"])
 	return val
 }
 
 func (b *CodeBlock) Tags() []string {
-	items := b.Attributes().Items()
-	var superset []string
+	var (
+		superset []string
+		attr     = b.Attributes().Items
+	)
 
-	categories, ok := items["category"]
+	categories, ok := attr["category"]
 	if ok {
 		superset = append(superset, strings.Split(categories, ",")...)
 	}
 
-	tags, ok := items["tag"]
+	tags, ok := attr["tag"]
 	if ok {
 		superset = append(superset, strings.Split(tags, ",")...)
 	}
 
 	return superset
-}
-
-func (b *CodeBlock) Clone() *CodeBlock {
-	clone := *b
-
-	clone.attributes = b.attributes.Clone()
-
-	lines := make([]string, len(b.lines))
-	copy(lines, b.lines)
-	clone.lines = lines
-
-	value := make([]byte, len(b.value))
-	copy(value, b.value)
-	clone.value = value
-
-	return &clone
 }
 
 func (b *CodeBlock) Content() []byte {
@@ -175,14 +160,14 @@ func (b *CodeBlock) Content() []byte {
 }
 
 func (b *CodeBlock) Cwd() string {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	return items["cwd"]
 }
 
 func (b *CodeBlock) Document() *Document { return b.document }
 
 func (b *CodeBlock) ExcludeFromRunAll() bool {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	val, err := strconv.ParseBool(items["excludeFromRunAll"])
 	if err != nil {
 		return false
@@ -200,7 +185,7 @@ func (b *CodeBlock) FirstLine() string {
 func (b *CodeBlock) ID() string { return b.id }
 
 func (b *CodeBlock) Interactive() bool {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	val, _ := strconv.ParseBool(items["interactive"])
 	return val
 }
@@ -209,7 +194,7 @@ func (b *CodeBlock) Interactive() bool {
 // Deprecated: use Interactive instead, however, keep using
 // if you want to align with the VS Code extension.
 func (b *CodeBlock) InteractiveLegacy() bool {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	val, err := strconv.ParseBool(items["interactive"])
 	if err != nil {
 		return true
@@ -218,7 +203,7 @@ func (b *CodeBlock) InteractiveLegacy() bool {
 }
 
 func (b *CodeBlock) Interpreter() string {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	return items["interpreter"]
 }
 
@@ -252,12 +237,12 @@ func (b *CodeBlock) MarshalJSON() ([]byte, error) {
 }
 
 func (b *CodeBlock) PromptEnvStr() string {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	return items["promptEnv"]
 }
 
 func (b *CodeBlock) PromptEnv() bool {
-	items := b.Attributes().Items()
+	items := b.Attributes().Items
 	val, ok := items["promptEnv"]
 	if !ok {
 		return true

--- a/pkg/document/block.go
+++ b/pkg/document/block.go
@@ -92,7 +92,7 @@ func newCodeBlock(
 		return nil, errors.New("invalid node kind neither CodeBlock nor FencedCodeBlock")
 	}
 
-	attributes, err := getAttributes(fenced, source, DefaultAttributeParser)
+	attributes, err := newAttributesFromFencedCodeBlock(fenced, source)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func getLanguage(node *ast.FencedCodeBlock, source []byte) string {
 	var rawAttrs string
 	if node.Info != nil {
 		codeBlockInfo := node.Info.Text(source)
-		rawAttrs = string(getRawAttributes(codeBlockInfo))
+		rawAttrs = string(extractAttributes(codeBlockInfo))
 	}
 
 	// If the language is the same as the raw attributes,

--- a/pkg/document/block_test.go
+++ b/pkg/document/block_test.go
@@ -11,7 +11,7 @@ func TestBlock_Clone(t *testing.T) {
 	block := &CodeBlock{
 		id:            "id",
 		idGenerated:   false,
-		attributes:    map[string]string{"key": "value"},
+		attributes:    mustReturnAttributes(t, "json", map[string]string{"key": "value"}),
 		document:      nil,
 		inner:         nil,
 		intro:         "intro",
@@ -24,8 +24,11 @@ func TestBlock_Clone(t *testing.T) {
 	clone := block.Clone()
 	assert.True(t, cmp.Equal(block, clone, cmp.AllowUnexported(CodeBlock{})), "expected %v, got %v", block, clone)
 
-	block.attributes["key"] = "new-value"
-	assert.NotEqual(t, block.attributes["key"], clone.attributes["key"])
+	attrs := block.attributes.Items()
+	attrs["key"] = "new-value"
+	block.attributes = mustReturnAttributes(t, "json", attrs)
+
+	assert.NotEqual(t, block.attributes.Items()["key"], clone.attributes.Items()["key"])
 
 	block.lines[0] = "new-line"
 	assert.NotEqual(t, block.lines[0], clone.lines[0])
@@ -37,10 +40,10 @@ func TestBlock_Clone(t *testing.T) {
 func TestBlock_Tags(t *testing.T) {
 	t.Run("Superset including legacy categories", func(t *testing.T) {
 		block := &CodeBlock{
-			attributes: map[string]string{
+			attributes: mustReturnAttributes(t, "json", map[string]string{
 				"category": "cat1,cat2",
 				"tag":      "tag1,tag2",
-			},
+			}),
 		}
 		assert.Equal(t, []string{"cat1", "cat2", "tag1", "tag2"}, block.Tags())
 	})

--- a/pkg/document/block_test.go
+++ b/pkg/document/block_test.go
@@ -3,47 +3,19 @@ package document
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestBlock_Clone(t *testing.T) {
-	block := &CodeBlock{
-		id:            "id",
-		idGenerated:   false,
-		attributes:    mustReturnAttributes(t, "json", map[string]string{"key": "value"}),
-		document:      nil,
-		inner:         nil,
-		intro:         "intro",
-		language:      "language",
-		lines:         []string{"line1", "line2"},
-		name:          "name",
-		nameGenerated: false,
-		value:         []byte("value"),
-	}
-	clone := block.Clone()
-	assert.True(t, cmp.Equal(block, clone, cmp.AllowUnexported(CodeBlock{})), "expected %v, got %v", block, clone)
-
-	attrs := block.attributes.Items()
-	attrs["key"] = "new-value"
-	block.attributes = mustReturnAttributes(t, "json", attrs)
-
-	assert.NotEqual(t, block.attributes.Items()["key"], clone.attributes.Items()["key"])
-
-	block.lines[0] = "new-line"
-	assert.NotEqual(t, block.lines[0], clone.lines[0])
-
-	block.value[0] = 'a'
-	assert.NotEqual(t, block.value[0], clone.value[0])
-}
 
 func TestBlock_Tags(t *testing.T) {
 	t.Run("Superset including legacy categories", func(t *testing.T) {
 		block := &CodeBlock{
-			attributes: mustReturnAttributes(t, "json", map[string]string{
-				"category": "cat1,cat2",
-				"tag":      "tag1,tag2",
-			}),
+			attributes: NewAttributesWithFormat(
+				map[string]string{
+					"category": "cat1,cat2",
+					"tag":      "tag1,tag2",
+				},
+				"json",
+			),
 		}
 		assert.Equal(t, []string{"cat1", "cat2", "tag1", "tag2"}, block.Tags())
 	})

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -15,14 +15,6 @@ import (
 	"github.com/stateful/runme/v3/pkg/document/constants"
 )
 
-var DefaultAttributeParser = newFailoverAttributeParser(
-	[]attributeParser{
-		&jsonParser{},
-		&babikMLParser{},
-	},
-	&jsonParser{},
-)
-
 var defaultRenderer = cmark.Render
 
 type Document struct {

--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -161,7 +161,7 @@ func toCellsRec(
 
 		case *document.CodeBlock:
 			attr := block.Attributes()
-			metadata := attr.Items()
+			metadata := attr.Items
 			transform := true
 
 			t, tOk := metadata["transform"]
@@ -188,7 +188,7 @@ func toCellsRec(
 
 			textRange := block.TextRange()
 
-			if f := attr.Format(); f != defaultAttributeFormat {
+			if f := attr.Format; f != defaultAttributeFormat {
 				metadata[PrefixAttributeName(InternalAttributePrefix, "format")] = f
 			}
 
@@ -324,11 +324,8 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) error {
 	}
 
 	_, _ = w.Write([]byte{' '})
-	parsedAttr, err := document.NewAttributesWithFormat(attr, format)
-	if err != nil {
-		return err
-	}
-	_ = document.WriteAttributes(w, parsedAttr)
+	attrWithFormat := document.NewAttributesWithFormat(attr, format)
+	_ = document.WriteAttributes(w, attrWithFormat)
 
 	return nil
 }

--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -311,7 +311,7 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 
 	if len(attr) > 0 {
 		_, _ = w.Write([]byte{' '})
-		_ = document.DefaultAttributeParser.Write(attr, w)
+		_ = document.WriteAttributes(w, attr)
 	}
 }
 

--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -21,6 +21,7 @@ import (
 const (
 	InternalAttributePrefix = "runme.dev"
 	PrivateAttributePrefix  = "_"
+	defaultAttributeFormat  = "json"
 )
 
 type CellKind int
@@ -159,7 +160,8 @@ func toCellsRec(
 			}
 
 		case *document.CodeBlock:
-			metadata := block.Attributes()
+			attr := block.Attributes()
+			metadata := attr.Items()
 			transform := true
 
 			t, tOk := metadata["transform"]
@@ -185,6 +187,10 @@ func toCellsRec(
 			}
 
 			textRange := block.TextRange()
+
+			if f := attr.Format(); f != defaultAttributeFormat {
+				metadata[PrefixAttributeName(InternalAttributePrefix, "format")] = f
+			}
 
 			// In the future, we will include language detection (#77).
 			if cellID := block.ID(); cellID != "" {
@@ -288,18 +294,22 @@ func PrefixAttributeName(prefix, name string) string {
 	}
 }
 
-func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
+func serializeFencedCodeAttributes(w io.Writer, cell *Cell) error {
+	format := defaultAttributeFormat
 	// Filter out private keys, i.e. starting with "_" or "runme.dev/".
 	// A key with a name "index" that comes from VS Code is also filtered out.
 	keys := make([]string, 0, len(cell.Metadata))
 	for k := range cell.Metadata {
+		if k == fmt.Sprint(InternalAttributePrefix, "/", "format") {
+			format = cell.Metadata[k]
+		}
 		if k == "index" || strings.HasPrefix(k, PrivateAttributePrefix) || strings.HasPrefix(k, InternalAttributePrefix) || len(k) == 0 {
 			continue
 		}
 		keys = append(keys, k)
 	}
 
-	attr := make(document.Attributes, len(keys))
+	attr := make(map[string]string, len(keys))
 
 	for _, k := range keys {
 		if len(k) <= 0 {
@@ -309,10 +319,18 @@ func serializeFencedCodeAttributes(w io.Writer, cell *Cell) {
 		attr[k] = cell.Metadata[k]
 	}
 
-	if len(attr) > 0 {
-		_, _ = w.Write([]byte{' '})
-		_ = document.WriteAttributes(w, attr)
+	if len(attr) == 0 {
+		return nil
 	}
+
+	_, _ = w.Write([]byte{' '})
+	parsedAttr, err := document.NewAttributesWithFormat(attr, format)
+	if err != nil {
+		return err
+	}
+	_ = document.WriteAttributes(w, parsedAttr)
+
+	return nil
 }
 
 func removeAnsiCodes(str string) string {
@@ -320,13 +338,16 @@ func removeAnsiCodes(str string) string {
 	return re.ReplaceAllString(str, "")
 }
 
-func serializeCells(cells []*Cell) []byte {
+func serializeCells(cells []*Cell) ([]byte, error) {
 	var buf bytes.Buffer
 
 	for idx, cell := range cells {
 		switch cell.Kind {
 		case CodeKind:
-			serializeCellCodeBlock(&buf, cell)
+			err := serializeCellCodeBlock(&buf, cell)
+			if err != nil {
+				return nil, err
+			}
 
 		case MarkupKind:
 			_, _ = buf.WriteString(cell.Value)
@@ -342,14 +363,15 @@ func serializeCells(cells []*Cell) []byte {
 		}
 	}
 
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
-func serializeCellCodeBlock(w io.Writer, cell *Cell) {
+func serializeCellCodeBlock(w io.Writer, cell *Cell) error {
 	var buf bytes.Buffer
 	value := cell.Value
 
-	if b, err := strconv.ParseBool(cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "fenced")]); err == nil && !b {
+	isFencedCodeBlock, err := strconv.ParseBool(cell.Metadata[PrefixAttributeName(InternalAttributePrefix, "fenced")])
+	if err == nil && !isFencedCodeBlock {
 		for _, v := range strings.Split(value, "\n") {
 			_, _ = buf.Write(bytes.Repeat([]byte{' '}, 4))
 			_, _ = buf.WriteString(v)
@@ -366,7 +388,10 @@ func serializeCellCodeBlock(w io.Writer, cell *Cell) {
 		_, _ = buf.Write(bytes.Repeat([]byte{'`'}, ticksCount))
 		_, _ = buf.WriteString(cell.LanguageID)
 
-		serializeFencedCodeAttributes(&buf, cell)
+		err := serializeFencedCodeAttributes(&buf, cell)
+		if err != nil {
+			return err
+		}
 
 		_ = buf.WriteByte('\n')
 		_, _ = buf.WriteString(cell.Value)
@@ -380,6 +405,8 @@ func serializeCellCodeBlock(w io.Writer, cell *Cell) {
 	serializeCellOutputsImage(&buf, cell)
 
 	_, _ = w.Write(buf.Bytes())
+
+	return nil
 }
 
 func serializeCellOutputsText(w io.Writer, cell *Cell) {

--- a/pkg/document/editor/cell_test.go
+++ b/pkg/document/editor/cell_test.go
@@ -159,6 +159,15 @@ def hello():
 	assert.Equal(t, "def hello():\n    print(\"Hello World\")", cell.Value)
 }
 
+func mustReturnSerializedCells(t *testing.T, cells []*Cell) []byte {
+	t.Helper()
+
+	data, err := serializeCells(cells)
+	require.NoError(t, err)
+
+	return data
+}
+
 func Test_serializeCells_Edited(t *testing.T) {
 	data := []byte(`# Examples
 
@@ -184,7 +193,7 @@ Last paragraph.
 		assert.Equal(
 			t,
 			"# New header\n\n1. Item 1\n2. Item 2\n3. Item 3\n\nLast paragraph.\n",
-			string(serializeCells(cells)),
+			string(mustReturnSerializedCells(t, cells)),
 		)
 	})
 
@@ -194,7 +203,7 @@ Last paragraph.
 		assert.Equal(
 			t,
 			"# Examples\n\n1. Item 1\n2. Item 2\n3. Item 3\n4. Item 4\n\nLast paragraph.\n",
-			string(serializeCells(cells)),
+			string(mustReturnSerializedCells(t, cells)),
 		)
 	})
 
@@ -211,7 +220,7 @@ Last paragraph.
 			assert.Equal(
 				t,
 				"# Title\n\n# Examples\n\n1. Item 1\n2. Item 2\n3. Item 3\n\nLast paragraph.\n",
-				string(serializeCells(cells)),
+				string(mustReturnSerializedCells(t, cells)),
 			)
 		})
 
@@ -226,7 +235,7 @@ Last paragraph.
 			assert.Equal(
 				t,
 				"# Examples\n\nA new paragraph.\n\n1. Item 1\n2. Item 2\n3. Item 3\n\nLast paragraph.\n",
-				string(serializeCells(cells)),
+				string(mustReturnSerializedCells(t, cells)),
 			)
 		})
 
@@ -240,7 +249,7 @@ Last paragraph.
 			assert.Equal(
 				t,
 				"# Examples\n\n1. Item 1\n2. Item 2\n3. Item 3\n\nLast paragraph.\n\nParagraph after the last one.\n",
-				string(serializeCells(cells)),
+				string(mustReturnSerializedCells(t, cells)),
 			)
 		})
 	})
@@ -251,7 +260,7 @@ Last paragraph.
 		assert.Equal(
 			t,
 			"# Examples\n\nLast paragraph.\n",
-			string(serializeCells(cells)),
+			string(mustReturnSerializedCells(t, cells)),
 		)
 	})
 }
@@ -295,7 +304,7 @@ brew bundle --no-lock
 pre-commit install
 `+"```"+`
 `,
-		string(serializeCells(cells)),
+		string(mustReturnSerializedCells(t, cells)),
 	)
 }
 
@@ -306,7 +315,7 @@ func Test_serializeCells(t *testing.T) {
 		node, err := doc.Root()
 		require.NoError(t, err)
 		cells := toCells(doc, node, data)
-		assert.Equal(t, string(data), string(serializeCells(cells)))
+		assert.Equal(t, string(data), string(mustReturnSerializedCells(t, cells)))
 	})
 
 	t.Run("privateFields", func(t *testing.T) {
@@ -320,7 +329,7 @@ func Test_serializeCells(t *testing.T) {
 		cells[0].Metadata["_private"] = "private"
 		cells[0].Metadata["runme.dev/internal"] = "internal"
 
-		assert.Equal(t, string(data), string(serializeCells(cells)))
+		assert.Equal(t, string(data), string(mustReturnSerializedCells(t, cells)))
 	})
 
 	t.Run("UnsupportedLang", func(t *testing.T) {
@@ -335,7 +344,7 @@ def hello():
 		node, err := doc.Root()
 		require.NoError(t, err)
 		cells := toCells(doc, node, data)
-		assert.Equal(t, string(data), string(serializeCells(cells)))
+		assert.Equal(t, string(data), string(mustReturnSerializedCells(t, cells)))
 	})
 }
 

--- a/pkg/document/editor/editor.go
+++ b/pkg/document/editor/editor.go
@@ -173,7 +173,11 @@ func Serialize(notebook *Notebook, outputMetadata *document.RunmeMetadata, opts 
 	}
 
 	// Serialize cells.
-	result = append(result, serializeCells(notebook.Cells)...)
+	serializedCells, err := serializeCells(notebook.Cells)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, serializedCells...)
 
 	// Add trailing line breaks.
 	if lineBreaks, ok := notebook.Metadata[PrefixAttributeName(InternalAttributePrefix, constants.FinalLineBreaksKey)]; ok {

--- a/pkg/document/editor/editor_test.go
+++ b/pkg/document/editor/editor_test.go
@@ -734,3 +734,21 @@ A paragraph
 		)
 	})
 }
+
+func TestEditor_AttributeFormat(t *testing.T) {
+	t.Run("RetainOriginalFormat", func(t *testing.T) {
+		mixedFormats := []byte("## Retain attribute format\n\nFirst block uses HTML.\n\n```sh { name=date interactive=false }\ndate\n```\n\nThe second JSON.\n\n```javascript {\"interactive\":\"false\",\"name\":\"iso\"}\nconsole.log(new Date().toISOString())\n```\n")
+
+		notebook, err := Deserialize(mixedFormats, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		actual, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			string(mixedFormats),
+			string(actual),
+		)
+	})
+}

--- a/pkg/document/editor/editorservice/service_test.go
+++ b/pkg/document/editor/editorservice/service_test.go
@@ -31,7 +31,7 @@ var (
 		`echo "Foo"`,
 		"```",
 		"## H2",
-		"```sh { name=bar }",
+		"```sh { \"name\": \"bar\" }",
 		`echo "Bar"`,
 		"```",
 		"### H3",
@@ -105,7 +105,7 @@ func Test_IdentityUnspecified(t *testing.T) {
 			assert.NotRegexp(t, "^\n\n", content)
 		}
 
-		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 	}
 }
 
@@ -144,7 +144,7 @@ func Test_IdentityAll(t *testing.T) {
 		assert.Contains(t, content, "runme:\n")
 		assert.Contains(t, content, "id: "+testMockID)
 		assert.Contains(t, content, "version: "+version.BaseVersion())
-		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 		assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 	}
@@ -185,7 +185,7 @@ func Test_IdentityDocument(t *testing.T) {
 		assert.Contains(t, content, "runme:\n")
 		assert.Contains(t, content, "id: "+testMockID+"\n")
 		assert.Contains(t, content, "version: "+version.BaseVersion()+"\n")
-		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 		assert.Contains(t, content, "```sh {\"name\":\"bar\"}\n")
 		assert.Contains(t, content, "```js\n")
 	}
@@ -233,7 +233,7 @@ func Test_IdentityCell(t *testing.T) {
 			assert.NotRegexp(t, "^\n\n", content)
 		}
 
-		assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+		assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 		assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 		assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 	}
@@ -273,7 +273,7 @@ func Test_RunmelessFrontmatter(t *testing.T) {
 	assert.Regexp(t, "^---\n", content)
 	assert.NotRegexp(t, "^\n\n", content)
 
-	assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+	assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 	assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 }
@@ -312,7 +312,7 @@ func Test_RetainInvalidFrontmatter(t *testing.T) {
 	assert.Regexp(t, "^\\+\\+\\+\n", content)
 	assert.NotRegexp(t, "^\n\n", content)
 
-	assert.Contains(t, content, "```sh {\"id\":\"123\",\"name\":\"foo\"}\n")
+	assert.Contains(t, content, "```sh { name=foo id=123 }\n")
 	assert.Contains(t, content, "```sh {\"id\":\""+testMockID+"\",\"name\":\"bar\"}\n")
 	assert.Contains(t, content, "```js {\"id\":\""+testMockID+"\"}\n")
 }

--- a/pkg/document/identity/resolver_test.go
+++ b/pkg/document/identity/resolver_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stateful/runme/v3/internal/ulid"
-	"github.com/stateful/runme/v3/pkg/document"
 )
 
 func TestLifecycleIdentities(t *testing.T) {
@@ -52,10 +51,7 @@ func TestIdentityResolver(t *testing.T) {
 		ulid.MockGenerator(id)
 		resolver := NewResolver(CellLifecycleIdentity)
 		obj := struct{}{}
-		attributes, err := document.NewAttributes(map[string]string{"id": id})
-		assert.NoError(t, err)
-		id, ok := resolver.GetCellID(obj, attributes.Items())
-
+		id, ok := resolver.GetCellID(obj, map[string]string{"id": id})
 		assert.True(t, ok)
 		assert.NotEmpty(t, id)
 	})

--- a/pkg/document/identity/resolver_test.go
+++ b/pkg/document/identity/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stateful/runme/v3/internal/ulid"
+	"github.com/stateful/runme/v3/pkg/document"
 )
 
 func TestLifecycleIdentities(t *testing.T) {
@@ -51,8 +52,9 @@ func TestIdentityResolver(t *testing.T) {
 		ulid.MockGenerator(id)
 		resolver := NewResolver(CellLifecycleIdentity)
 		obj := struct{}{}
-		attributes := map[string]string{"id": id}
-		id, ok := resolver.GetCellID(obj, attributes)
+		attributes, err := document.NewAttributes(map[string]string{"id": id})
+		assert.NoError(t, err)
+		id, ok := resolver.GetCellID(obj, attributes.Items())
 
 		assert.True(t, ok)
 		assert.NotEmpty(t, id)

--- a/pkg/document/node_test.go
+++ b/pkg/document/node_test.go
@@ -128,7 +128,7 @@ func TestCodeBlockAttributes(t *testing.T) {
 		require.Len(t, blocks, 1)
 
 		block := blocks[0]
-		assert.Len(t, block.attributes, 1)
+		assert.Len(t, block.attributes.Items(), 1)
 		assert.Equal(t, tc.expectedLanguage, block.language)
 	}
 }

--- a/pkg/document/node_test.go
+++ b/pkg/document/node_test.go
@@ -128,7 +128,7 @@ func TestCodeBlockAttributes(t *testing.T) {
 		require.Len(t, blocks, 1)
 
 		block := blocks[0]
-		assert.Len(t, block.attributes.Items(), 1)
+		assert.Len(t, block.attributes.Items, 1)
 		assert.Equal(t, tc.expectedLanguage, block.language)
 	}
 }


### PR DESCRIPTION
Not all tools processing markdowns equally accommodate attributes/annotations [inside fenced code blocks](https://docs.runme.dev/configuration/cell-level#configure-using-markdown). This is especially true if they aren't encoded in HTML attribute format. A notable example is https://gohugo.io/.

Instead of always preferring `JSON` encoding. This PR changes the default behavior of the attribute parser to retain the original encoding format.