### PR TITLE
Clean up TLS default path logic. Use convention if config isn't present.

### DIFF
--- a/pkg/agent/application/app.go
+++ b/pkg/agent/application/app.go
@@ -25,6 +25,11 @@ import (
 	"github.com/runmedev/runme/v3/pkg/agent/config"
 )
 
+const (
+	defaultCertFile = "cert.pem"
+	defaultKeyFile  = "key.pem"
+)
+
 type App struct {
 	AppName        string
 	AppConfig      *config.AppConfig
@@ -49,6 +54,17 @@ func (a *App) LoadConfig(cmd *cobra.Command) error {
 		return err
 	}
 	cfg := ac.GetConfig()
+	if cfg.AssistantServer != nil && cfg.AssistantServer.TLSConfig != nil {
+		tls := cfg.AssistantServer.TLSConfig
+		if tls.Generate {
+			if tls.CertFile == "" {
+				tls.CertFile = filepath.Join(ac.GetConfigDir(), defaultCertFile)
+			}
+			if tls.KeyFile == "" {
+				tls.KeyFile = filepath.Join(ac.GetConfigDir(), defaultKeyFile)
+			}
+		}
+	}
 	if problems := cfg.IsValid(); len(problems) > 0 {
 		_, _ = fmt.Fprintf(os.Stdout, "Invalid configuration; %s\n", strings.Join(problems, "\n"))
 		return fmt.Errorf("invalid configuration; fix the problems and then try again")

--- a/pkg/agent/cmd/certificate_check.go
+++ b/pkg/agent/cmd/certificate_check.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"path/filepath"
-
 	"github.com/go-logr/zapr"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -19,13 +17,6 @@ func ensureTLSCertificate(app *application.App) error {
 	tlsConfig := app.AppConfig.AssistantServer.TLSConfig
 	if tlsConfig == nil || !tlsConfig.Generate {
 		return nil
-	}
-
-	if tlsConfig.KeyFile == "" {
-		tlsConfig.KeyFile = filepath.Join(app.AppConfig.GetConfigDir(), tlsbuilder.KeyPEMFile)
-	}
-	if tlsConfig.CertFile == "" {
-		tlsConfig.CertFile = filepath.Join(app.AppConfig.GetConfigDir(), tlsbuilder.CertPEMFile)
 	}
 
 	_, err := tlsbuilder.LoadOrGenerateConfig(tlsConfig.CertFile, tlsConfig.KeyFile, zap.L())


### PR DESCRIPTION
Move cert/key path defaulting into LoadConfig and remove the redundant fallback from ensureTLSCertificate.

1. Use local constants instead of the deprecated `tlsbuilder.CertPEMFile`/`KeyPEMFile`.
2. Nest the two path checks under a single `if tls.Generate` guard.