### PR TITLE
Add APIs to increase extensibility

### DIFF
--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -30,6 +30,9 @@ type WebSocketHandler struct {
 
 	runner *runme.Runner
 
+	// tapFactory creates a StreamTap per run. May be nil (no recording).
+	tapFactory TapFactory
+
 	mu   sync.Mutex
 	runs map[string]*Multiplexer
 }
@@ -40,6 +43,14 @@ func NewWebSocketHandler(runner *runme.Runner, auth *iam.AuthContext) *WebSocket
 		runner: runner,
 		runs:   make(map[string]*Multiplexer),
 	}
+}
+
+// SetTapFactory configures a factory that creates a StreamTap for each new run.
+// If factory is nil or returns nil, recording is disabled for that run.
+func (h *WebSocketHandler) SetTapFactory(factory TapFactory) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.tapFactory = factory
 }
 
 // Handler is the main handler mounted in a mux to handle websocket connection upgrades.
@@ -105,7 +116,11 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 	// If we already have a run, accept the connection on the existing multiplexer.
 	multiplex, ok := h.runs[runID]
 	if !ok {
-		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner)
+		var tap StreamTap
+		if h.tapFactory != nil {
+			tap = h.tapFactory(runID)
+		}
+		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap)
 		h.runs[runID] = multiplex
 	}
 

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -42,6 +42,9 @@ type Multiplexer struct {
 	runner  *runme.Runner
 	streams *Streams
 
+	// tap receives session lifecycle and data events. Never nil (uses noopTap as default).
+	tap StreamTap
+
 	// authedWebsocketRequests is a channel that receives socket requests from authenticated clients.
 	authedWebsocketRequests chan *streamv1.WebsocketRequest
 
@@ -51,7 +54,11 @@ type Multiplexer struct {
 }
 
 // NewMultiplexer creates a new Multiplexer (see description above).
-func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner) *Multiplexer {
+// tap may be nil, in which case recording is disabled.
+func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner, tap StreamTap) *Multiplexer {
+	if tap == nil {
+		tap = noopTap{}
+	}
 	ctx, cancel := context.WithCancel(ctx)
 	m := &Multiplexer{
 		ctx:    ctx,
@@ -60,6 +67,7 @@ func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, ru
 		runID:  runID,
 		auth:   auth,
 		runner: runner,
+		tap:    tap,
 	}
 
 	m.authedWebsocketRequests = make(chan *streamv1.WebsocketRequest, 100)
@@ -76,6 +84,8 @@ func (m *Multiplexer) acceptConnection(streamID string, sc *Connection) error {
 		log.Error(err, "Could not create stream")
 		return err
 	}
+
+	m.tap.ClientConnect(streamID)
 
 	// Start a goroutine to receive requests for a specific stream.
 	go m.receiveRequests(streamID, sc)
@@ -97,7 +107,10 @@ func (m *Multiplexer) receiveRequests(streamID string, sc *Connection) {
 	)
 	defer span.End()
 
-	defer m.streams.removeStream(ctx, streamID)
+	defer func() {
+		m.tap.ClientDisconnect(streamID)
+		m.streams.removeStream(ctx, streamID)
+	}()
 	log := logs.FromContextWithTrace(ctx)
 
 	if err := m.streams.receive(ctx, streamID, m.runID, sc); err != nil {
@@ -151,6 +164,10 @@ func (m *Multiplexer) close() {
 	time.Sleep(ClientGracePeriod)
 	// With Runme's execution finished we can close all websocket connections.
 	m.streams.close(m.ctx)
+
+	// Finalize the recording after all streams are closed.
+	m.tap.RunEnd(-1)
+	_ = m.tap.Close()
 }
 
 // process manages request processing for a runID. Returns false if a run is already in flight.
@@ -175,6 +192,8 @@ func (m *Multiplexer) process() (wait bool) {
 	}
 	p = NewProcessor(ctx, m.runID)
 	m.setInflight(p)
+
+	m.tap.RunStart(m.runID)
 
 	// Start a goroutine to execute requests against runme server.
 	go m.execute(p)
@@ -205,7 +224,31 @@ func (m *Multiplexer) process() (wait bool) {
 				log.Info("Received message doesn't contain an ExecuteRequest")
 				continue
 			}
-			p.ExecuteRequests <- req.GetExecuteRequest()
+
+			execReq := req.GetExecuteRequest()
+
+			// Record input data.
+			if len(execReq.GetInputData()) > 0 {
+				m.tap.Input(execReq.GetInputData())
+			}
+
+			// Record winsize changes.
+			if ws := execReq.GetWinsize(); ws != nil {
+				m.tap.Resize(ws.GetCols(), ws.GetRows())
+			}
+
+			// Record command start when a Config is present (first request).
+			if cfg := execReq.GetConfig(); cfg != nil {
+				program := cfg.GetProgramName()
+				if program == "" {
+					if cmds := cfg.GetCommands(); cmds != nil && len(cmds.GetItems()) > 0 {
+						program = cmds.GetItems()[0]
+					}
+				}
+				m.tap.CommandStart(program, cfg.GetDirectory())
+			}
+
+			p.ExecuteRequests <- execReq
 		}
 	}
 }
@@ -254,6 +297,20 @@ func (m *Multiplexer) broadcastResponses(p *Processor) {
 			// The channel is closed, no more responses to broadcast.
 			return
 		}
+
+		// Record stdout data.
+		if len(res.GetStdoutData()) > 0 {
+			m.tap.Output(res.GetStdoutData())
+		}
+		// Record stderr data.
+		if len(res.GetStderrData()) > 0 {
+			m.tap.Stderr(res.GetStderrData())
+		}
+		// Record command end when exit code is present.
+		if res.GetExitCode() != nil {
+			m.tap.CommandEnd(int(res.GetExitCode().GetValue()))
+		}
+
 		response := &streamv1.WebsocketResponse{
 			Status: &streamv1.WebsocketStatus{
 				Code: code.Code_OK,

--- a/pkg/agent/runme/stream/tap.go
+++ b/pkg/agent/runme/stream/tap.go
@@ -1,0 +1,65 @@
+package stream
+
+// StreamTap receives lifecycle and data events from the multiplexer.
+// Implementations must be safe for concurrent use.
+//
+// The multiplexer calls these methods at the corresponding points in the
+// request/response flow. All methods are best-effort: errors are logged
+// but do not interrupt the session.
+type StreamTap interface {
+	// RunStart is called when a new multiplexer run begins processing.
+	RunStart(runID string)
+
+	// RunEnd is called when the multiplexer run completes.
+	// exitCode is the final process exit code (or -1 if unknown).
+	RunEnd(exitCode int)
+
+	// Output records terminal stdout data from an ExecuteResponse.
+	Output(data []byte)
+
+	// Stderr records terminal stderr data from an ExecuteResponse.
+	// Implementations may also merge this into the output stream for
+	// replay compatibility.
+	Stderr(data []byte)
+
+	// Input records terminal input data from a WebsocketRequest.
+	Input(data []byte)
+
+	// Resize records a terminal resize event.
+	Resize(cols, rows uint32)
+
+	// CommandStart is called when an ExecuteRequest with a Config is received,
+	// signaling the start of a command execution.
+	CommandStart(program, cwd string)
+
+	// CommandEnd is called when command execution finishes.
+	CommandEnd(exitCode int)
+
+	// ClientConnect is called when a WebSocket client connects to the multiplexer.
+	ClientConnect(streamID string)
+
+	// ClientDisconnect is called when a WebSocket client disconnects.
+	ClientDisconnect(streamID string)
+
+	// Close finalizes the recording and releases resources.
+	Close() error
+}
+
+// TapFactory creates a StreamTap for a given runID.
+// If nil is returned, recording is disabled for that run.
+type TapFactory func(runID string) StreamTap
+
+// noopTap is a StreamTap that discards all events.
+type noopTap struct{}
+
+func (noopTap) RunStart(string)             {}
+func (noopTap) RunEnd(int)                  {}
+func (noopTap) Output([]byte)               {}
+func (noopTap) Stderr([]byte)               {}
+func (noopTap) Input([]byte)                {}
+func (noopTap) Resize(uint32, uint32)       {}
+func (noopTap) CommandStart(string, string) {}
+func (noopTap) CommandEnd(int)              {}
+func (noopTap) ClientConnect(string)        {}
+func (noopTap) ClientDisconnect(string)     {}
+func (noopTap) Close() error                { return nil }

--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -75,6 +75,7 @@ type Server struct {
 	registerHandlers RegisterHandlers
 	assetsFS         fs.FS
 	wsHandler        *stream.WebSocketHandler
+	tapFactory       stream.TapFactory
 	chatKitHandler   *chatkit.ChatKitHandler
 	codex            codexComponents
 }
@@ -93,6 +94,9 @@ type (
 		// AssetsFileSystemProvider is an optional asset filesystem provider. If nil, a default implementation
 		// will be used when the agent is enabled.
 		AssetsFileSystemProvider AssetsFileSystemProvider
+		// TapFactory creates a StreamTap for each new multiplexer run.
+		// If nil, no recording is performed.
+		TapFactory stream.TapFactory
 	}
 )
 
@@ -191,6 +195,7 @@ func NewServer(opts Options, agent agentv1connect.MessagesServiceHandler) (*Serv
 		checker:          checker,
 		registerHandlers: opts.RegisterHandlers,
 		assetsFS:         assetsFS,
+		tapFactory:       opts.TapFactory,
 	}
 	return s, nil
 }
@@ -406,6 +411,10 @@ func (s *Server) registerServices() error {
 			Checker: s.checker,
 			Role:    api.RunnerUserRole,
 		})
+		if s.tapFactory != nil {
+			s.wsHandler.SetTapFactory(s.tapFactory)
+			log.Info("Stream tap factory configured for session recording")
+		}
 		// Unprotected WebSockets handler since socket protection is done on the app-level (messages)
 		mux.Handle("/ws", otelhttp.NewHandler(http.HandlerFunc(s.wsHandler.Handler), "/ws"))
 		log.Info("Setting up runner websocket handler", "path", "/ws")


### PR DESCRIPTION
## Summary
- Add `BuildHandler()` to `Server` for serving requests in-process (e.g. relay tunneling)
- Introduce `StreamTap` interface and `TapFactory` for observing multiplexer session lifecycle and data events (input, output, resize, connect/disconnect)
- Wire `TapFactory` through `Server` options into the WebSocket handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)