### PR TITLE
test: retain Harbor example artifacts

### DIFF
--- a/examples/harbor/datasets/runme-integration/simple-agent/task.toml
+++ b/examples/harbor/datasets/runme-integration/simple-agent/task.toml
@@ -20,7 +20,7 @@ timeout_sec = 240.0
 [environment]
 build_timeout_sec = 60.0
 cpus = 1
-memory_mb = 512
+memory_mb = 1024
 storage_mb = 1024
 gpus = 0
 workdir = "/app/examples/harbor/datasets/runme-integration/simple-agent/workdir"

--- a/examples/harbor/datasets/runme-integration/simple-agent/tests/test.sh
+++ b/examples/harbor/datasets/runme-integration/simple-agent/tests/test.sh
@@ -12,6 +12,8 @@ fi
 actual="$(cat result.txt)"
 
 if [ "$actual" = "$expected" ]; then
+  mkdir -p /logs/artifacts
+  cp result.txt /logs/artifacts/result.txt
   printf '1.0' > /logs/verifier/reward.txt
 else
   printf 'expected %s, got %s\n' "$expected" "$actual" >&2

--- a/examples/harbor/datasets/runme-integration/text-stats-reward/task.toml
+++ b/examples/harbor/datasets/runme-integration/text-stats-reward/task.toml
@@ -20,7 +20,7 @@ timeout_sec = 240.0
 [environment]
 build_timeout_sec = 60.0
 cpus = 1
-memory_mb = 512
+memory_mb = 1024
 storage_mb = 1024
 gpus = 0
 workdir = "/app/examples/harbor/datasets/runme-integration/text-stats-reward/workdir"

--- a/examples/harbor/datasets/runme-integration/text-stats-reward/tests/test.sh
+++ b/examples/harbor/datasets/runme-integration/text-stats-reward/tests/test.sh
@@ -5,3 +5,9 @@ uvx --from harbor-rewardkit==0.1 rewardkit \
   --workspace /app/examples/harbor/datasets/runme-integration/text-stats-reward/workdir \
   --output /logs/verifier/reward.json \
   /tests
+
+if [ -f /app/examples/harbor/datasets/runme-integration/text-stats-reward/workdir/results.json ]; then
+  mkdir -p /logs/artifacts
+  cp /app/examples/harbor/datasets/runme-integration/text-stats-reward/workdir/results.json \
+    /logs/artifacts/results.json
+fi

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -311,6 +311,30 @@ def test_upload_dir_rewrites_shell_scripts(
     assert "/logs/verifier" not in decoded
 
 
+def test_upload_dir_rewrites_artifact_paths_in_shell_scripts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "test.sh").write_text(
+        "mkdir -p /logs/artifacts\n"
+        "cp results.json /logs/artifacts/results.json\n"
+    )
+
+    environment = _make_env(tmp_path)
+    asyncio.run(environment.start(force_build=False))
+    asyncio.run(environment.upload_dir(source, "/tests"))
+
+    request = FakeClient.instances[0].requests[-1]["upload_directory"]
+    decoded = env_module.base64.b64decode(request["files"][0]["data"]).decode()
+    assert str(tmp_path / "trial" / "artifacts") in decoded
+    assert "/logs/artifacts" not in decoded
+
+
 def test_upload_dir_rewrites_python_verifier_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -335,6 +359,29 @@ def test_upload_dir_rewrites_python_verifier_paths(
     assert str(tmp_path / "trial" / "verifier" / "reward.json") in decoded
     assert 'Path("/app/poem.txt")' not in decoded
     assert 'Path("/logs/verifier/reward.json")' not in decoded
+
+
+def test_upload_dir_rewrites_python_artifact_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "artifact.py").write_text(
+        'Path("/logs/artifacts/results.json").write_text("{}")\n'
+    )
+
+    environment = _make_env(tmp_path)
+    asyncio.run(environment.start(force_build=False))
+    asyncio.run(environment.upload_dir(source, "/tests"))
+
+    request = FakeClient.instances[0].requests[-1]["upload_directory"]
+    decoded = env_module.base64.b64decode(request["files"][0]["data"]).decode()
+    assert str(tmp_path / "trial" / "artifacts" / "results.json") in decoded
+    assert 'Path("/logs/artifacts/results.json")' not in decoded
 
 
 def test_protocol_error_raises_runtime_error() -> None:


### PR DESCRIPTION
## Summary

- copy `simple-agent`'s verified `result.txt` into `/logs/artifacts/result.txt`
- copy `text-stats-reward`'s generated `results.json` into `/logs/artifacts/results.json` after RewardKit succeeds
- add Harbor environment tests covering `/logs/artifacts` path rewriting in shell and Python verifier files

## Validation

- `uv run pytest` in `integrations/harbor`
- `RUNME_BIN=/tmp/runme-harbor-artifacts-runme uv --project integrations/harbor run runme-harbor run examples/harbor/datasets/runme-integration --task-dir simple-agent --agent oracle -y`
- `RUNME_BIN=/tmp/runme-harbor-artifacts-runme uv --project integrations/harbor run runme-harbor run examples/harbor/datasets/runme-integration --task-dir text-stats-reward --agent oracle -y`

Oracle eval jobs:
- `.runme/evals/jobs/2026-06-15__16-06-07`
- `.runme/evals/jobs/2026-06-15__16-06-19`