### PR TITLE
fix: serialize multiclient stream processing

### DIFF
--- a/pkg/agent/runme/stream/handler.go
+++ b/pkg/agent/runme/stream/handler.go
@@ -119,16 +119,16 @@ func (h *WebSocketHandler) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	sc := NewConnection(conn)
 
-	multiplex, err := h.handleConnection(ctx, runID, streamID, sc)
+	multiplex, created, err := h.handleConnection(ctx, runID, streamID, sc)
 	if err != nil {
 		log.Error(err, "Could not handle websocket connection")
 		_ = sc.Error("Could not handle websocket connection")
 		return
 	}
 
-	// If the processor was celling, we remove the run from the handler.
-	wait := multiplex.process()
-	if wait {
+	wait := false
+	if created {
+		wait = multiplex.process()
 		h.removeRun(ctx, runID)
 	}
 
@@ -136,7 +136,7 @@ func (h *WebSocketHandler) Handler(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleConnection accepts a websocket connection as a stream into a multiplexer.
-func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, streamID string, sc *Connection) (*Multiplexer, error) {
+func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, streamID string, sc *Connection) (*Multiplexer, bool, error) {
 	log := logs.FromContextWithTrace(ctx)
 	log.Info("WebSocketHandler.handleConnection", "runID", runID, "streamID", streamID)
 
@@ -144,6 +144,7 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 	defer h.mu.Unlock()
 
 	// If we already have a run, accept the connection on the existing multiplexer.
+	created := false
 	multiplex, ok := h.runs[runID]
 	if !ok {
 		var tap StreamTap
@@ -157,13 +158,17 @@ func (h *WebSocketHandler) handleConnection(ctx context.Context, runID string, s
 
 		multiplex = NewMultiplexer(ctx, runID, h.auth, h.runner, tap, h.preprocessor, options)
 		h.runs[runID] = multiplex
+		created = true
 	}
 
 	if err := multiplex.acceptConnection(streamID, sc); err != nil {
-		return nil, errors.Wrap(err, "could not accept connection")
+		if created {
+			delete(h.runs, runID)
+		}
+		return nil, false, errors.Wrap(err, "could not accept connection")
 	}
 
-	return multiplex, nil
+	return multiplex, created, nil
 }
 
 // Shutdown cancels all active multiplexers and waits until each one completes

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -713,6 +713,30 @@ func TestRunmeHandler_MutliClient(t *testing.T) {
 	}
 
 	knownID := ulid.GenerateID()
+	for i, sc := range connections {
+		ts := timestamppb.Now().AsTime().UnixMilli()
+		pingReq, err := protojson.Marshal(&streamv1.WebsocketRequest{
+			RunId:   runID,
+			KnownId: knownID,
+			Ping: &streamv1.Ping{
+				Timestamp: ts,
+			},
+		})
+		if err != nil {
+			t.Fatalf("Failed to marshal readiness ping: %v", err)
+		}
+		if err := sc.WriteMessage(websocket.TextMessage, pingReq); err != nil {
+			t.Fatalf("Failed to write readiness ping on socket %d: %v", i+1, err)
+		}
+		resp, err := sc.ReadWebsocketResponse(context.Background())
+		if err != nil {
+			t.Fatalf("Failed to read readiness pong on socket %d: %v", i+1, err)
+		}
+		if resp.GetPong() == nil || resp.GetPong().GetTimestamp() != ts {
+			t.Fatalf("Expected readiness pong on socket %d", i+1)
+		}
+	}
+
 	dummyReq, err := protojson.Marshal(&streamv1.WebsocketRequest{
 		RunId:   runID,
 		KnownId: knownID,

--- a/pkg/agent/runme/stream/multiplexer.go
+++ b/pkg/agent/runme/stream/multiplexer.go
@@ -65,7 +65,8 @@ type Multiplexer struct {
 
 	mu sync.Mutex
 	// p is the processor that is currently processing messages. If p is nil then no run against runme.Runner is currently processing
-	p *Processor
+	p         *Processor
+	closeOnce sync.Once
 }
 
 // NewMultiplexer creates a new Multiplexer (see description above).
@@ -179,25 +180,27 @@ func (m *Multiplexer) startInactivityTimeout(timeout time.Duration, interval tim
 
 // close shuts down the RunmeMultiplexer.
 func (m *Multiplexer) close() {
-	defer close(m.done)
+	m.closeOnce.Do(func() {
+		defer close(m.done)
 
-	p := m.getInflight()
-	if p != nil {
-		p.close()
-	}
-	m.setInflight(nil)
+		p := m.getInflight()
+		if p != nil {
+			p.close()
+		}
+		m.setInflight(nil)
 
-	// Finalize the recording before client grace. Client grace is about
-	// disconnect/reconnect semantics and should not delay RunEnd delivery.
-	m.tap.RunEnd()
-	_ = m.tap.Close()
+		// Finalize the recording before client grace. Client grace is about
+		// disconnect/reconnect semantics and should not delay RunEnd delivery.
+		m.tap.RunEnd()
+		_ = m.tap.Close()
 
-	// Wait for the client grace period to give the client a chance to close the connection.
-	// Intentionally do not short-circuit on m.ctx.Done(); this grace period gives
-	// clients a chance to receive disconnect signaling triggered by cancellation.
-	time.Sleep(m.clientGracePeriod)
-	// With Runme's execution finished we can close all websocket connections.
-	m.streams.close(m.ctx)
+		// Wait for the client grace period to give the client a chance to close the connection.
+		// Intentionally do not short-circuit on m.ctx.Done(); this grace period gives
+		// clients a chance to receive disconnect signaling triggered by cancellation.
+		time.Sleep(m.clientGracePeriod)
+		// With Runme's execution finished we can close all websocket connections.
+		m.streams.close(m.ctx)
+	})
 }
 
 // Wait blocks until the multiplexer has finished its close path, including
@@ -226,14 +229,12 @@ func (m *Multiplexer) process() (wait bool) {
 
 	// todo(sebastian): Still have to decide what to do if a user tries to send a new request
 	// before the current's done as below. The cleanest solution might be to SIGINT the run in runme.Runner.
-	p := m.getInflight()
-	if p != nil {
+	p, ok := m.startInflight(ctx)
+	if !ok {
 		log.Info("Already have a run in flight", "runID", m.runID)
 		wait = false
 		return
 	}
-	p = NewProcessor(ctx, m.runID)
-	m.setInflight(p)
 
 	m.tap.RunStart(m.runID)
 
@@ -317,6 +318,16 @@ func (m *Multiplexer) setInflight(p *Processor) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.p = p
+}
+
+func (m *Multiplexer) startInflight(ctx context.Context) (*Processor, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.p != nil {
+		return m.p, false
+	}
+	m.p = NewProcessor(ctx, m.runID)
+	return m.p, true
 }
 
 // execute invokes the Runme runner to execute the request.


### PR DESCRIPTION
## Summary
- add a ping/pong readiness barrier before starting `TestRunmeHandler_MutliClient` execution
- only let the websocket handler that creates a multiplexer own `process()` for that run
- serialize processor startup so only one owner can create the processor
- make multiplexer close idempotent
- remove a newly-created multiplexer from `h.runs` if its initial `acceptConnection` fails

## Why
The original flake showed one client missing the first broadcast because the test started execution before every websocket server-side stream loop was ready. After adding the readiness barrier, the test exposed a deeper race: multiple websocket handlers can enter `process()` concurrently for the same run. Because the old check/set of `m.p` was not atomic, more than one handler could create/close processor state.

The fix keeps the multiplexer tied to the original request context so upstream cancellation behavior remains intact, but prevents non-creating handlers from racing to own the run. It also cleans up the just-created `h.runs` entry if the initial connection cannot be accepted.

## Verification
- `go test ./pkg/agent/runme/stream -run TestRunmeHandler_MutliClient -count=1000 -race`
- `go test ./pkg/agent/runme/stream`