### PR TITLE
dockerexec: negotiate Docker API version

### DIFF
--- a/internal/dockerexec/docker.go
+++ b/internal/dockerexec/docker.go
@@ -23,8 +23,8 @@ type Options struct {
 }
 
 func New(opts *Options) (*Docker, error) {
-	// Typically, the version is dicted by the Docker API version in the CI (GitHub Actions).
-	c, err := client.NewClientWithOpts(client.FromEnv, client.WithVersion("1.43"))
+	// Negotiate API version with the daemon to avoid hard-coded mismatches across environments.
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
CI appears to have started failing.
https://github.com/runmedev/runme/actions/runs/21955632206/job/63477672958

Error is.

```
--- FAIL: TestDockerCommand (0.00s)
    command_docker_test.go:22: 
        	Error Trace:	/home/runner/work/runme/runme/command/command_docker_test.go:22
        	Error:      	Received unexpected error:
        	            	Error response from daemon: client version 1.43 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
        	            	github.com/runmedev/runme/v3/internal/dockerexec.(*Docker).pullImage
        	            		/home/runner/work/runme/runme/internal/dockerexec/docker.go:101
        	            	github.com/runmedev/runme/v3/internal/dockerexec.(*Docker).buildOrPullImage
        	            		/home/runner/work/runme/runme/internal/dockerexec/docker.go:90
        	            	github.com/runmedev/runme/v3/internal/dockerexec.New
        	            		/home/runner/work/runme/runme/internal/dockerexec/docker.go:49
        	            	github.com/runmedev/runme/v3/command.TestDockerCommand
        	            		/home/runner/work/runme/runme/command/command_docker_test.go:21
        	            	testing.tRunner
        	            		/opt/hostedtoolcache/go/1.25.7/x64/src/testing/testing.go:1934
        	            	runtime.goexit
        	            		/opt/hostedtoolcache/go/1.25.7/x64/src/runtime/asm_amd64.s:1693
        	Test:       	TestDockerCommand
FAIL
```

Guessing the docker version used in our images got updated but our go code is pinning to a specific version.