### PR TITLE
Dagger Shell natively in CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           version: "latest"
           verb: core
           args: "engine local-cache"
+        if: ${{ matrix.os == 'ubuntu-latest' }}
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
-      - name: Make Dagger available
+      - name: Setup Dagger (Linux only)
         uses: dagger/dagger-for-github@v7
         with:
           version: "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
+      - name: Make Dagger available
+        uses: dagger/dagger-for-github@v7
+        with:
+          version: "latest"
+          verb: core
+          args: "engine local-cache"
       - name: Setup go
         uses: actions/setup-go@v5
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ python3 -m pip install pre-commit
 
 Like many complex go projects, this project uses a variety of linting tools to ensure code quality and prevent regressions! The main linter (revive) can be run with:
 
-```sh {"id":"01HF7BT3HEQBTBM9SSTKQENPT3","interactive":"false"}
+```sh {"id":"01HF7BT3HEQBTBM9SSTKQENPT3","interactive":"false","name":"lint"}
 make lint
 ```
 

--- a/examples/dagger/simple.dag
+++ b/examples/dagger/simple.dag
@@ -1,0 +1,11 @@
+---
+shell: dagger shell
+---
+
+```sh {"name":"simple_dagger","terminalRows":"18"}
+### Exported in runme.dev as simple_dagger
+git github.com/stateful/runme |
+    head |
+    tree |
+    file examples/README.md
+```

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -30,7 +30,7 @@ func isShell(cfg *ProgramConfig) bool {
 
 func isShellProgram(programName string) bool {
 	switch strings.ToLower(programName) {
-	case "sh", "bash", "zsh", "ksh", "shell":
+	case "sh", "bash", "zsh", "ksh", "shell", "dagger shell":
 		return true
 	case "cmd", "powershell", "pwsh", "fish":
 		return true

--- a/internal/notebook/resolver.go
+++ b/internal/notebook/resolver.go
@@ -3,7 +3,9 @@ package notebook
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -11,6 +13,7 @@ import (
 
 	"github.com/stateful/runme/v3/internal/notebook/daggershell"
 	parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
+	"github.com/stateful/runme/v3/pkg/document"
 	"github.com/stateful/runme/v3/pkg/document/editor/editorservice"
 )
 
@@ -19,11 +22,52 @@ type NotebookResolver struct {
 	editor   parserv1.ParserServiceServer
 }
 
-func NewNotebookResolver(notebook *parserv1.Notebook) *NotebookResolver {
-	return &NotebookResolver{
-		notebook: notebook,
-		editor:   editorservice.NewParserServiceServer(zap.NewNop()),
+type Option func(*NotebookResolver) error
+
+func WithNotebook(notebook *parserv1.Notebook) Option {
+	return func(r *NotebookResolver) error {
+		r.notebook = notebook
+		return nil
 	}
+}
+
+func WithSource(source []byte) Option {
+	return func(r *NotebookResolver) error {
+		des, err := r.editor.Deserialize(context.Background(), &parserv1.DeserializeRequest{Source: source})
+		if err != nil {
+			return err
+		}
+
+		r.notebook = des.Notebook
+		return nil
+	}
+}
+
+func WithDocumentPath(path string) Option {
+	return func(r *NotebookResolver) error {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		return WithSource(source)(r)
+	}
+}
+
+func NewResolver(opts ...Option) (*NotebookResolver, error) {
+	r := &NotebookResolver{
+		editor: editorservice.NewParserServiceServer(zap.NewNop()),
+	}
+
+	// apply options
+	for _, opt := range opts {
+		err := opt(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
 }
 
 func (r *NotebookResolver) parseNotebook(context context.Context) (*parserv1.Notebook, error) {
@@ -124,4 +168,22 @@ func (r *NotebookResolver) ResolveDaggerShell(context context.Context, cellIndex
 	}
 
 	return rendered.String(), nil
+}
+
+func (r *NotebookResolver) GetCellIndexByBlock(block *document.CodeBlock) (uint32, error) {
+	return getCellIndexByBlock(r.notebook, block)
+}
+
+// todo(sebastian): there are better ways
+func getCellIndexByBlock(notebook *parserv1.Notebook, block *document.CodeBlock) (blockIndex uint32, err error) {
+	blockIndex = 0
+	for i, cell := range notebook.Cells {
+		blockValue := string(block.Content())
+		if cell.Value == blockValue {
+			blockIndex = uint32(i)
+			return
+		}
+	}
+
+	return blockIndex, errors.New("cell for block not found")
 }

--- a/internal/notebook/resolver_test.go
+++ b/internal/notebook/resolver_test.go
@@ -8,7 +8,36 @@ import (
 	"github.com/stretchr/testify/require"
 
 	parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
+	"github.com/stateful/runme/v3/pkg/document"
+	"github.com/stateful/runme/v3/pkg/document/identity"
 )
+
+func TestResolve_GetCellIndexByBlock(t *testing.T) {
+	simpleSource := []byte("---\nrunme:\n  id: 01JJDCG2SQSGV0DP55XCR55AYM\n  version: v3\nshell: dagger shell\nterminalRows: 20\n---\n\n# Compose Notebook Pipelines using the Dagger Shell\n\nLet's get upstream artifacts ready. First, compile the Runme kernel binary.\n\n```sh {\"id\":\"01JJDCG2SPRDWGQ1F4Z6EH69EJ\",\"name\":\"KERNEL_BINARY\"}\ngithub.com/purpleclay/daggerverse/golang $(git https://github.com/stateful/runme | head | tree) |\n  build | \n  file runme\n```\n\nThen, grab the presetup.sh script to provision the build container.\n\n```sh {\"id\":\"01JJDCG2SQSGV0DP55X86EJFSZ\",\"name\":\"PRESETUP\",\"terminalRows\":\"14\"}\ngit https://github.com/stateful/vscode-runme |\n  head |\n  tree |\n  file dagger/scripts/presetup.sh\n```\n\n## Build the Runme VS Code Extension\n\nLet's tie together above's artifacts via their respective cell names to build the Runme VS Code extension.\n\n```sh {\"id\":\"01JJDCG2SQSGV0DP55X8JVYDNR\",\"name\":\"EXTENSION\",\"terminalRows\":\"25\"}\ngithub.com/stateful/vscode-runme |\n  with-remote github.com/stateful/vscode-runme main |\n  with-container $(KERNEL_BINARY) $(PRESETUP) |\n  build-extension GITHUB_TOKEN\n```\n")
+
+	resolver, err := NewResolver(WithSource(simpleSource))
+	require.NoError(t, err)
+
+	doc := document.New(simpleSource, identity.NewResolver(identity.DefaultLifecycleIdentity))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+
+	node, err := doc.Root()
+	require.NoError(t, err)
+	require.Len(t, node.Children(), 8)
+
+	expectedValue := []byte("git https://github.com/stateful/vscode-runme |\n  head |\n  tree |\n  file dagger/scripts/presetup.sh")
+	expectedIndex := uint32(4)
+
+	block, ok := node.Children()[expectedIndex].Item().(*document.CodeBlock)
+	require.True(t, ok)
+	require.NotNil(t, block)
+	require.Equal(t, expectedValue, block.Content())
+
+	index, err := resolver.GetCellIndexByBlock(block)
+	require.NoError(t, err)
+	assert.Equal(t, expectedIndex, index)
+}
 
 func TestResolveDaggerShell(t *testing.T) {
 	ctx := context.Background()
@@ -55,7 +84,9 @@ func TestResolveDaggerShell(t *testing.T) {
 		},
 	}
 
-	resolver := NewNotebookResolver(daggerShellNotebook)
+	resolver, err := NewResolver(WithNotebook(daggerShellNotebook))
+	require.NoError(t, err)
+
 	definition := `KERNEL_BINARY()
 {
   github.com/purpleclay/daggerverse/golang $(git https://github.com/stateful/runme | head | tree) \
@@ -86,6 +117,18 @@ EXTENSION()
 	}
 }
 
+func TestResolveDaggerShell_Source(t *testing.T) {
+	simpleSource := "---\nshell: dagger shell\n---\n\n```sh {\"name\":\"simple_dagger\",\"terminalRows\":\"18\"}\n### Exported in runme.dev as simple_dagger\ngit github.com/stateful/runme |\n    head |\n    tree |\n    file examples/README.md\n```\n"
+
+	resolver, err := NewResolver(WithSource([]byte(simpleSource)))
+	require.NoError(t, err)
+
+	script, err := resolver.ResolveDaggerShell(context.Background(), uint32(0))
+	require.NoError(t, err)
+
+	assert.Equal(t, "simple_dagger()\n{\n  git github.com/stateful/runme \\\n    | head \\\n    | tree \\\n    | file examples/README.md\n}\nsimple_dagger\n", script)
+}
+
 func TestResolveDaggerShell_EmptyRunmeMetadata(t *testing.T) {
 	ctx := context.Background()
 
@@ -104,7 +147,9 @@ func TestResolveDaggerShell_EmptyRunmeMetadata(t *testing.T) {
 		},
 	}
 
-	resolver := NewNotebookResolver(daggerShellNotebook)
+	resolver, err := NewResolver(WithNotebook(daggerShellNotebook))
+	require.NoError(t, err)
+
 	stub := `{
   git github.com/stateful/runme \
     | head \

--- a/internal/notebook/service.go
+++ b/internal/notebook/service.go
@@ -44,7 +44,12 @@ func (r *notebookService) ResolveNotebook(ctx context.Context, req *notebookv1al
 		return nil, status.Error(codes.InvalidArgument, "cell index is required")
 	}
 
-	resolver := NewNotebookResolver(notebook)
+	resolver, err := NewResolver(WithNotebook(notebook))
+	if err != nil {
+		r.logger.Error("failed to create notebook resolver", zap.Error(err))
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	script, err := resolver.ResolveDaggerShell(ctx, cellIndex.GetValue())
 	if err != nil {
 		r.logger.Error("failed to resolve dagger shell", zap.Error(err))

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -518,7 +518,7 @@ func getCodeBlocks(data []byte) (document.CodeBlocks, error) {
 
 func isMarkdown(filePath string) bool {
 	ext := strings.ToLower(filepath.Ext(filePath))
-	return ext == ".md" || ext == ".mdx" || ext == ".mdi" || ext == ".mdr" || ext == ".run" || ext == ".runme"
+	return ext == ".md" || ext == ".mdx" || ext == ".mdi" || ext == ".mdr" || ext == ".run" || ext == ".runme" || ext == ".dag"
 }
 
 func (p *Project) LoadEnv() ([]string, error) {

--- a/testdata/script/daggershell.txtar
+++ b/testdata/script/daggershell.txtar
@@ -1,0 +1,42 @@
+exec runme ls
+cmp stdout golden-list.txt
+! stderr .
+
+exec runme ls --json
+cmp stdout golden-list-json.txt
+! stderr .
+
+exec runme run simple_dagger
+stdout 'digest\: sha256'
+stdout 'name\: README\.md'
+stdout 'size\: '
+
+-- shell.dag --
+---
+shell: dagger shell
+---
+
+```sh {"name":"simple_dagger","terminalRows":"18"}
+### Exported in runme.dev as simple_dagger
+git github.com/stateful/runme |
+    head |
+    tree |
+    file examples/README.md
+```
+
+-- golden-list.txt --
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+simple_dagger*	shell.dag	git github.com/stateful/runme |		Yes
+-- golden-list-allow-unnamed.txt --
+NAME	FILE	FIRST COMMAND	DESCRIPTION	NAMED
+-- golden-list-json.txt --
+[
+  {
+    "name": "simple_dagger",
+    "file": "shell.dag",
+    "first_command": "git github.com/stateful/runme |",
+    "description": "",
+    "named": true,
+    "run_all": true
+  }
+]


### PR DESCRIPTION
Natively run Dagger Shell when frontmatter (`shell: dagger shell`) requires it. An example is available [here](https://github.com/stateful/runme/pull/745/commits/7c1b4b5462c0751e03c465b71cbb9965a9a09b84).

Since the Notebook Resolver is entirely stateless we skip the GRPC service layer. Please note that `txtar` e2e test coverage of the CLI is excluded from SonarCloud.

https://github.com/user-attachments/assets/f7c273bd-a674-41cd-aa03-0e3cf648ef13

PS: The way Dagger's TUI renders in Runme's TUI isn't fantastic. However, since no low-hanging fix was available this will have to wait for a separate effort/PR.