### PR TITLE
Wait for stream tap finalization on shutdown

### DIFF
--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -169,6 +170,25 @@ func (h *WebSocketHandler) Shutdown() {
 	for _, m := range h.runs {
 		m.cancel()
 	}
+}
+
+// ShutdownAndWait cancels all active multiplexers and waits until each one
+// completes its close path, including tap RunEnd/Close delivery.
+func (h *WebSocketHandler) ShutdownAndWait(ctx context.Context) error {
+	h.mu.Lock()
+	multiplexers := make([]*Multiplexer, 0, len(h.runs))
+	for _, m := range h.runs {
+		multiplexers = append(multiplexers, m)
+		m.cancel()
+	}
+	h.mu.Unlock()
+
+	for _, m := range multiplexers {
+		if err := m.Wait(ctx); err != nil {
+			return fmt.Errorf("wait for run %s finalization: %w", m.runID, err)
+		}
+	}
+	return nil
 }
 
 // removeRun removes a run from the handler. It is called when the processor is done.

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,45 @@ import (
 	v2 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/runner/v2"
 	streamv1 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/stream/v1"
 )
+
+type lifecycleTap struct {
+	startOnce  sync.Once
+	runEndOnce sync.Once
+	closeOnce  sync.Once
+	started    chan struct{}
+	runEnded   chan struct{}
+	closed     chan struct{}
+}
+
+func newLifecycleTap() *lifecycleTap {
+	return &lifecycleTap{
+		started:  make(chan struct{}),
+		runEnded: make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (t *lifecycleTap) RunStart(string) {
+	t.startOnce.Do(func() { close(t.started) })
+}
+
+func (t *lifecycleTap) RunEnd() {
+	t.runEndOnce.Do(func() { close(t.runEnded) })
+}
+
+func (t *lifecycleTap) Output([]byte)               {}
+func (t *lifecycleTap) Stderr([]byte)               {}
+func (t *lifecycleTap) Input([]byte)                {}
+func (t *lifecycleTap) Resize(uint32, uint32)       {}
+func (t *lifecycleTap) CommandStart(string, string) {}
+func (t *lifecycleTap) CommandEnd(int)              {}
+func (t *lifecycleTap) ClientConnect(string)        {}
+func (t *lifecycleTap) ClientDisconnect(string)     {}
+
+func (t *lifecycleTap) Close() error {
+	t.closeOnce.Do(func() { close(t.closed) })
+	return nil
+}
 
 // dialWebSocket dials a websocket URL with a random id for testing and returns the connection, response, and error.
 func dialWebSocket(ts *httptest.Server, runID string) (*Connection, *http.Response, error) {
@@ -59,6 +99,88 @@ func TestWebSocketHandler_Handler_SwitchingProtocols(t *testing.T) {
 	err = sc.Close()
 	if err != nil {
 		t.Errorf("Failed to close websocket: %v", err)
+	}
+}
+
+func TestWebSocketHandler_ShutdownAndWaitWaitsForTapFinalization(t *testing.T) {
+	tap := newLifecycleTap()
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: newMockRunmeServer()},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+	)
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		h.auth,
+		h.runner,
+		tap,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: time.Millisecond},
+	)
+
+	h.mu.Lock()
+	h.runs[m.runID] = m
+	h.mu.Unlock()
+
+	processDone := make(chan struct{})
+	go func() {
+		m.process()
+		close(processDone)
+	}()
+
+	select {
+	case <-tap.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for run start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := h.ShutdownAndWait(ctx); err != nil {
+		t.Fatalf("ShutdownAndWait() error = %v", err)
+	}
+
+	select {
+	case <-tap.runEnded:
+	default:
+		t.Fatal("ShutdownAndWait returned before RunEnd")
+	}
+	select {
+	case <-tap.closed:
+	default:
+		t.Fatal("ShutdownAndWait returned before tap Close")
+	}
+	select {
+	case <-processDone:
+	default:
+		t.Fatal("ShutdownAndWait returned before multiplexer process exited")
+	}
+}
+
+func TestWebSocketHandler_ShutdownAndWaitReturnsContextError(t *testing.T) {
+	tap := newLifecycleTap()
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: newMockRunmeServer()},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+	)
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		h.auth,
+		h.runner,
+		tap,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: time.Millisecond},
+	)
+
+	h.mu.Lock()
+	h.runs[m.runID] = m
+	h.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := h.ShutdownAndWait(ctx); err == nil {
+		t.Fatal("ShutdownAndWait() error = nil, want context timeout")
 	}
 }
 

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -43,6 +43,7 @@ var (
 type Multiplexer struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+	done   chan struct{}
 
 	runID string
 
@@ -83,6 +84,7 @@ func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, ru
 	m := &Multiplexer{
 		ctx:    ctx,
 		cancel: cancel,
+		done:   make(chan struct{}),
 
 		runID:             runID,
 		auth:              auth,
@@ -177,6 +179,8 @@ func (m *Multiplexer) startInactivityTimeout(timeout time.Duration, interval tim
 
 // close shuts down the RunmeMultiplexer. We wait for 30s to give the client a chance to close the connection (preferred).
 func (m *Multiplexer) close() {
+	defer close(m.done)
+
 	p := m.getInflight()
 	if p != nil {
 		p.close()
@@ -190,8 +194,20 @@ func (m *Multiplexer) close() {
 	m.streams.close(m.ctx)
 
 	// Finalize the recording after all streams are closed.
-	m.tap.RunEnd(-1)
+	m.tap.RunEnd()
 	_ = m.tap.Close()
+}
+
+// Wait blocks until the multiplexer has finished its close path, including
+// tap finalization. Shutdown callers should use this after canceling the
+// multiplexer when they need RunEnd/Close delivery to complete.
+func (m *Multiplexer) Wait(ctx context.Context) error {
+	select {
+	case <-m.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // process manages request processing for a runID. Returns false if a run is already in flight.

--- a/pkg/agent/runme/stream/tap.go
+++ b/pkg/agent/runme/stream/tap.go
@@ -15,8 +15,7 @@ type StreamTap interface {
 	RunStart(runID string)
 
 	// RunEnd is called when the multiplexer run completes.
-	// exitCode is the final process exit code (or -1 if unknown).
-	RunEnd(exitCode int)
+	RunEnd()
 
 	// Output records terminal stdout data from an ExecuteResponse.
 	Output(data []byte)
@@ -69,7 +68,7 @@ type RequestPreprocessor func(req *v2.ExecuteRequest) (*v2.ExecuteRequest, error
 type noopTap struct{}
 
 func (noopTap) RunStart(string)             {}
-func (noopTap) RunEnd(int)                  {}
+func (noopTap) RunEnd()                     {}
 func (noopTap) Output([]byte)               {}
 func (noopTap) Stderr([]byte)               {}
 func (noopTap) Input([]byte)                {}


### PR DESCRIPTION
## Summary
- add a waitable shutdown path for stream websocket handlers
- track multiplexer completion through tap RunEnd/Close finalization
- remove the unused run-level exit code parameter from StreamTap.RunEnd
- add coverage for ShutdownAndWait waiting and timeout behavior

## Test Plan
- go test ./pkg/agent/runme/stream
- runme run lint test