### PR TITLE
fix(rbuffer): apply backpressure and eliminate stdout-capture deadlock

### DIFF
--- a/internal/rbuffer/ring_buffer.go
+++ b/internal/rbuffer/ring_buffer.go
@@ -9,33 +9,43 @@ import (
 
 var ErrClosed = errors.New("buffer closed")
 
+// RingBuffer is a bounded, concurrent-safe byte buffer that applies
+// backpressure on Write when full instead of overwriting unread data.
+//
+// Semantics:
+//   - Write blocks until all bytes in p have been written, or until
+//     Close is called (in which case it returns ErrClosed with the count
+//     written so far). It never discards unread data.
+//   - Read blocks until at least one byte is available or the buffer is
+//     closed and drained (in which case it returns io.EOF).
+//   - Close wakes all blocked readers and writers; subsequent Writes
+//     return ErrClosed, Reads return any remaining data then io.EOF.
 type RingBuffer struct {
-	mu         sync.Mutex
-	buf        []byte
-	size       int
-	r          int // next position to read
-	w          int // next position to write
-	isFull     bool
-	writeTrims *atomic.Int64
-	closed     *atomic.Bool
-	close      chan struct{}
-	more       chan struct{}
+	mu     sync.Mutex
+	cond   *sync.Cond // signals data-available, space-available, or closed
+	buf    []byte
+	size   int
+	r      int // next position to read
+	w      int // next position to write
+	isFull bool
+	closed *atomic.Bool
 }
 
 func NewRingBuffer(size int) *RingBuffer {
-	return &RingBuffer{
-		buf:        make([]byte, size),
-		size:       size,
-		writeTrims: &atomic.Int64{},
-		closed:     &atomic.Bool{},
-		close:      make(chan struct{}),
-		more:       make(chan struct{}),
+	b := &RingBuffer{
+		buf:    make([]byte, size),
+		size:   size,
+		closed: &atomic.Bool{},
 	}
+	b.cond = sync.NewCond(&b.mu)
+	return b
 }
 
 func (b *RingBuffer) Close() error {
 	if b.closed.CompareAndSwap(false, true) {
-		close(b.close)
+		b.mu.Lock()
+		b.cond.Broadcast()
+		b.mu.Unlock()
 	}
 	return nil
 }
@@ -44,66 +54,77 @@ func (b *RingBuffer) Reset() {
 	b.mu.Lock()
 	b.r = 0
 	b.w = 0
+	b.isFull = false
+	b.cond.Broadcast()
 	b.mu.Unlock()
 }
 
-func (b *RingBuffer) Read(p []byte) (n int, err error) {
+// Read blocks until at least one byte is available, the buffer is
+// closed and drained, or p is empty.
+func (b *RingBuffer) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 
 	b.mu.Lock()
-	n, err = b.read(p)
-	b.mu.Unlock()
+	defer b.mu.Unlock()
 
-	if err != nil && errors.Is(err, io.EOF) && !b.closed.Load() {
-		select {
-		case <-b.more:
-		case <-b.close:
+	for {
+		if b.w != b.r || b.isFull {
+			return b.readLocked(p), nil
+		}
+		if b.closed.Load() {
 			return 0, io.EOF
 		}
-		return n, nil
+		b.cond.Wait()
 	}
-
-	return n, err
 }
 
-func (b *RingBuffer) read(p []byte) (n int, err error) {
+// read is the internal non-blocking read used by tests. It returns
+// io.EOF when the buffer is empty.
+func (b *RingBuffer) read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	if b.w == b.r && !b.isFull {
 		return 0, io.EOF
 	}
+	return b.readLocked(p), nil
+}
 
+// readLocked copies up to len(p) bytes into p and advances r. Caller
+// must hold b.mu and ensure data is available.
+func (b *RingBuffer) readLocked(p []byte) int {
+	var n int
 	if b.w > b.r {
 		n = b.w - b.r
 		if n > len(p) {
 			n = len(p)
 		}
 		copy(p, b.buf[b.r:b.r+n])
-		b.r = (b.r + n) % b.size
-		b.isFull = false
-		return
-	}
-
-	n = b.size - b.r + b.w
-	if n > len(p) {
-		n = len(p)
-	}
-
-	if b.r+n <= b.size {
-		copy(p, b.buf[b.r:b.r+n])
 	} else {
-		copy(p, b.buf[b.r:b.size])
-		c1 := b.size - b.r
-		c2 := n - c1
-		copy(p[c1:], b.buf[0:c2])
+		n = b.size - b.r + b.w
+		if n > len(p) {
+			n = len(p)
+		}
+		if b.r+n <= b.size {
+			copy(p, b.buf[b.r:b.r+n])
+		} else {
+			c1 := b.size - b.r
+			copy(p, b.buf[b.r:b.size])
+			copy(p[c1:], b.buf[0:n-c1])
+		}
 	}
 	b.r = (b.r + n) % b.size
 	b.isFull = false
-
-	return n, err
+	b.cond.Broadcast()
+	return n
 }
 
-func (b *RingBuffer) Write(p []byte) (n int, err error) {
+// Write blocks until all of p has been written, applying backpressure
+// when the buffer is full instead of discarding unread data. If Close
+// is called while Write is blocked, it returns ErrClosed along with
+// the number of bytes successfully written so far.
+func (b *RingBuffer) Write(p []byte) (int, error) {
 	if b.closed.Load() {
 		return 0, ErrClosed
 	}
@@ -112,67 +133,55 @@ func (b *RingBuffer) Write(p []byte) (n int, err error) {
 	}
 
 	b.mu.Lock()
-	n, err = b.write(p)
-	b.mu.Unlock()
+	defer b.mu.Unlock()
 
-	select {
-	case b.more <- struct{}{}:
-	default:
-	}
-
-	return n, err
-}
-
-func (b *RingBuffer) write(p []byte) (n int, err error) {
-	if len(p) > b.size {
-		p = p[len(p)-b.size:]
-		b.writeTrims.Add(1)
-	}
-
-	var avail int
-	if b.w >= b.r {
-		avail = b.size - b.w + b.r
-	} else {
-		avail = b.r - b.w
-	}
-
-	n = len(p)
-
-	if len(p) >= avail {
-		b.isFull = true
-		b.writeTrims.Add(1)
-		b.r = b.w
-		c := copy(b.buf[b.w:], p)
-		b.w = copy(b.buf[0:], p[c:])
-		return n, nil
-	}
-
-	if b.w >= b.r {
-		c1 := b.size - b.w
-		if c1 >= n {
-			copy(b.buf[b.w:], p)
-			b.w += n
-		} else {
-			copy(b.buf[b.w:], p[:c1])
-			c2 := n - c1
-			copy(b.buf[0:], p[c1:])
-			b.w = c2
+	total := 0
+	for len(p) > 0 {
+		if b.closed.Load() {
+			return total, ErrClosed
 		}
-	} else {
-		copy(b.buf[b.w:], p)
-		b.w += n
-	}
 
-	if b.w == b.size {
-		b.isFull = true
-		b.w = 0
-	} else {
-		b.isFull = false
-	}
+		avail := b.availableLocked()
+		if avail == 0 {
+			b.cond.Wait()
+			continue
+		}
 
-	return n, err
+		k := len(p)
+		if k > avail {
+			k = avail
+		}
+
+		if b.w+k <= b.size {
+			copy(b.buf[b.w:], p[:k])
+			b.w += k
+			if b.w == b.size {
+				b.w = 0
+			}
+		} else {
+			c1 := b.size - b.w
+			copy(b.buf[b.w:], p[:c1])
+			copy(b.buf[0:], p[c1:k])
+			b.w = k - c1
+		}
+		if b.w == b.r {
+			b.isFull = true
+		}
+
+		total += k
+		p = p[k:]
+		b.cond.Broadcast()
+	}
+	return total, nil
 }
 
-func (b *RingBuffer) Trims() int64 {
-	return b.writeTrims.Load()
+// availableLocked returns free space in the buffer. Caller must hold b.mu.
+func (b *RingBuffer) availableLocked() int {
+	if b.isFull {
+		return 0
+	}
+	if b.w >= b.r {
+		return b.size - (b.w - b.r)
+	}
+	return b.r - b.w
 }

--- a/internal/rbuffer/ring_buffer_test.go
+++ b/internal/rbuffer/ring_buffer_test.go
@@ -5,11 +5,30 @@ import (
 	"crypto/rand"
 	"io"
 	mathRand "math/rand"
+	"runtime"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )
+
+// assertStillBlocked asserts that done has not been closed/signaled
+// after yielding the scheduler many times. Used to verify a goroutine
+// is parked in cond.Wait without relying on wall-clock sleeps. Returns
+// if no progress is observed; fails the test if done fires.
+func assertStillBlocked(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	for range 200 {
+		select {
+		case <-done:
+			t.Fatal("goroutine completed before expected — not blocked as intended")
+		default:
+		}
+		runtime.Gosched()
+	}
+}
 
 func assertRead(t *testing.T, b *RingBuffer, expected []byte) {
 	t.Helper()
@@ -24,13 +43,9 @@ func assertRead(t *testing.T, b *RingBuffer, expected []byte) {
 func assertWrite(t *testing.T, b *RingBuffer, data []byte) {
 	t.Helper()
 
-	expected := len(data)
-	if expected > b.size {
-		expected = b.size
-	}
 	n, err := b.Write(data)
 	assert.Nil(t, err)
-	assert.Equal(t, expected, n)
+	assert.Equal(t, len(data), n)
 }
 
 func TestRingBuffer(t *testing.T) {
@@ -51,13 +66,6 @@ func TestRingBuffer(t *testing.T) {
 		data = []byte("HELLO123")
 		assertWrite(t, buf, data)
 		assertRead(t, buf, data)
-
-		data = append(bytes.Repeat([]byte{1}, 10), bytes.Repeat([]byte{2}, 5)...)
-		assertWrite(t, buf, data)
-		assertRead(t, buf, data[5:])
-		data = append(bytes.Repeat([]byte{1}, 25), bytes.Repeat([]byte{2}, 8)...)
-		assertWrite(t, buf, data)
-		assertRead(t, buf, data[23:])
 	})
 
 	t.Run("ExceedingInput", func(t *testing.T) {
@@ -138,4 +146,107 @@ func TestRingBuffer_Close(t *testing.T) {
 	n, err = buf.Read(p)
 	assert.Equal(t, 0, n)
 	assert.Error(t, err)
+}
+
+// TestRingBuffer_BlocksOnFullInsteadOfTrimming asserts that when the
+// buffer is full, Write blocks until a Reader drains space — instead of
+// silently overwriting unread bytes as the prior implementation did.
+// This is the regression test for the PTY byte-loss bug where the shell
+// produced bytes faster than the runner consumed them and the ring
+// buffer silently dropped unread data.
+func TestRingBuffer_BlocksOnFullInsteadOfTrimming(t *testing.T) {
+	buf := NewRingBuffer(16)
+
+	// Fill the buffer completely.
+	first := bytes.Repeat([]byte{0xAA}, 16)
+	assertWrite(t, buf, first)
+
+	// Kick off a write that must block: there is zero space available.
+	done := make(chan struct{})
+	var writeErr atomic.Pointer[error]
+	var writeN atomic.Int64
+	go func() {
+		n, err := buf.Write([]byte{0xBB})
+		writeN.Store(int64(n))
+		if err != nil {
+			writeErr.Store(&err)
+		}
+		close(done)
+	}()
+
+	// Confirm the goroutine parks in Write without completing.
+	assertStillBlocked(t, done)
+
+	// Drain one byte. That should unblock the pending Write.
+	got := make([]byte, 1)
+	n, err := buf.Read(got)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, byte(0xAA), got[0])
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Write still blocked after Reader drained space")
+	}
+
+	assert.Equal(t, int64(1), writeN.Load())
+	assert.Nil(t, writeErr.Load(), "Write returned an unexpected error")
+
+	// Drain the rest and assert the original 16 bytes are intact,
+	// followed by the byte that was blocked.
+	rest := make([]byte, 16)
+	total := 0
+	for total < 16 {
+		n, err := buf.Read(rest[total:])
+		assert.NoError(t, err)
+		total += n
+	}
+	assert.Equal(t, append(first[1:], 0xBB), rest)
+}
+
+// TestRingBuffer_CloseUnblocksWriter asserts that Close wakes up a
+// writer blocked on a full buffer and returns ErrClosed with the byte
+// count written so far.
+func TestRingBuffer_CloseUnblocksWriter(t *testing.T) {
+	buf := NewRingBuffer(4)
+
+	// Fill the buffer.
+	assertWrite(t, buf, []byte{1, 2, 3, 4})
+
+	// Start a writer that will block on the full buffer.
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	blocked := make(chan struct{})
+	go func() {
+		close(blocked)
+		n, err := buf.Write([]byte{5, 6, 7})
+		done <- result{n: n, err: err}
+	}()
+
+	// Confirm the goroutine parks in Write without completing. We
+	// observe via `blocked` that it reached the call site, then verify
+	// `done` has not fired across many scheduler yields.
+	<-blocked
+	for range 200 {
+		select {
+		case r := <-done:
+			t.Fatalf("Write returned before Close: n=%d err=%v", r.n, r.err)
+		default:
+		}
+		runtime.Gosched()
+	}
+
+	assert.NoError(t, buf.Close())
+
+	select {
+	case r := <-done:
+		assert.ErrorIs(t, r.err, ErrClosed)
+		assert.Equal(t, 0, r.n, "no bytes should have been written while the buffer was full")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Close did not unblock the pending Writer")
+	}
 }

--- a/runnerv2service/execution.go
+++ b/runnerv2service/execution.go
@@ -17,7 +17,6 @@ import (
 
 	runnerv2 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/runner/v2"
 	"github.com/runmedev/runme/v3/command"
-	"github.com/runmedev/runme/v3/internal/rbuffer"
 	"github.com/runmedev/runme/v3/project"
 	"github.com/runmedev/runme/v3/session"
 )
@@ -101,13 +100,7 @@ func (e *execution) closeIO() {
 	e.logger.Info("closed stderr writer", zap.Error(err))
 }
 
-func (e *execution) storeOutputInEnv(ctx context.Context, r io.Reader) {
-	b, err := io.ReadAll(r)
-	if err != nil {
-		e.logger.Warn("failed to read last output", zap.Error(err))
-		return
-	}
-
+func (e *execution) storeOutputInEnv(ctx context.Context, b []byte) {
 	sanitized := bytes.ReplaceAll(b, []byte{'\000'}, nil)
 	env := command.CreateEnv(command.StoreStdoutEnvName, string(sanitized))
 	if err := e.session.SetEnv(ctx, env); err != nil {
@@ -124,12 +117,9 @@ func (e *execution) storeOutputInEnv(ctx context.Context, r io.Reader) {
 func (e *execution) Wait(ctx context.Context, srv runnerv2.RunnerService_ExecuteServer) (int, error) {
 	envStdout := io.Discard
 	if e.storeStdoutInEnv {
-		b := rbuffer.NewRingBuffer(session.MaxEnvSizeInBytes - len(command.StoreStdoutEnvName) - 1)
-		defer func() {
-			_ = b.Close()
-			e.storeOutputInEnv(ctx, b)
-		}()
-		envStdout = b
+		w := &tailCapWriter{cap: session.MaxEnvSizeInBytes - len(command.StoreStdoutEnvName) - 1}
+		defer func() { e.storeOutputInEnv(ctx, w.Bytes()) }()
+		envStdout = w
 	}
 
 	readSendDone := make(chan error, 2)

--- a/runnerv2service/tail_writer.go
+++ b/runnerv2service/tail_writer.go
@@ -1,0 +1,33 @@
+package runnerv2service
+
+// tailCapWriter is a non-blocking io.Writer that retains at most cap
+// bytes, keeping the tail (most recent writes). It's used to capture a
+// bounded suffix of a command's stdout for env-var storage without
+// applying backpressure to the producer.
+//
+// Not safe for concurrent use. Callers must establish a happens-before
+// relationship (e.g. closing the producer) before reading Bytes.
+type tailCapWriter struct {
+	buf []byte
+	cap int
+}
+
+func (w *tailCapWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	if w.cap <= 0 {
+		return n, nil
+	}
+	if n >= w.cap {
+		w.buf = append(w.buf[:0], p[n-w.cap:]...)
+		return n, nil
+	}
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.cap {
+		w.buf = w.buf[len(w.buf)-w.cap:]
+	}
+	return n, nil
+}
+
+func (w *tailCapWriter) Bytes() []byte {
+	return w.buf
+}


### PR DESCRIPTION
## Summary

- Rewrite `internal/rbuffer.RingBuffer` to apply backpressure on `Write` when full, instead of silently overwriting unread bytes — fixes a PTY output-loss bug when the shell produced faster than the runner consumed.
- Replace the `envStdout` ring buffer in `runnerv2service/execution.go` with a non-blocking `tailCapWriter`. The ring buffer was used as a one-way sink drained only *after* the command exited; with the new blocking semantics, stdout >`MaxEnvSizeInBytes` (~128 KB) deadlocked the entire pipeline (writer → readSendLoop → inner buffer → pipe → command). Tail-N semantics preserved to match the existing `bytes.HasSuffix` assertion in `TestRunnerServiceServerExecute_LastStdoutExceedsEnvLimit` and the tail truncation already done by `command.limitEnviron`.
- Add regression tests for backpressure and `Close`-unblocks-writer behavior, using a `runtime.Gosched()` polling helper instead of wall-clock sleeps to stay deterministic under load.

## Test plan

- [x] `go test ./internal/rbuffer/... -count=1`
- [x] `go test ./runnerv2service/... -count=1 -run TestRunnerServiceServerExecute_LastStdoutExceedsEnvLimit`
- [x] Full `go test ./runnerv2service/...`
- [x] `gofumpt -d` clean on all touched files
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)