### PR TITLE
fix: serialize runner v2 execute responses

### DIFF
--- a/runnerv2service/buffer.go
+++ b/runnerv2service/buffer.go
@@ -67,18 +67,22 @@ func (b *buffer) Close() error {
 }
 
 func (b *buffer) Read(p []byte) (int, error) {
-	b.mu.Lock()
-	n, err := b.b.Read(p)
-	b.mu.Unlock()
+	for {
+		b.mu.Lock()
+		n, err := b.b.Read(p)
+		b.mu.Unlock()
 
-	if err != nil && errors.Is(err, io.EOF) && !b.closed.Load() {
+		if n > 0 || err == nil || !errors.Is(err, io.EOF) {
+			return n, err
+		}
+
+		if b.closed.Load() {
+			return n, io.EOF
+		}
+
 		select {
 		case <-b.more:
 		case <-b.close:
-			return n, io.EOF
 		}
-		return n, nil
 	}
-
-	return n, err
 }

--- a/runnerv2service/buffer_test.go
+++ b/runnerv2service/buffer_test.go
@@ -1,0 +1,51 @@
+package runnerv2service
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferReadDrainsBufferedDataBeforeEOF(t *testing.T) {
+	t.Parallel()
+
+	buf := newBuffer(4)
+	n, err := buf.Write([]byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.NoError(t, buf.Close())
+
+	p := make([]byte, 2)
+
+	n, err = buf.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, "he", string(p[:n]))
+
+	n, err = buf.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, 2, n)
+	require.Equal(t, "ll", string(p[:n]))
+
+	n, err = buf.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, "o", string(p[:n]))
+
+	n, err = buf.Read(p)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 0, n)
+}
+
+func TestBufferReadClosedEmptyBufferReturnsEOF(t *testing.T) {
+	t.Parallel()
+
+	buf := newBuffer(4)
+	require.NoError(t, buf.Close())
+
+	p := make([]byte, 2)
+	n, err := buf.Read(p)
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(t, 0, n)
+}

--- a/runnerv2service/execution.go
+++ b/runnerv2service/execution.go
@@ -39,6 +39,8 @@ type execution struct {
 	stdinW, stdoutW, stderrW io.WriteCloser
 }
 
+type executeResponseSender func(context.Context, *runnerv2.ExecuteResponse) error
+
 func newExecution(
 	cfg *command.ProgramConfig,
 	proj *project.Project,
@@ -114,7 +116,7 @@ func (e *execution) storeOutputInEnv(ctx context.Context, b []byte) {
 	}
 }
 
-func (e *execution) Wait(ctx context.Context, srv runnerv2.RunnerService_ExecuteServer) (int, error) {
+func (e *execution) Wait(ctx context.Context, send executeResponseSender) (int, error) {
 	envStdout := io.Discard
 	if e.storeStdoutInEnv {
 		w := &tailCapWriter{cap: session.MaxEnvSizeInBytes - len(command.StoreStdoutEnvName) - 1}
@@ -127,7 +129,8 @@ func (e *execution) Wait(ctx context.Context, srv runnerv2.RunnerService_Execute
 		mimetypeDetected := false
 
 		readSendDone <- e.readSendLoop(
-			srv,
+			ctx,
+			send,
 			e.stdoutR,
 			func(b []byte) *runnerv2.ExecuteResponse {
 				if _, err := envStdout.Write(b); err != nil {
@@ -156,7 +159,8 @@ func (e *execution) Wait(ctx context.Context, srv runnerv2.RunnerService_Execute
 	}()
 	go func() {
 		readSendDone <- e.readSendLoop(
-			srv,
+			ctx,
+			send,
 			e.stderrR,
 			func(b []byte) *runnerv2.ExecuteResponse {
 				return &runnerv2.ExecuteResponse{
@@ -205,7 +209,8 @@ finalWait:
 }
 
 func (e *execution) readSendLoop(
-	srv runnerv2.RunnerService_ExecuteServer,
+	ctx context.Context,
+	send executeResponseSender,
 	src io.Reader,
 	cb func([]byte) *runnerv2.ExecuteResponse,
 	logger *zap.Logger,
@@ -247,9 +252,9 @@ func (e *execution) readSendLoop(
 		}
 
 		readTime := time.Now()
-		response := cb(data[:n])
+		response := cb(bytes.Clone(data[:n]))
 
-		if err := srv.Send(response); err != nil {
+		if err := send(ctx, response); err != nil {
 			logger.Warn("failed to send response", zap.Error(err))
 			return errors.WithStack(err)
 		}

--- a/runnerv2service/service_execute.go
+++ b/runnerv2service/service_execute.go
@@ -1,8 +1,10 @@
 package runnerv2service
 
 import (
+	"context"
 	"io"
 	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -79,13 +81,17 @@ func (r *runnerService) Execute(srv runnerv2.RunnerService_ExecuteServer) error 
 		return err
 	}
 
+	sender := newExecuteResponseStreamSender(srv, logger.Named("responseSender"))
+
 	// Start the command and send the initial response with PID.
 	if err := exec.Cmd.Start(ctx); err != nil {
+		_ = sender.Close()
 		return err
 	}
-	if err := srv.Send(&runnerv2.ExecuteResponse{
+	if err := sender.Send(ctx, &runnerv2.ExecuteResponse{
 		Pid: &wrapperspb.UInt32Value{Value: uint32(exec.Cmd.Pid())},
 	}); err != nil {
+		_ = sender.Close()
 		return err
 	}
 
@@ -133,7 +139,7 @@ func (r *runnerService) Execute(srv runnerv2.RunnerService_ExecuteServer) error 
 		}
 	}(req)
 
-	exitCode, waitErr := exec.Wait(ctx, srv)
+	exitCode, waitErr := exec.Wait(ctx, sender.Send)
 	logger.Info("command finished", zap.Int("exitCode", exitCode), zap.Error(waitErr))
 
 	var finalExitCode *wrapperspb.UInt32Value
@@ -149,7 +155,7 @@ func (r *runnerService) Execute(srv runnerv2.RunnerService_ExecuteServer) error 
 		prevPwd = v
 	}
 
-	if err := srv.Send(&runnerv2.ExecuteResponse{
+	if err := sender.Send(ctx, &runnerv2.ExecuteResponse{
 		ExitCode: finalExitCode,
 		Pwd: &runnerv2.ExecuteResponse_Pwd{
 			Current:  currPwd,
@@ -158,8 +164,79 @@ func (r *runnerService) Execute(srv runnerv2.RunnerService_ExecuteServer) error 
 	}); err != nil {
 		logger.Info("failed to send exit code", zap.Error(err))
 	}
+	if err := sender.Close(); err != nil {
+		logger.Info("response sender stopped with error", zap.Error(err))
+		if waitErr == nil {
+			waitErr = err
+		}
+	}
 
 	return waitErr
+}
+
+type executeResponseStreamSender struct {
+	responses chan *runnerv2.ExecuteResponse
+	done      chan struct{}
+	closeOnce sync.Once
+	errMu     sync.Mutex
+	err       error
+}
+
+func newExecuteResponseStreamSender(
+	srv runnerv2.RunnerService_ExecuteServer,
+	logger *zap.Logger,
+) *executeResponseStreamSender {
+	s := &executeResponseStreamSender{
+		responses: make(chan *runnerv2.ExecuteResponse),
+		done:      make(chan struct{}),
+	}
+
+	go func() {
+		defer close(s.done)
+		for resp := range s.responses {
+			if err := srv.Send(resp); err != nil {
+				logger.Warn("failed to send response", zap.Error(err))
+				s.setErr(errors.WithStack(err))
+				return
+			}
+		}
+	}()
+
+	return s
+}
+
+func (s *executeResponseStreamSender) Send(ctx context.Context, resp *runnerv2.ExecuteResponse) error {
+	select {
+	case s.responses <- resp:
+		return nil
+	case <-s.done:
+		if err := s.Err(); err != nil {
+			return err
+		}
+		return errors.New("response sender stopped")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *executeResponseStreamSender) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.responses)
+	})
+	<-s.done
+	return s.Err()
+}
+
+func (s *executeResponseStreamSender) setErr(err error) {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	s.err = err
+}
+
+func (s *executeResponseStreamSender) Err() error {
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
 }
 
 func getExecutionInfoFromExecutionRequest(req *runnerv2.ExecuteRequest) *rcontext.ExecutionInfo {

--- a/runnerv2service/service_execute.go
+++ b/runnerv2service/service_execute.go
@@ -179,7 +179,8 @@ type executeResponseStreamSender struct {
 	done      chan struct{}
 	closeOnce sync.Once
 	errMu     sync.Mutex
-	err       error
+	// +checklocks:errMu
+	err error
 }
 
 func newExecuteResponseStreamSender(

--- a/runnerv2service/service_execute_test.go
+++ b/runnerv2service/service_execute_test.go
@@ -5,6 +5,7 @@ package runnerv2service
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -155,6 +156,47 @@ func TestRunnerServiceServerExecute_Response(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), resp.GetExitCode().GetValue())
 	assert.Nil(t, resp.GetPid())
+}
+
+func TestRunnerServiceServerExecute_MixedOutputShortProcess(t *testing.T) {
+	_, _, lis, stop := startRunnerServiceServer(t)
+	t.Cleanup(stop)
+
+	_, client := testutils.NewGRPCClientWithT(t, lis, runnerv2.NewRunnerServiceClient)
+
+	for i := range 10 {
+		stream, err := client.Execute(context.Background())
+		require.NoError(t, err)
+
+		resultC := make(chan executeResult)
+		go getExecuteResult(stream, resultC)
+
+		stdout := fmt.Sprintf("stdout-%02d", i)
+		stderr := fmt.Sprintf("stderr-%02d", i)
+		err = stream.Send(
+			&runnerv2.ExecuteRequest{
+				Config: &runnerv2.ProgramConfig{
+					ProgramName: "bash",
+					Source: &runnerv2.ProgramConfig_Commands{
+						Commands: &runnerv2.ProgramConfig_CommandList{
+							Items: []string{
+								fmt.Sprintf("printf %q", stdout),
+								fmt.Sprintf("printf %q >&2", stderr),
+							},
+						},
+					},
+					Mode: runnerv2.CommandMode_COMMAND_MODE_INLINE,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		result := <-resultC
+		require.NoError(t, result.Err)
+		require.Equal(t, 0, result.ExitCode)
+		require.Equal(t, stdout, string(result.Stdout))
+		require.Equal(t, stderr, string(result.Stderr))
+	}
 }
 
 func TestRunnerServiceServerExecute_StoreLastStdout(t *testing.T) {


### PR DESCRIPTION
## Summary

- fix `runnerv2service` buffer reads so buffered output is drained before EOF after close
- serialize Runner v2 `Execute` responses through one sender goroutine instead of calling `srv.Send` from stdout/stderr loops
- copy output chunks before enqueueing them so async sends cannot race with the reusable read buffer
- add regression coverage for buffer EOF behavior and short-process mixed stdout/stderr output

## Validation

- `go test -run 'TestBuffer|TestRunnerServiceServerExecute_MixedOutputShortProcess|TestClient_ExecuteProgram' ./runnerv2service ./runnerv2client`
- `go test -race ./runnerv2service ./runnerv2client`
- `make VERSION=v3.16.12-rc.0-a2e50da test/execute TAGS=test_with_txtar`

Note: plain `runme run test` fails locally on this force-updated `main` because `git describe --tags` cannot describe `a2e50da`, producing `BuildVersion=-a2e50da` and tripping unrelated version assertions. The same Makefile test target passes when given an explicit semver-ish `VERSION` override.
