### PR TITLE
Make cell names more obvious in markdown viewers

### DIFF
--- a/pkg/document/block.go
+++ b/pkg/document/block.go
@@ -150,8 +150,19 @@ func (b *CodeBlock) Tags() []string {
 	return superset
 }
 
+func (b *CodeBlock) valueWithoutLabelComments() []byte {
+	var lines [][]byte
+	for _, line := range bytes.Split(b.value, []byte{'\n'}) {
+		if bytes.HasPrefix(line, []byte("### ")) {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return bytes.Join(lines, []byte{'\n'})
+}
+
 func (b *CodeBlock) Content() []byte {
-	value := bytes.Trim(b.value, "\n")
+	value := bytes.Trim(b.valueWithoutLabelComments(), "\n")
 	lines := bytes.Split(value, []byte{'\n'})
 	if len(lines) < 2 {
 		return b.value

--- a/pkg/document/editor/editor.go
+++ b/pkg/document/editor/editor.go
@@ -172,8 +172,13 @@ func Serialize(notebook *Notebook, outputMetadata *document.RunmeMetadata, opts 
 		)
 	}
 
+	labelComment := false
+	if frontmatter != nil && frontmatter.Shell == "dagger shell" {
+		labelComment = true
+	}
+
 	// Serialize cells.
-	serializedCells, err := serializeCells(notebook.Cells)
+	serializedCells, err := serializeCells(notebook.Cells, labelComment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/document/editor/editor_test.go
+++ b/pkg/document/editor/editor_test.go
@@ -752,3 +752,47 @@ func TestEditor_AttributeFormat(t *testing.T) {
 		)
 	})
 }
+
+func TestEditor_LabelComments(t *testing.T) {
+	labelComments := []byte("## Retain attribute format\n\nFirst block uses HTML.\n\n```sh { name=date interactive=false }\n### Exported in runme.dev as date\ndate\n```\n\nThe second JSON.\n\n```javascript {\"interactive\":\"false\",\"name\":\"iso\"}\n### Exported in runme.dev as iso\nconsole.log(new Date().toISOString())\n```\n")
+	t.Run("StrippedByDefault", func(t *testing.T) {
+
+		notebook, err := Deserialize(labelComments, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.Nil(t, notebook.Frontmatter)
+
+		assert.Equal(t, "date", notebook.Cells[2].Metadata["name"])
+		require.NotContains(t, notebook.Cells[2].Value, labelCommentPreamble)
+
+		assert.Equal(t, "iso", notebook.Cells[4].Metadata["name"])
+		require.NotContains(t, notebook.Cells[4].Value, labelCommentPreamble)
+
+		actual, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+
+		require.NotContains(t, string(actual), labelCommentPreamble+"date")
+		require.NotContains(t, string(actual), labelCommentPreamble+"iso")
+	})
+
+	t.Run("SerializeForDaggerShell", func(t *testing.T) {
+		withFrontmatter := bytes.Join([][]byte{[]byte("---\nshell: dagger shell\n---\n\n"), labelComments}, nil)
+
+		notebook, err := Deserialize(withFrontmatter, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		assert.Equal(t, "dagger shell", notebook.Frontmatter.Shell)
+
+		assert.Equal(t, "date", notebook.Cells[2].Metadata["name"])
+		require.NotContains(t, notebook.Cells[2].Value, labelCommentPreamble)
+
+		assert.Equal(t, "iso", notebook.Cells[4].Metadata["name"])
+		require.NotContains(t, notebook.Cells[4].Value, labelCommentPreamble)
+
+		actual, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+
+		require.Contains(t, string(actual), labelCommentPreamble+"date")
+		require.Contains(t, string(actual), labelCommentPreamble+"iso")
+	})
+}


### PR DESCRIPTION
Cells with names will contain a leading comment with the name of the cell. This is helpful if you are new to Runme. Let's start with `dagger shell` first because call names are used to string together functions/pipelines.

Example:

<img width="919" alt="image" src="https://github.com/user-attachments/assets/d726b59c-2e8b-4f09-b133-96173eca2764" />
