### PR TITLE
Skip but retain mkdocs scissor syntax in invalid frontmatter

### DIFF
--- a/pkg/document/editor/editor_test.go
+++ b/pkg/document/editor/editor_test.go
@@ -251,7 +251,8 @@ A paragraph
 }
 
 func TestEditor_RetainInvalidFrontmatter(t *testing.T) {
-	data := []byte(`+++
+	t.Run("SnippetSyntax", func(t *testing.T) {
+		data := []byte(`+++
 title = '{{ replace .File.ContentBaseName "-" " " | title }}'
 date = {{ .Date }}
 draft = true
@@ -261,15 +262,31 @@ draft = true
 
 A paragraph
 `)
-	notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
-	require.NoError(t, err)
-	result, err := Serialize(notebook, nil, Options{})
-	require.NoError(t, err)
-	assert.Equal(
-		t,
-		string(data),
-		string(result),
-	)
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+		result, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(result),
+		)
+	})
+
+	t.Run("MkdocsScissorSyntax", func(t *testing.T) {
+		data := []byte("--8<-- \"snippets/live-code-snippets-button-executor.md\"\n\n## Import Dynatrace Dashboard\n\n```sh {\"name\":\"docker ps\"}\ndocker ps\n```\n")
+		notebook, err := Deserialize(data, Options{IdentityResolver: identityResolverNone})
+		require.NoError(t, err)
+
+		// assert.NotNil(t, notebook.Frontmatter)
+		result, err := Serialize(notebook, nil, Options{})
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			string(data),
+			string(result),
+		)
+	})
 }
 
 func TestEditor_SessionOutput(t *testing.T) {

--- a/pkg/document/parser.go
+++ b/pkg/document/parser.go
@@ -153,19 +153,31 @@ loop:
 			break
 		}
 
-		r1 := l.next()
-		l.backup()
+		ahead := [3]rune{}
+		for i := 0; i < len(ahead); i++ {
+			ahead[i] = l.next()
+			if ahead[i] == eof {
+				break loop
+			}
+		}
+		for i := 0; i < len(ahead); i++ {
+			l.backup()
+		}
 
 		switch {
 		case r0 == '+':
 			return parseRawFrontmatter(l, byte(r0))
+		case r0 == '-' && ahead[0] == '-' && ahead[1] == '8' && ahead[2] == '<':
+			// skip scissor syntax
+			l.backup()
+			break loop
 		case r0 == '-':
 			return parseRawFrontmatter(l, byte(r0))
-		case r0 == '{' && r1 == '{':
+		case r0 == '{' && ahead[0] == '{':
 			// skip markdown templates
 			l.backup()
 			break loop
-		case r0 == '{' && r1 == '%':
+		case r0 == '{' && ahead[0] == '%':
 			// skip markdown preprocessor includes
 			l.backup()
 			break loop

--- a/pkg/document/parser_test.go
+++ b/pkg/document/parser_test.go
@@ -103,3 +103,11 @@ All notable changes to this project will be documented in this file.
 	assert.Equal(t, "", string(sections.Frontmatter))
 	assert.Equal(t, "{{- $repourl := $.Info.RepositoryURL -}}\n# CHANGELOG\nAll notable changes to this project will be documented in this file.\n", string(sections.Content))
 }
+
+func TestParseSections_SkipMkdocsScissorSyntax(t *testing.T) {
+	data := []byte("--8<-- \"snippets/live-code-snippets-button-executor.md\"\n\n## Import Dynatrace Dashboard\n\n``` {\"name\": \"docker ps\"}\ndocker ps\n```\n")
+	sections, err := ParseSections(data)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(sections.Frontmatter))
+	// assert.Equal(t, "{{- $repourl := $.Info.RepositoryURL -}}\n# CHANGELOG\nAll notable changes to this project will be documented in this file.\n", string(sections.Content))
+}


### PR DESCRIPTION
Better support for the Mkdocs ecosystem. Thanks for reporting @agardnerIT!

Solves https://github.com/stateful/runme/issues/723. Example (remove backslashes):

```
--8<-- "snippets/live-code-snippets-button-executor.md"

## Import Dynatrace Dashboard

\```sh {"name":"docker ps"}
docker ps
\```
```