### PR TITLE
Specifically included or excluded code blocks (`transform` & `ignore` attributes)

### DIFF
--- a/pkg/document/block.go
+++ b/pkg/document/block.go
@@ -126,6 +126,31 @@ func (b *CodeBlock) FencedEncoding() bool { return b.encoding == Fenced }
 
 func (b *CodeBlock) Attributes() *Attributes { return b.attributes }
 
+func (b *CodeBlock) Ignored() (ignored bool) {
+	if b.Attributes() == nil {
+		return
+	}
+
+	transform, err := strconv.ParseBool(b.Attributes().Items["transform"])
+	if err == nil {
+		ignored = !transform
+		return
+	}
+
+	ignore, err := strconv.ParseBool(b.Attributes().Items["ignore"])
+	if err == nil {
+		ignored = ignore
+		return
+	}
+
+	// ingore mermaid blocks by default unless attributes are set
+	if b.Language() == "mermaid" {
+		ignored = true
+	}
+
+	return
+}
+
 func (b *CodeBlock) Background() bool {
 	val, _ := strconv.ParseBool(b.Attributes().Items["background"])
 	return val

--- a/pkg/document/block_test.go
+++ b/pkg/document/block_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBlock_Tags(t *testing.T) {
-	t.Run("Superset including legacy categories", func(t *testing.T) {
+	t.Run("SupersetIncludingLegacyCategories", func(t *testing.T) {
 		block := &CodeBlock{
 			attributes: NewAttributesWithFormat(
 				map[string]string{
@@ -18,5 +18,75 @@ func TestBlock_Tags(t *testing.T) {
 			),
 		}
 		assert.Equal(t, []string{"cat1", "cat2", "tag1", "tag2"}, block.Tags())
+	})
+}
+
+func TestBlock_Ignored(t *testing.T) {
+	t.Run("DefaultTrue", func(t *testing.T) {
+		block := &CodeBlock{}
+		assert.False(t, block.Ignored())
+	})
+
+	t.Run("TransformAttributeFalse", func(t *testing.T) {
+		block := &CodeBlock{
+			attributes: NewAttributesWithFormat(
+				map[string]string{
+					"transform": "false",
+				},
+				"json",
+			),
+		}
+		assert.True(t, block.Ignored())
+	})
+
+	t.Run("IgnoreAttributeTrue", func(t *testing.T) {
+		block := &CodeBlock{
+			attributes: NewAttributesWithFormat(
+				map[string]string{
+					"ignore": "true",
+				},
+				"json",
+			),
+		}
+		assert.True(t, block.Ignored())
+	})
+}
+
+func TestBlock_Mermaid(t *testing.T) {
+	t.Run("IgnoreByDefault", func(t *testing.T) {
+		block := &CodeBlock{
+			attributes: NewAttributesWithFormat(
+				map[string]string{},
+				"json",
+			),
+			language: "mermaid",
+		}
+		assert.True(t, block.Ignored())
+	})
+
+	t.Run("IncludeWithTransform", func(t *testing.T) {
+		block := &CodeBlock{
+			attributes: NewAttributesWithFormat(
+				map[string]string{
+					"transform": "true",
+				},
+				"json",
+			),
+			language: "mermaid",
+		}
+		assert.False(t, block.Ignored())
+	})
+
+	t.Run("IncludeWithNegatedIgnore", func(t *testing.T) {
+		block := &CodeBlock{
+			attributes: NewAttributesWithFormat(
+				map[string]string{
+					"ignore": "false",
+				},
+				"json",
+			),
+			language: "mermaid",
+		}
+		assert.False(t, block.Ignored())
 	})
 }

--- a/pkg/document/editor/cell.go
+++ b/pkg/document/editor/cell.go
@@ -163,23 +163,9 @@ func toCellsRec(
 		case *document.CodeBlock:
 			attr := block.Attributes()
 			metadata := attr.Items
-			transform := true
+			ignored := block.Ignored()
 
-			t, tOk := metadata["transform"]
-			s, err := strconv.ParseBool(t)
-
-			if !tOk {
-				transform = true
-			} else if err == nil {
-				transform = s
-			}
-
-			// mermaid's an exception if attr wasn't explicitly set
-			if block.Language() == "mermaid" && !tOk {
-				transform = false
-			}
-
-			if !transform {
+			if ignored {
 				*cells = append(*cells, &Cell{
 					Kind:  MarkupKind,
 					Value: fmtValue(block.Value()),


### PR DESCRIPTION
This PR will enforce consistent behavior across clients (Notebook, CLI, editor/tasks) when specific code blocks are being ignored. The language `mermaid` continues to be default excluded, which can be overwritten with `transform=true` or `ignore=false.`

Since `transform` makes the most sense in the notebook case, `ignore` is an alias with inverted boolean logic.

Fixes #751.