### PR TITLE
feat(stream): request preprocessor and configurable WS close grace period

### DIFF
--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -36,6 +37,10 @@ type WebSocketHandler struct {
 	// preprocessor transforms initial ExecuteRequests before execution. May be nil.
 	preprocessor RequestPreprocessor
 
+	// clientGracePeriod, when > 0, overrides the default multiplexer client
+	// close grace period.
+	clientGracePeriod time.Duration
+
 	mu   sync.Mutex
 	runs map[string]*Multiplexer
 }
@@ -63,6 +68,14 @@ func (h *WebSocketHandler) SetRequestPreprocessor(preprocessor RequestPreprocess
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.preprocessor = preprocessor
+}
+
+// SetClientGracePeriod overrides the multiplexer client close grace period.
+// If d <= 0, the multiplexer default (ClientGracePeriod) is used.
+func (h *WebSocketHandler) SetClientGracePeriod(d time.Duration) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.clientGracePeriod = d
 }
 
 // Handler is the main handler mounted in a mux to handle websocket connection upgrades.
@@ -132,7 +145,12 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 		if h.tapFactory != nil {
 			tap = h.tapFactory(runID)
 		}
-		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap, h.preprocessor)
+		var options *MultiplexerOptions
+		if h.clientGracePeriod > 0 {
+			options = &MultiplexerOptions{ClientGracePeriod: h.clientGracePeriod}
+		}
+
+		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap, h.preprocessor, options)
 		h.runs[runID] = multiplex
 	}
 

--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -33,6 +33,9 @@ type WebSocketHandler struct {
 	// tapFactory creates a StreamTap per run. May be nil (no recording).
 	tapFactory TapFactory
 
+	// preprocessor transforms initial ExecuteRequests before execution. May be nil.
+	preprocessor RequestPreprocessor
+
 	mu   sync.Mutex
 	runs map[string]*Multiplexer
 }
@@ -51,6 +54,15 @@ func (h *WebSocketHandler) SetTapFactory(factory TapFactory) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.tapFactory = factory
+}
+
+// SetRequestPreprocessor configures a function that transforms initial
+// ExecuteRequests (those with Config) before they reach the runner.
+// If preprocessor is nil, requests pass through unchanged.
+func (h *WebSocketHandler) SetRequestPreprocessor(preprocessor RequestPreprocessor) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.preprocessor = preprocessor
 }
 
 // Handler is the main handler mounted in a mux to handle websocket connection upgrades.
@@ -120,7 +132,7 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 		if h.tapFactory != nil {
 			tap = h.tapFactory(runID)
 		}
-		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap)
+		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap, h.preprocessor)
 		h.runs[runID] = multiplex
 	}
 

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -21,6 +21,14 @@ import (
 // Stream client grace period (package-level, for testability).
 var ClientGracePeriod = 30 * time.Second
 
+// MultiplexerOptions configures runtime behavior for a Multiplexer.
+type MultiplexerOptions struct {
+	// ClientGracePeriod is how long to wait in close() before force-closing
+	// websocket streams, giving clients a chance to close first.
+	// If <= 0, defaults to ClientGracePeriod.
+	ClientGracePeriod time.Duration
+}
+
 // Multiplexer timeout and interval for inactivity (package-level, for testability).
 var (
 	MultiplexerTimeout  = 20 * time.Minute
@@ -51,6 +59,9 @@ type Multiplexer struct {
 	// authedWebsocketRequests is a channel that receives socket requests from authenticated clients.
 	authedWebsocketRequests chan *streamv1.WebsocketRequest
 
+	// clientGracePeriod controls the close grace period for websocket clients.
+	clientGracePeriod time.Duration
+
 	mu sync.Mutex
 	// p is the processor that is currently processing messages. If p is nil then no run against runme.Runner is currently processing
 	p *Processor
@@ -59,20 +70,26 @@ type Multiplexer struct {
 // NewMultiplexer creates a new Multiplexer (see description above).
 // tap may be nil, in which case recording is disabled.
 // preprocessor may be nil, in which case requests pass through unchanged.
-func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner, tap StreamTap, preprocessor RequestPreprocessor) *Multiplexer {
+func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner, tap StreamTap, preprocessor RequestPreprocessor, options *MultiplexerOptions) *Multiplexer {
 	if tap == nil {
 		tap = noopTap{}
 	}
+	clientGracePeriod := ClientGracePeriod
+	if options != nil && options.ClientGracePeriod > 0 {
+		clientGracePeriod = options.ClientGracePeriod
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	m := &Multiplexer{
 		ctx:    ctx,
 		cancel: cancel,
 
-		runID:        runID,
-		auth:         auth,
-		runner:       runner,
-		tap:          tap,
-		preprocessor: preprocessor,
+		runID:             runID,
+		auth:              auth,
+		runner:            runner,
+		tap:               tap,
+		preprocessor:      preprocessor,
+		clientGracePeriod: clientGracePeriod,
 	}
 
 	m.authedWebsocketRequests = make(chan *streamv1.WebsocketRequest, 100)
@@ -166,7 +183,7 @@ func (m *Multiplexer) close() {
 	}
 	m.setInflight(nil)
 	// Wait for the client grace period to give the client a chance to close the connection.
-	time.Sleep(ClientGracePeriod)
+	time.Sleep(m.clientGracePeriod)
 	// With Runme's execution finished we can close all websocket connections.
 	m.streams.close(m.ctx)
 

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -45,6 +45,9 @@ type Multiplexer struct {
 	// tap receives session lifecycle and data events. Never nil (uses noopTap as default).
 	tap StreamTap
 
+	// preprocessor transforms initial ExecuteRequests before they reach the runner. May be nil.
+	preprocessor RequestPreprocessor
+
 	// authedWebsocketRequests is a channel that receives socket requests from authenticated clients.
 	authedWebsocketRequests chan *streamv1.WebsocketRequest
 
@@ -55,7 +58,8 @@ type Multiplexer struct {
 
 // NewMultiplexer creates a new Multiplexer (see description above).
 // tap may be nil, in which case recording is disabled.
-func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner, tap StreamTap) *Multiplexer {
+// preprocessor may be nil, in which case requests pass through unchanged.
+func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, runner *runme.Runner, tap StreamTap, preprocessor RequestPreprocessor) *Multiplexer {
 	if tap == nil {
 		tap = noopTap{}
 	}
@@ -64,10 +68,11 @@ func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, ru
 		ctx:    ctx,
 		cancel: cancel,
 
-		runID:  runID,
-		auth:   auth,
-		runner: runner,
-		tap:    tap,
+		runID:        runID,
+		auth:         auth,
+		runner:       runner,
+		tap:          tap,
+		preprocessor: preprocessor,
 	}
 
 	m.authedWebsocketRequests = make(chan *streamv1.WebsocketRequest, 100)
@@ -235,6 +240,16 @@ func (m *Multiplexer) process() (wait bool) {
 			// Record winsize changes.
 			if ws := execReq.GetWinsize(); ws != nil {
 				m.tap.Resize(ws.GetCols(), ws.GetRows())
+			}
+
+			// Preprocess the initial request (Config present) before recording and execution.
+			if cfg := execReq.GetConfig(); cfg != nil && m.preprocessor != nil {
+				modified, ppErr := m.preprocessor(execReq)
+				if ppErr != nil {
+					log.Error(ppErr, "Request preprocessor failed, passing original request")
+				} else {
+					execReq = modified
+				}
 			}
 
 			// Record command start when a Config is present (first request).

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -183,6 +183,8 @@ func (m *Multiplexer) close() {
 	}
 	m.setInflight(nil)
 	// Wait for the client grace period to give the client a chance to close the connection.
+	// Intentionally do not short-circuit on m.ctx.Done(); this grace period gives
+	// clients a chance to receive disconnect signaling triggered by cancellation.
 	time.Sleep(m.clientGracePeriod)
 	// With Runme's execution finished we can close all websocket connections.
 	m.streams.close(m.ctx)
@@ -264,6 +266,8 @@ func (m *Multiplexer) process() (wait bool) {
 				modified, ppErr := m.preprocessor(execReq)
 				if ppErr != nil {
 					log.Error(ppErr, "Request preprocessor failed, passing original request")
+				} else if modified == nil {
+					log.Error(errors.New("request preprocessor returned nil request"), "Passing original request")
 				} else {
 					execReq = modified
 				}

--- a/pkg/agent/runme/stream/tap.go
+++ b/pkg/agent/runme/stream/tap.go
@@ -1,5 +1,9 @@
 package stream
 
+import (
+	v2 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/runner/v2"
+)
+
 // StreamTap receives lifecycle and data events from the multiplexer.
 // Implementations must be safe for concurrent use.
 //
@@ -48,6 +52,14 @@ type StreamTap interface {
 // TapFactory creates a StreamTap for a given runID.
 // If nil is returned, recording is disabled for that run.
 type TapFactory func(runID string) StreamTap
+
+// RequestPreprocessor transforms an ExecuteRequest before it reaches
+// the runner. Only the initial request (Config != nil) is preprocessed;
+// subsequent input-only requests pass through unchanged.
+//
+// Implementations may modify the request in place and return it, or
+// return a new request. Returning an error aborts the request.
+type RequestPreprocessor func(req *v2.ExecuteRequest) (*v2.ExecuteRequest, error)
 
 // noopTap is a StreamTap that discards all events.
 type noopTap struct{}

--- a/pkg/agent/runme/stream/tap.go
+++ b/pkg/agent/runme/stream/tap.go
@@ -58,7 +58,11 @@ type TapFactory func(runID string) StreamTap
 // subsequent input-only requests pass through unchanged.
 //
 // Implementations may modify the request in place and return it, or
-// return a new request. Returning an error aborts the request.
+// return a new request. If an error is returned, the multiplexer logs
+// the failure and falls back to the original request.
+//
+// Returning a nil request is invalid and is treated as a preprocessor
+// failure; the original request is used.
 type RequestPreprocessor func(req *v2.ExecuteRequest) (*v2.ExecuteRequest, error)
 
 // noopTap is a StreamTap that discards all events.


### PR DESCRIPTION
## Summary
- **feat(stream)**: add `RequestPreprocessor` hook so embedders can transform initial `ExecuteRequest`s (those with `Config`) before they reach the runner — mirrors the existing `SetTapFactory` pattern.
- **feat(stream)**: make the WebSocket close grace period configurable.

## Test plan
- [x] `go test ./pkg/agent/runme/stream/...`
- [ ] `runme run lint test`