### PR TITLE
Wait for stream tap finalization on shutdown

### DIFF
--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -38,20 +38,32 @@ type WebSocketHandler struct {
 	// preprocessor transforms initial ExecuteRequests before execution. May be nil.
 	preprocessor RequestPreprocessor
 
-	// clientGracePeriod, when > 0, overrides the default multiplexer client
-	// close grace period.
-	clientGracePeriod time.Duration
+	// clientGracePeriod overrides the default multiplexer client close grace
+	// period when set. A zero value disables the grace period.
+	clientGracePeriod *time.Duration
 
 	mu   sync.Mutex
 	runs map[string]*Multiplexer
 }
 
-func NewWebSocketHandler(runner *runme.Runner, auth *iam.AuthContext) *WebSocketHandler {
-	return &WebSocketHandler{
+type WebSocketHandlerOption func(*WebSocketHandler)
+
+func WithClientGracePeriod(d time.Duration) WebSocketHandlerOption {
+	return func(h *WebSocketHandler) {
+		h.clientGracePeriod = &d
+	}
+}
+
+func NewWebSocketHandler(runner *runme.Runner, auth *iam.AuthContext, options ...WebSocketHandlerOption) *WebSocketHandler {
+	h := &WebSocketHandler{
 		auth:   auth,
 		runner: runner,
 		runs:   make(map[string]*Multiplexer),
 	}
+	for _, option := range options {
+		option(h)
+	}
+	return h
 }
 
 // SetTapFactory configures a factory that creates a StreamTap for each new run.
@@ -69,14 +81,6 @@ func (h *WebSocketHandler) SetRequestPreprocessor(preprocessor RequestPreprocess
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.preprocessor = preprocessor
-}
-
-// SetClientGracePeriod overrides the multiplexer client close grace period.
-// If d <= 0, the multiplexer default (ClientGracePeriod) is used.
-func (h *WebSocketHandler) SetClientGracePeriod(d time.Duration) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.clientGracePeriod = d
 }
 
 // Handler is the main handler mounted in a mux to handle websocket connection upgrades.
@@ -147,8 +151,8 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 			tap = h.tapFactory(runID)
 		}
 		var options *MultiplexerOptions
-		if h.clientGracePeriod > 0 {
-			options = &MultiplexerOptions{ClientGracePeriod: h.clientGracePeriod}
+		if h.clientGracePeriod != nil {
+			options = &MultiplexerOptions{ClientGracePeriod: *h.clientGracePeriod}
 		}
 
 		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap, h.preprocessor, options)

--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -161,14 +162,23 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 	return multiplex, nil
 }
 
-// Shutdown cancels all active multiplexers, which propagates context
-// cancellation to running commands.
-func (h *WebSocketHandler) Shutdown() {
+// Shutdown cancels all active multiplexers and waits until each one completes
+// its close path or ctx expires.
+func (h *WebSocketHandler) Shutdown(ctx context.Context) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	multiplexers := make([]*Multiplexer, 0, len(h.runs))
 	for _, m := range h.runs {
+		multiplexers = append(multiplexers, m)
 		m.cancel()
 	}
+	h.mu.Unlock()
+
+	for _, m := range multiplexers {
+		if err := m.Wait(ctx); err != nil {
+			return fmt.Errorf("wait for run %s finalization: %w", m.runID, err)
+		}
+	}
+	return nil
 }
 
 // removeRun removes a run from the handler. It is called when the processor is done.

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,45 @@ import (
 	v2 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/runner/v2"
 	streamv1 "github.com/runmedev/runme/v3/api/gen/proto/go/runme/stream/v1"
 )
+
+type lifecycleTap struct {
+	startOnce  sync.Once
+	runEndOnce sync.Once
+	closeOnce  sync.Once
+	started    chan struct{}
+	runEnded   chan struct{}
+	closed     chan struct{}
+}
+
+func newLifecycleTap() *lifecycleTap {
+	return &lifecycleTap{
+		started:  make(chan struct{}),
+		runEnded: make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (t *lifecycleTap) RunStart(string) {
+	t.startOnce.Do(func() { close(t.started) })
+}
+
+func (t *lifecycleTap) RunEnd() {
+	t.runEndOnce.Do(func() { close(t.runEnded) })
+}
+
+func (t *lifecycleTap) Output([]byte)               {}
+func (t *lifecycleTap) Stderr([]byte)               {}
+func (t *lifecycleTap) Input([]byte)                {}
+func (t *lifecycleTap) Resize(uint32, uint32)       {}
+func (t *lifecycleTap) CommandStart(string, string) {}
+func (t *lifecycleTap) CommandEnd(int)              {}
+func (t *lifecycleTap) ClientConnect(string)        {}
+func (t *lifecycleTap) ClientDisconnect(string)     {}
+
+func (t *lifecycleTap) Close() error {
+	t.closeOnce.Do(func() { close(t.closed) })
+	return nil
+}
 
 // dialWebSocket dials a websocket URL with a random id for testing and returns the connection, response, and error.
 func dialWebSocket(ts *httptest.Server, runID string) (*Connection, *http.Response, error) {
@@ -59,6 +99,132 @@ func TestWebSocketHandler_Handler_SwitchingProtocols(t *testing.T) {
 	err = sc.Close()
 	if err != nil {
 		t.Errorf("Failed to close websocket: %v", err)
+	}
+}
+
+func TestWebSocketHandler_ShutdownWaitsForTapFinalization(t *testing.T) {
+	tap := newLifecycleTap()
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: newMockRunmeServer()},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+	)
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		h.auth,
+		h.runner,
+		tap,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: time.Millisecond},
+	)
+
+	h.mu.Lock()
+	h.runs[m.runID] = m
+	h.mu.Unlock()
+
+	processDone := make(chan struct{})
+	go func() {
+		m.process()
+		close(processDone)
+	}()
+
+	select {
+	case <-tap.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for run start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := h.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	select {
+	case <-tap.runEnded:
+	default:
+		t.Fatal("Shutdown returned before RunEnd")
+	}
+	select {
+	case <-tap.closed:
+	default:
+		t.Fatal("Shutdown returned before tap Close")
+	}
+	select {
+	case <-processDone:
+	default:
+		t.Fatal("Shutdown returned before multiplexer process exited")
+	}
+}
+
+func TestMultiplexerCloseFinalizesTapBeforeClientGracePeriod(t *testing.T) {
+	tap := newLifecycleTap()
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+		&runme.Runner{Server: newMockRunmeServer()},
+		tap,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: 100 * time.Millisecond},
+	)
+
+	go m.close()
+
+	select {
+	case <-tap.runEnded:
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("timed out waiting for RunEnd before client grace period")
+	}
+	select {
+	case <-tap.closed:
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("timed out waiting for tap Close before client grace period")
+	}
+	select {
+	case <-m.done:
+		t.Fatal("multiplexer close completed before client grace period")
+	default:
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := m.Wait(ctx); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+}
+
+func TestWebSocketHandler_ShutdownReturnsContextError(t *testing.T) {
+	tap := newLifecycleTap()
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: newMockRunmeServer()},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+	)
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		h.auth,
+		h.runner,
+		tap,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: 100 * time.Millisecond},
+	)
+
+	h.mu.Lock()
+	h.runs[m.runID] = m
+	h.mu.Unlock()
+
+	go m.process()
+	select {
+	case <-tap.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for run start")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := h.Shutdown(ctx); err == nil {
+		t.Fatal("Shutdown() error = nil, want context timeout")
 	}
 }
 

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -194,6 +194,37 @@ func TestMultiplexerCloseFinalizesTapBeforeClientGracePeriod(t *testing.T) {
 	}
 }
 
+func TestMultiplexerOptionsCanDisableClientGracePeriod(t *testing.T) {
+	m := NewMultiplexer(
+		context.Background(),
+		ulid.GenerateID(),
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+		&runme.Runner{Server: newMockRunmeServer()},
+		nil,
+		nil,
+		&MultiplexerOptions{ClientGracePeriod: 0},
+	)
+
+	if m.clientGracePeriod != 0 {
+		t.Fatalf("clientGracePeriod = %s, want 0s", m.clientGracePeriod)
+	}
+}
+
+func TestWebSocketHandlerWithClientGracePeriodAllowsZero(t *testing.T) {
+	h := NewWebSocketHandler(
+		&runme.Runner{Server: newMockRunmeServer()},
+		&iam.AuthContext{Checker: &iam.AllowAllChecker{}},
+		WithClientGracePeriod(0),
+	)
+
+	if h.clientGracePeriod == nil {
+		t.Fatal("clientGracePeriod = nil, want explicit 0s")
+	}
+	if *h.clientGracePeriod != 0 {
+		t.Fatalf("clientGracePeriod = %s, want 0s", *h.clientGracePeriod)
+	}
+}
+
 func TestWebSocketHandler_ShutdownReturnsContextError(t *testing.T) {
 	tap := newLifecycleTap()
 	h := NewWebSocketHandler(

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -25,7 +25,7 @@ var ClientGracePeriod = 30 * time.Second
 type MultiplexerOptions struct {
 	// ClientGracePeriod is how long to wait in close() before force-closing
 	// websocket streams, giving clients a chance to close first.
-	// If <= 0, defaults to ClientGracePeriod.
+	// If options are nil, defaults to ClientGracePeriod.
 	ClientGracePeriod time.Duration
 }
 
@@ -76,7 +76,7 @@ func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, ru
 		tap = noopTap{}
 	}
 	clientGracePeriod := ClientGracePeriod
-	if options != nil && options.ClientGracePeriod > 0 {
+	if options != nil {
 		clientGracePeriod = options.ClientGracePeriod
 	}
 

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -43,6 +43,7 @@ var (
 type Multiplexer struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+	done   chan struct{}
 
 	runID string
 
@@ -83,6 +84,7 @@ func NewMultiplexer(ctx context.Context, runID string, auth *iam.AuthContext, ru
 	m := &Multiplexer{
 		ctx:    ctx,
 		cancel: cancel,
+		done:   make(chan struct{}),
 
 		runID:             runID,
 		auth:              auth,
@@ -175,23 +177,39 @@ func (m *Multiplexer) startInactivityTimeout(timeout time.Duration, interval tim
 	}
 }
 
-// close shuts down the RunmeMultiplexer. We wait for 30s to give the client a chance to close the connection (preferred).
+// close shuts down the RunmeMultiplexer.
 func (m *Multiplexer) close() {
+	defer close(m.done)
+
 	p := m.getInflight()
 	if p != nil {
 		p.close()
 	}
 	m.setInflight(nil)
+
+	// Finalize the recording before client grace. Client grace is about
+	// disconnect/reconnect semantics and should not delay RunEnd delivery.
+	m.tap.RunEnd()
+	_ = m.tap.Close()
+
 	// Wait for the client grace period to give the client a chance to close the connection.
 	// Intentionally do not short-circuit on m.ctx.Done(); this grace period gives
 	// clients a chance to receive disconnect signaling triggered by cancellation.
 	time.Sleep(m.clientGracePeriod)
 	// With Runme's execution finished we can close all websocket connections.
 	m.streams.close(m.ctx)
+}
 
-	// Finalize the recording after all streams are closed.
-	m.tap.RunEnd(-1)
-	_ = m.tap.Close()
+// Wait blocks until the multiplexer has finished its close path, including
+// tap finalization. Shutdown callers should use this after canceling the
+// multiplexer when they need RunEnd/Close delivery to complete.
+func (m *Multiplexer) Wait(ctx context.Context) error {
+	select {
+	case <-m.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // process manages request processing for a runID. Returns false if a run is already in flight.

--- a/pkg/agent/runme/stream/tap.go
+++ b/pkg/agent/runme/stream/tap.go
@@ -15,8 +15,7 @@ type StreamTap interface {
 	RunStart(runID string)
 
 	// RunEnd is called when the multiplexer run completes.
-	// exitCode is the final process exit code (or -1 if unknown).
-	RunEnd(exitCode int)
+	RunEnd()
 
 	// Output records terminal stdout data from an ExecuteResponse.
 	Output(data []byte)
@@ -69,7 +68,7 @@ type RequestPreprocessor func(req *v2.ExecuteRequest) (*v2.ExecuteRequest, error
 type noopTap struct{}
 
 func (noopTap) RunStart(string)             {}
-func (noopTap) RunEnd(int)                  {}
+func (noopTap) RunEnd()                     {}
 func (noopTap) Output([]byte)               {}
 func (noopTap) Stderr([]byte)               {}
 func (noopTap) Input([]byte)                {}

--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -492,8 +492,12 @@ func (s *Server) shutdown() {
 	// and invisible to hServer.Shutdown, so we must cancel their contexts
 	// explicitly. This propagates to running commands via cmd.Cancel.
 	if s.wsHandler != nil {
-		s.wsHandler.Shutdown()
-		log.Info("Cancelled active runs")
+		ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+		defer cancel()
+		if err := s.wsHandler.Shutdown(ctx); err != nil {
+			log.Error(err, "Error shutting down websocket handler")
+		}
+		log.Info("WebSocket handler shutdown complete")
 	}
 	if s.codex.bridge != nil {
 		s.codex.bridge.Shutdown()


### PR DESCRIPTION
## Summary
- add a waitable shutdown path for stream websocket handlers
- track multiplexer completion through tap RunEnd/Close finalization
- remove the unused run-level exit code parameter from StreamTap.RunEnd
- add coverage for ShutdownAndWait waiting and timeout behavior

## Test Plan
- go test ./pkg/agent/runme/stream
- runme run lint test