### PR TITLE
[codex] Sync Harbor job metadata from trials

### DIFF
--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import importlib.metadata
+import os
 import re
 import shutil
 import subprocess
@@ -17,6 +18,7 @@ CLAUDE_IMPORT_PATH = "runme_harbor.runme_agents:RunmeClaudeCode"
 OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
 MIN_HARBOR_VERSION = (0, 13, 1)
 MAX_HARBOR_VERSION = (0, 14, 0)
+SKIP_METADATA_SYNC_ENV = "RUNME_HARBOR_SKIP_METADATA_SYNC"
 AGENT_ARGUMENTS = {
     "oracle": ("--agent", "oracle"),
     "codex": ("--agent-import-path", CODEX_IMPORT_PATH),
@@ -43,7 +45,15 @@ def run(args: argparse.Namespace) -> int:
     command = build_harbor_command(args)
     if args.debug:
         print(_command_string(command), file=sys.stderr)
-    return subprocess.call(command)
+    exit_code = subprocess.call(command)
+    if not _skip_metadata_sync():
+        from runme_harbor.metadata_sync import sync_jobs_metadata
+
+        try:
+            sync_jobs_metadata(args.jobs_dir)
+        except Exception as exc:
+            print(f"warning: failed to sync Harbor job metadata: {exc}", file=sys.stderr)
+    return exit_code
 
 
 def build_harbor_command(args: argparse.Namespace) -> list[str]:
@@ -132,6 +142,10 @@ def _preflight(agent: str) -> None:
         raise SystemExit("`--agent claude-code` requires the `claude` CLI on PATH.")
     if agent == "openclaw" and not shutil.which("openclaw"):
         raise SystemExit("`--agent openclaw` requires the `openclaw` CLI on PATH.")
+
+
+def _skip_metadata_sync() -> bool:
+    return os.environ.get(SKIP_METADATA_SYNC_ENV, "").lower() in {"1", "true", "yes"}
 
 
 def _contains_concurrency_flag(args: list[str]) -> bool:

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -59,6 +59,8 @@ def run(args: argparse.Namespace) -> int:
 
 
 def sync_metadata(args: argparse.Namespace) -> int:
+    _preflight_harbor_package()
+
     from runme_harbor.metadata_sync import sync_jobs_metadata
 
     synced = sync_jobs_metadata(args.jobs_dir)
@@ -133,16 +135,9 @@ def _find_removed_task_flag(args: list[str]) -> str | None:
 
 
 def _preflight(agent: str) -> None:
-    try:
-        importlib.import_module("harbor")
-    except ModuleNotFoundError as exc:
-        raise SystemExit("Runme Harbor requires the `harbor` Python package.") from exc
+    _preflight_harbor_package()
     if not shutil.which("harbor"):
         raise SystemExit("Runme Harbor requires the `harbor` CLI on PATH.")
-
-    version = _version_tuple(importlib.metadata.version("harbor"))
-    if version < MIN_HARBOR_VERSION or version >= MAX_HARBOR_VERSION:
-        raise SystemExit("Runme Harbor requires harbor>=0.13.1,<0.14.")
 
     try:
         importlib.import_module("runme_harbor")
@@ -155,6 +150,17 @@ def _preflight(agent: str) -> None:
         raise SystemExit("`--agent claude-code` requires the `claude` CLI on PATH.")
     if agent == "openclaw" and not shutil.which("openclaw"):
         raise SystemExit("`--agent openclaw` requires the `openclaw` CLI on PATH.")
+
+
+def _preflight_harbor_package() -> None:
+    try:
+        importlib.import_module("harbor")
+    except ModuleNotFoundError as exc:
+        raise SystemExit("Runme Harbor requires the `harbor` Python package.") from exc
+
+    version = _version_tuple(importlib.metadata.version("harbor"))
+    if version < MIN_HARBOR_VERSION or version >= MAX_HARBOR_VERSION:
+        raise SystemExit("Runme Harbor requires harbor>=0.13.1,<0.14.")
 
 
 def _skip_metadata_sync() -> bool:

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -32,6 +32,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         args = _parse_args(list(argv) if argv is not None else sys.argv[1:])
         if args.command == "run":
             return run(args)
+        if args.command == "sync-metadata":
+            return sync_metadata(args)
     except SystemExit as exc:
         if isinstance(exc.code, int):
             return exc.code
@@ -54,6 +56,14 @@ def run(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(f"warning: failed to sync Harbor job metadata: {exc}", file=sys.stderr)
     return exit_code
+
+
+def sync_metadata(args: argparse.Namespace) -> int:
+    from runme_harbor.metadata_sync import sync_jobs_metadata
+
+    synced = sync_jobs_metadata(args.jobs_dir)
+    print(f"Synced Harbor metadata for {synced} job(s).")
+    return 0
 
 
 def build_harbor_command(args: argparse.Namespace) -> list[str]:
@@ -97,6 +107,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     run_parser.add_argument("--jobs-dir", default=".runme/evals/jobs")
     run_parser.add_argument("-y", "--yes", action="store_true")
     run_parser.add_argument("--debug", action="store_true")
+
+    sync_parser = subparsers.add_parser("sync-metadata", allow_abbrev=False)
+    sync_parser.add_argument("--jobs-dir", default=".runme/evals/jobs")
 
     args, passthrough = parser.parse_known_args(argv)
     removed_task_flag = _find_removed_task_flag(passthrough)

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from harbor.models.job.config import JobConfig
+from harbor.models.trajectories.trajectory import Trajectory
 from harbor.models.trial.config import AgentConfig
 from harbor.models.trial.result import TrialResult
 
@@ -84,8 +85,21 @@ def _observed_agents(job_dir: Path) -> list[ObservedAgent]:
             model_name = model_info.name
             if model_info.provider:
                 model_name = f"{model_info.provider}/{model_info.name}"
+        else:
+            model_name = _trajectory_model_name(result_path)
         observed.add(ObservedAgent(name=result.agent_info.name, model_name=model_name))
     return sorted(observed)
+
+
+def _trajectory_model_name(result_path: Path) -> str | None:
+    trajectory_path = result_path.parent / "agent" / "trajectory.json"
+    if not trajectory_path.exists():
+        return None
+    try:
+        trajectory = Trajectory.model_validate_json(trajectory_path.read_text())
+    except Exception:
+        return None
+    return trajectory.agent.model_name
 
 
 def _same_json(left: str, right: str) -> bool:

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -9,7 +9,7 @@ from harbor.models.trial.config import AgentConfig
 from harbor.models.trial.result import TrialResult
 
 
-ORIGINAL_CONFIG_BACKUP = "config.runme-original.json"
+ORIGINAL_CONFIG_BACKUP = "config.original.json"
 
 
 @dataclass(frozen=True, order=True)

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -17,7 +17,7 @@ ORIGINAL_CONFIG_BACKUP = "config.original.json"
 ORIGINAL_RESULT_BACKUP = "result.original.json"
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class ObservedAgent:
     name: str
     model_name: str | None = None
@@ -137,7 +137,7 @@ def _observed_agents(job_dir: Path) -> list[ObservedAgent]:
         else:
             model_name = _trajectory_model_name(result_path)
         observed.add(ObservedAgent(name=result.agent_info.name, model_name=model_name))
-    return sorted(observed)
+    return sorted(observed, key=lambda agent: (agent.name, agent.model_name or ""))
 
 
 def _trajectory_model_name(result_path: Path) -> str | None:

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass
+from importlib import import_module
 from pathlib import Path
 
 from harbor.models.job.config import JobConfig
 from harbor.models.trajectories.trajectory import Trajectory
 from harbor.models.trial.config import AgentConfig
-from harbor.models.trial.result import TrialResult
+from harbor.models.trial.result import ModelInfo, TrialResult
+
+from runme_harbor.cli import AGENT_ARGUMENTS, ENVIRONMENT_IMPORT_PATH
 
 
 ORIGINAL_CONFIG_BACKUP = "config.original.json"
+ORIGINAL_RESULT_BACKUP = "result.original.json"
 
 
 @dataclass(frozen=True, order=True)
@@ -47,27 +51,72 @@ def _sync_job_metadata(job_dir: Path) -> bool:
     except Exception:
         return False
 
+    results_synced = _sync_trial_results(job_dir)
+    original_config = _original_config(job_dir)
     observed_agents = _observed_agents(job_dir)
     if not observed_agents:
-        return False
+        return results_synced
+
+    synced_agents = [
+        _synced_agent_config(agent, original_config=original_config)
+        for agent in observed_agents
+    ]
+    updates: dict[str, object] = {"agents": synced_agents}
+    if _has_runme_agent(synced_agents):
+        updates["environment"] = _synced_environment(config, original_config=original_config)
 
     synced_config = config.model_copy(
-        update={
-            "agents": [
-                AgentConfig(name=agent.name, model_name=agent.model_name)
-                for agent in observed_agents
-            ]
-        }
+        update=updates
     )
     synced_json = synced_config.model_dump_json(indent=4)
     current_json = config_path.read_text()
     if _same_json(current_json, synced_json):
-        return False
+        return results_synced
 
     backup_path = job_dir / ORIGINAL_CONFIG_BACKUP
     if not backup_path.exists():
         shutil.copy2(config_path, backup_path)
     config_path.write_text(synced_json)
+    return True
+
+
+def _sync_trial_results(job_dir: Path) -> bool:
+    synced = False
+    for result_path in sorted(job_dir.glob("*/result.json")):
+        if _sync_trial_result(result_path):
+            synced = True
+    return synced
+
+
+def _sync_trial_result(result_path: Path) -> bool:
+    try:
+        result = TrialResult.model_validate_json(result_path.read_text())
+    except Exception:
+        return False
+
+    if result.agent_info.model_info is not None:
+        return False
+
+    model_name = _trajectory_model_name(result_path)
+    if not model_name:
+        return False
+
+    synced_result = result.model_copy(
+        update={
+            "agent_info": result.agent_info.model_copy(
+                update={"model_info": ModelInfo(name=model_name)}
+            )
+        }
+    )
+    synced_json = synced_result.model_dump_json(indent=4)
+    current_json = result_path.read_text()
+    if _same_trial_result_json(current_json, synced_json):
+        return False
+
+    backup_path = result_path.with_name(ORIGINAL_RESULT_BACKUP)
+    if not backup_path.exists():
+        shutil.copy2(result_path, backup_path)
+    result_path.write_text(synced_json)
     return True
 
 
@@ -102,6 +151,88 @@ def _trajectory_model_name(result_path: Path) -> str | None:
     return trajectory.agent.model_name
 
 
+def _original_config(job_dir: Path) -> JobConfig | None:
+    backup_path = job_dir / ORIGINAL_CONFIG_BACKUP
+    if not backup_path.exists():
+        return None
+    try:
+        return JobConfig.model_validate_json(backup_path.read_text())
+    except Exception:
+        return None
+
+
+def _synced_agent_config(
+    observed: ObservedAgent,
+    *,
+    original_config: JobConfig | None,
+) -> AgentConfig:
+    original_agent = _matching_original_agent(observed, original_config=original_config)
+    import_path = original_agent.import_path if original_agent else _runme_agent_import_paths().get(observed.name)
+    if import_path:
+        return AgentConfig(name=observed.name, import_path=import_path, model_name=observed.model_name)
+    return AgentConfig(name=observed.name, model_name=observed.model_name)
+
+
+def _matching_original_agent(
+    observed: ObservedAgent,
+    *,
+    original_config: JobConfig | None,
+) -> AgentConfig | None:
+    if original_config is None:
+        return None
+
+    expected_import_path = _runme_agent_import_paths().get(observed.name)
+    for agent in original_config.agents:
+        if expected_import_path and agent.import_path == expected_import_path:
+            return agent
+        if agent.name == observed.name:
+            return agent
+    return None
+
+
+def _has_runme_agent(agents: list[AgentConfig]) -> bool:
+    import_paths = set(_runme_agent_import_paths().values())
+    return any(agent.import_path in import_paths for agent in agents)
+
+
+def _synced_environment(
+    config: JobConfig,
+    *,
+    original_config: JobConfig | None,
+):
+    if original_config is not None and original_config.environment.import_path:
+        return original_config.environment
+    if config.environment.import_path:
+        return config.environment
+    return config.environment.model_copy(update={"import_path": ENVIRONMENT_IMPORT_PATH})
+
+
+def _runme_agent_import_paths() -> dict[str, str]:
+    agent_import_paths: dict[str, str] = {}
+    for args in AGENT_ARGUMENTS.values():
+        if len(args) != 2 or args[0] != "--agent-import-path":
+            continue
+        import_path = args[1]
+        agent_name = _agent_name_from_import_path(import_path)
+        if agent_name:
+            agent_import_paths[agent_name] = import_path
+    return agent_import_paths
+
+
+def _agent_name_from_import_path(import_path: str) -> str | None:
+    module_name, _, class_name = import_path.partition(":")
+    if not module_name or not class_name:
+        return None
+    try:
+        agent_class = getattr(import_module(module_name), class_name)
+        name = agent_class.name()
+    except Exception:
+        return None
+    if isinstance(name, str) and name:
+        return name
+    return None
+
+
 def _same_json(left: str, right: str) -> bool:
     try:
         left_config = JobConfig.model_validate_json(left)
@@ -109,3 +240,12 @@ def _same_json(left: str, right: str) -> bool:
     except Exception:
         return left == right
     return left_config == right_config
+
+
+def _same_trial_result_json(left: str, right: str) -> bool:
+    try:
+        left_result = TrialResult.model_validate_json(left)
+        right_result = TrialResult.model_validate_json(right)
+    except Exception:
+        return left == right
+    return left_result == right_result

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from harbor.models.job.config import JobConfig
+from harbor.models.trial.config import AgentConfig
+from harbor.models.trial.result import TrialResult
+
+
+ORIGINAL_CONFIG_BACKUP = "config.runme-original.json"
+
+
+@dataclass(frozen=True, order=True)
+class ObservedAgent:
+    name: str
+    model_name: str | None = None
+
+
+def sync_jobs_metadata(jobs_dir: str | Path) -> int:
+    """Sync Harbor job config metadata from completed trial results.
+
+    Harbor's local viewer derives job agents/models from job config. Runme's
+    integration can execute a different concrete agent/model than the original
+    planned config records, so update local job configs after trials finish.
+    """
+    jobs_path = Path(jobs_dir).expanduser()
+    if not jobs_path.exists():
+        return 0
+
+    synced = 0
+    for job_dir in sorted(path for path in jobs_path.iterdir() if path.is_dir()):
+        if _sync_job_metadata(job_dir):
+            synced += 1
+    return synced
+
+
+def _sync_job_metadata(job_dir: Path) -> bool:
+    config_path = job_dir / "config.json"
+    if not config_path.exists():
+        return False
+
+    try:
+        config = JobConfig.model_validate_json(config_path.read_text())
+    except Exception:
+        return False
+
+    observed_agents = _observed_agents(job_dir)
+    if not observed_agents:
+        return False
+
+    synced_config = config.model_copy(
+        update={
+            "agents": [
+                AgentConfig(name=agent.name, model_name=agent.model_name)
+                for agent in observed_agents
+            ]
+        }
+    )
+    synced_json = synced_config.model_dump_json(indent=4)
+    current_json = config_path.read_text()
+    if _same_json(current_json, synced_json):
+        return False
+
+    backup_path = job_dir / ORIGINAL_CONFIG_BACKUP
+    if not backup_path.exists():
+        shutil.copy2(config_path, backup_path)
+    config_path.write_text(synced_json)
+    return True
+
+
+def _observed_agents(job_dir: Path) -> list[ObservedAgent]:
+    observed: set[ObservedAgent] = set()
+    for result_path in sorted(job_dir.glob("*/result.json")):
+        try:
+            result = TrialResult.model_validate_json(result_path.read_text())
+        except Exception:
+            continue
+
+        model_name = None
+        model_info = result.agent_info.model_info
+        if model_info is not None:
+            model_name = model_info.name
+            if model_info.provider:
+                model_name = f"{model_info.provider}/{model_info.name}"
+        observed.add(ObservedAgent(name=result.agent_info.name, model_name=model_name))
+    return sorted(observed)
+
+
+def _same_json(left: str, right: str) -> bool:
+    try:
+        left_config = JobConfig.model_validate_json(left)
+        right_config = JobConfig.model_validate_json(right)
+    except Exception:
+        return left == right
+    return left_config == right_config

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -94,11 +94,14 @@ def _sync_trial_result(result_path: Path) -> bool:
     except Exception:
         return False
 
-    if result.agent_info.model_info is not None:
-        return False
-
     model_name = _trajectory_model_name(result_path)
     if not model_name:
+        return False
+    if (
+        result.agent_info.model_info is not None
+        and result.agent_info.model_info.name == model_name
+        and result.agent_info.model_info.provider is None
+    ):
         return False
 
     synced_result = result.model_copy(
@@ -129,13 +132,14 @@ def _observed_agents(job_dir: Path) -> list[ObservedAgent]:
             continue
 
         model_name = None
-        model_info = result.agent_info.model_info
-        if model_info is not None:
+        atif_model_name = _trajectory_model_name(result_path)
+        if atif_model_name:
+            model_name = atif_model_name
+        elif result.agent_info.model_info is not None:
+            model_info = result.agent_info.model_info
             model_name = model_info.name
             if model_info.provider:
                 model_name = f"{model_info.provider}/{model_info.name}"
-        else:
-            model_name = _trajectory_model_name(result_path)
         observed.add(ObservedAgent(name=result.agent_info.name, model_name=model_name))
     return sorted(observed, key=lambda agent: (agent.name, agent.model_name or ""))
 

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from runme_harbor import cli
+from runme_harbor import metadata_sync
 
 
 def parse(argv: list[str]):
@@ -132,6 +133,35 @@ def test_main_runs_harbor_and_prints_debug(
 
     assert calls[0][0:2] == ["harbor", "run"]
     assert "harbor run" in capsys.readouterr().err
+
+
+def test_main_syncs_metadata_after_harbor_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    synced: list[str] = []
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: None)
+    monkeypatch.setattr(cli.subprocess, "call", lambda _command: 7)
+    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+
+    assert cli.main(["run", str(tmp_path), "--jobs-dir", "jobs"]) == 7
+
+    assert synced == ["jobs"]
+
+
+def test_main_skips_metadata_sync_when_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    synced: list[str] = []
+    monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: None)
+    monkeypatch.setattr(cli.subprocess, "call", lambda _command: 0)
+    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+
+    assert cli.main(["run", str(tmp_path), "--jobs-dir", "jobs"]) == 0
+
+    assert synced == []
 
 
 @pytest.mark.parametrize(

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -164,6 +164,30 @@ def test_main_skips_metadata_sync_when_disabled(
     assert synced == []
 
 
+def test_main_sync_metadata_command_uses_default_jobs_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    synced: list[str] = []
+    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 3)
+
+    assert cli.main(["sync-metadata"]) == 0
+
+    assert synced == [".runme/evals/jobs"]
+    assert capsys.readouterr().out == "Synced Harbor metadata for 3 job(s).\n"
+
+
+def test_main_sync_metadata_command_accepts_jobs_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    synced: list[str] = []
+    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+
+    assert cli.main(["sync-metadata", "--jobs-dir", "jobs"]) == 0
+
+    assert synced == ["jobs"]
+
+
 @pytest.mark.parametrize(
     ("agent", "missing", "message"),
     [

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -169,10 +169,13 @@ def test_main_sync_metadata_command_uses_default_jobs_dir(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     synced: list[str] = []
+    preflighted: list[bool] = []
+    monkeypatch.setattr(cli, "_preflight_harbor_package", lambda: preflighted.append(True))
     monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 3)
 
     assert cli.main(["sync-metadata"]) == 0
 
+    assert preflighted == [True]
     assert synced == [".runme/evals/jobs"]
     assert capsys.readouterr().out == "Synced Harbor metadata for 3 job(s).\n"
 
@@ -181,11 +184,29 @@ def test_main_sync_metadata_command_accepts_jobs_dir(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     synced: list[str] = []
+    monkeypatch.setattr(cli, "_preflight_harbor_package", lambda: None)
     monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
 
     assert cli.main(["sync-metadata", "--jobs-dir", "jobs"]) == 0
 
     assert synced == ["jobs"]
+
+
+def test_main_sync_metadata_command_reports_preflight_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_preflight() -> None:
+        raise SystemExit("Runme Harbor requires the `harbor` Python package.")
+
+    synced: list[str] = []
+    monkeypatch.setattr(cli, "_preflight_harbor_package", fail_preflight)
+    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+
+    assert cli.main(["sync-metadata"]) == 1
+
+    assert synced == []
+    assert capsys.readouterr().err == "Runme Harbor requires the `harbor` Python package.\n"
 
 
 @pytest.mark.parametrize(

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -76,6 +76,20 @@ def test_sync_jobs_metadata_sorts_and_deduplicates_observed_agents(tmp_path: Pat
     ]
 
 
+def test_sync_jobs_metadata_sorts_same_agent_with_missing_model_info(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-a", agent_name="runme-codex")
+    _write_trial_result(job_dir, "trial-b", agent_name="runme-codex", model_name="gpt-5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, None),
+        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5"),
+    ]
+
+
 def test_sync_jobs_metadata_omits_missing_model_info(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
     _write_trial_result(job_dir, "trial-1", agent_name="oracle")

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -138,7 +138,7 @@ def test_sync_jobs_metadata_uses_atif_model_when_trial_model_info_missing(
     )
 
 
-def test_sync_jobs_metadata_preserves_trial_model_info_over_atif(
+def test_sync_jobs_metadata_prefers_atif_over_trial_model_info(
     tmp_path: Path,
 ) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
@@ -155,13 +155,75 @@ def test_sync_jobs_metadata_preserves_trial_model_info_over_atif(
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
     assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")
+        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
     ]
     result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
     assert result.agent_info.model_info is not None
-    assert result.agent_info.model_info.name == "gpt-5"
-    assert result.agent_info.model_info.provider == "openai"
-    assert not (job_dir / "trial-1" / ORIGINAL_RESULT_BACKUP).exists()
+    assert result.agent_info.model_info.name == "gpt-5.5"
+    assert result.agent_info.model_info.provider is None
+    result_backup = TrialResult.model_validate_json(
+        (job_dir / "trial-1" / ORIGINAL_RESULT_BACKUP).read_text()
+    )
+    assert result_backup.agent_info.model_info is not None
+    assert result_backup.agent_info.model_info.name == "gpt-5"
+    assert result_backup.agent_info.model_info.provider == "openai"
+
+
+def test_sync_jobs_metadata_replaces_claude_alias_with_atif_model_name(
+    tmp_path: Path,
+) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="runme-claude-code",
+        model_name="haiku",
+    )
+    _write_trajectory(
+        job_dir / "trial-1",
+        agent_name="runme-claude-code",
+        model_name="claude-haiku-4-5-20251001",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [
+        ("runme-claude-code", CLAUDE_IMPORT_PATH, "claude-haiku-4-5-20251001")
+    ]
+    result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
+    assert result.agent_info.model_info is not None
+    assert result.agent_info.model_info.name == "claude-haiku-4-5-20251001"
+    assert result.agent_info.model_info.provider is None
+
+
+def test_sync_jobs_metadata_clears_provider_when_atif_model_name_matches(
+    tmp_path: Path,
+) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="runme-claude-code",
+        provider="anthropic",
+        model_name="claude-haiku-4-5-20251001",
+    )
+    _write_trajectory(
+        job_dir / "trial-1",
+        agent_name="runme-claude-code",
+        model_name="claude-haiku-4-5-20251001",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [
+        ("runme-claude-code", CLAUDE_IMPORT_PATH, "claude-haiku-4-5-20251001")
+    ]
+    result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
+    assert result.agent_info.model_info is not None
+    assert result.agent_info.model_info.name == "claude-haiku-4-5-20251001"
+    assert result.agent_info.model_info.provider is None
 
 
 def test_sync_jobs_metadata_ignores_unreadable_atif(tmp_path: Path) -> None:

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -6,18 +6,32 @@ from harbor.models.job.config import JobConfig
 from harbor.models.trial.config import AgentConfig
 from harbor.models.trial.result import TrialResult
 
-from runme_harbor.metadata_sync import ORIGINAL_CONFIG_BACKUP, sync_jobs_metadata
+from runme_harbor.cli import (
+    CLAUDE_IMPORT_PATH,
+    CODEX_IMPORT_PATH,
+    ENVIRONMENT_IMPORT_PATH,
+)
+from runme_harbor.metadata_sync import (
+    ORIGINAL_CONFIG_BACKUP,
+    ORIGINAL_RESULT_BACKUP,
+    sync_jobs_metadata,
+)
 
 
-def test_sync_jobs_metadata_uses_observed_trial_agents(tmp_path: Path) -> None:
+def test_sync_jobs_metadata_uses_observed_runme_agent_import_paths(tmp_path: Path) -> None:
     job_dir = _write_job_config(
         tmp_path,
-        agents=[AgentConfig(name="planned", model_name="planned-provider/planned-model")],
+        agents=[
+            AgentConfig(
+                import_path=CODEX_IMPORT_PATH,
+                model_name="planned-provider/planned-model",
+            )
+        ],
     )
     _write_trial_result(
         job_dir,
         "trial-1",
-        agent_name="codex",
+        agent_name="runme-codex",
         provider="openai",
         model_name="gpt-5",
     )
@@ -25,55 +39,89 @@ def test_sync_jobs_metadata_uses_observed_trial_agents(tmp_path: Path) -> None:
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [
-        ("codex", "openai/gpt-5")
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")
     ]
+    assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
 
     assert ORIGINAL_CONFIG_BACKUP == "config.original.json"
     backup = JobConfig.model_validate_json((job_dir / "config.original.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in backup.agents] == [
-        ("planned", "planned-provider/planned-model")
+    assert _agent_summaries(backup) == [
+        (
+            None,
+            CODEX_IMPORT_PATH,
+            "planned-provider/planned-model",
+        )
     ]
 
 
 def test_sync_jobs_metadata_sorts_and_deduplicates_observed_agents(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-z", agent_name="codex", provider=None, model_name="gpt-5")
-    _write_trial_result(job_dir, "trial-a", agent_name="claude-code", provider="anthropic", model_name="sonnet")
-    _write_trial_result(job_dir, "trial-b", agent_name="codex", provider=None, model_name="gpt-5")
+    _write_trial_result(job_dir, "trial-z", agent_name="runme-codex", provider=None, model_name="gpt-5")
+    _write_trial_result(
+        job_dir,
+        "trial-a",
+        agent_name="runme-claude-code",
+        provider="anthropic",
+        model_name="sonnet",
+    )
+    _write_trial_result(job_dir, "trial-b", agent_name="runme-codex", provider=None, model_name="gpt-5")
 
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [
-        ("claude-code", "anthropic/sonnet"),
-        ("codex", "gpt-5"),
+    assert _agent_summaries(config) == [
+        ("runme-claude-code", CLAUDE_IMPORT_PATH, "anthropic/sonnet"),
+        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5"),
     ]
 
 
 def test_sync_jobs_metadata_omits_missing_model_info(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-1", agent_name="codex")
+    _write_trial_result(job_dir, "trial-1", agent_name="oracle")
 
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [("codex", None)]
+    assert _agent_summaries(config) == [("oracle", None, None)]
+
+
+def test_sync_jobs_metadata_keeps_builtin_agent_names(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-1", agent_name="oracle", model_name="gpt-5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [("oracle", None, "gpt-5")]
 
 
 def test_sync_jobs_metadata_uses_atif_model_when_trial_model_info_missing(
     tmp_path: Path,
 ) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-1", agent_name="codex")
-    _write_trajectory(job_dir / "trial-1", agent_name="codex", model_name="gpt-5.5")
+    _write_trial_result(job_dir, "trial-1", agent_name="runme-codex")
+    _write_trajectory(job_dir / "trial-1", agent_name="runme-codex", model_name="gpt-5.5")
 
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [
-        ("codex", "gpt-5.5")
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
     ]
+    result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
+    assert result.agent_info.model_info is not None
+    assert result.agent_info.model_info.name == "gpt-5.5"
+    assert result.agent_info.model_info.provider is None
+    result_backup = TrialResult.model_validate_json(
+        (job_dir / "trial-1" / ORIGINAL_RESULT_BACKUP).read_text()
+    )
+    assert result_backup.agent_info.model_info is None
+
+    assert sync_jobs_metadata(tmp_path) == 0
+    assert result_backup == TrialResult.model_validate_json(
+        (job_dir / "trial-1" / ORIGINAL_RESULT_BACKUP).read_text()
+    )
 
 
 def test_sync_jobs_metadata_preserves_trial_model_info_over_atif(
@@ -83,23 +131,28 @@ def test_sync_jobs_metadata_preserves_trial_model_info_over_atif(
     _write_trial_result(
         job_dir,
         "trial-1",
-        agent_name="codex",
+        agent_name="runme-codex",
         provider="openai",
         model_name="gpt-5",
     )
-    _write_trajectory(job_dir / "trial-1", agent_name="codex", model_name="gpt-5.5")
+    _write_trajectory(job_dir / "trial-1", agent_name="runme-codex", model_name="gpt-5.5")
 
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [
-        ("codex", "openai/gpt-5")
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")
     ]
+    result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
+    assert result.agent_info.model_info is not None
+    assert result.agent_info.model_info.name == "gpt-5"
+    assert result.agent_info.model_info.provider == "openai"
+    assert not (job_dir / "trial-1" / ORIGINAL_RESULT_BACKUP).exists()
 
 
 def test_sync_jobs_metadata_ignores_unreadable_atif(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-1", agent_name="codex")
+    _write_trial_result(job_dir, "trial-1", agent_name="runme-codex")
     trajectory_path = job_dir / "trial-1" / "agent" / "trajectory.json"
     trajectory_path.parent.mkdir()
     trajectory_path.write_text("{")
@@ -107,7 +160,9 @@ def test_sync_jobs_metadata_ignores_unreadable_atif(tmp_path: Path) -> None:
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [("codex", None)]
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, None)
+    ]
 
 
 def test_sync_jobs_metadata_skips_jobs_without_readable_trials(tmp_path: Path) -> None:
@@ -116,7 +171,7 @@ def test_sync_jobs_metadata_skips_jobs_without_readable_trials(tmp_path: Path) -
     assert sync_jobs_metadata(tmp_path) == 0
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [("planned", None)]
+    assert _agent_summaries(config) == [("planned", None, None)]
     assert not (job_dir / ORIGINAL_CONFIG_BACKUP).exists()
 
 
@@ -128,7 +183,7 @@ def test_sync_jobs_metadata_ignores_unreadable_trials(tmp_path: Path) -> None:
     _write_trial_result(
         job_dir,
         "good-trial",
-        agent_name="claude-code",
+        agent_name="runme-claude-code",
         provider="anthropic",
         model_name="sonnet",
     )
@@ -136,14 +191,14 @@ def test_sync_jobs_metadata_ignores_unreadable_trials(tmp_path: Path) -> None:
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert [(agent.name, agent.model_name) for agent in config.agents] == [
-        ("claude-code", "anthropic/sonnet")
+    assert _agent_summaries(config) == [
+        ("runme-claude-code", CLAUDE_IMPORT_PATH, "anthropic/sonnet")
     ]
 
 
 def test_sync_jobs_metadata_preserves_original_backup(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-1", agent_name="codex", model_name="gpt-5")
+    _write_trial_result(job_dir, "trial-1", agent_name="runme-codex", model_name="gpt-5")
 
     assert sync_jobs_metadata(tmp_path) == 1
     backup_path = job_dir / ORIGINAL_CONFIG_BACKUP
@@ -153,10 +208,42 @@ def test_sync_jobs_metadata_preserves_original_backup(tmp_path: Path) -> None:
     assert backup_path.read_text() == backup_text
 
 
+def test_sync_jobs_metadata_corrects_prior_runme_agent_name_sync(tmp_path: Path) -> None:
+    job_dir = _write_job_config(
+        tmp_path,
+        agents=[AgentConfig(import_path=CODEX_IMPORT_PATH)],
+    )
+    backup_text = (job_dir / "config.json").read_text()
+    (job_dir / ORIGINAL_CONFIG_BACKUP).write_text(backup_text)
+    config = JobConfig.model_validate_json(backup_text).model_copy(
+        update={"agents": [AgentConfig(name="runme-codex", model_name="gpt-5.5")]}
+    )
+    (job_dir / "config.json").write_text(config.model_dump_json(indent=4))
+    _write_trial_result(job_dir, "trial-1", agent_name="runme-codex")
+    _write_trajectory(job_dir / "trial-1", agent_name="runme-codex", model_name="gpt-5.5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [
+        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
+    ]
+    assert (job_dir / ORIGINAL_CONFIG_BACKUP).read_text() == backup_text
+
+
+def _agent_summaries(config: JobConfig) -> list[tuple[str | None, str | None, str | None]]:
+    return [(agent.name, agent.import_path, agent.model_name) for agent in config.agents]
+
+
 def _write_job_config(tmp_path: Path, *, agents: list[AgentConfig]) -> Path:
     job_dir = tmp_path / "job-1"
     job_dir.mkdir()
-    config = JobConfig(job_name="job-1", jobs_dir=tmp_path, agents=agents)
+    config = JobConfig(
+        job_name="job-1",
+        jobs_dir=tmp_path,
+        agents=agents,
+        environment={"import_path": ENVIRONMENT_IMPORT_PATH},
+    )
     (job_dir / "config.json").write_text(config.model_dump_json(indent=4))
     return job_dir
 

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -61,6 +61,55 @@ def test_sync_jobs_metadata_omits_missing_model_info(tmp_path: Path) -> None:
     assert [(agent.name, agent.model_name) for agent in config.agents] == [("codex", None)]
 
 
+def test_sync_jobs_metadata_uses_atif_model_when_trial_model_info_missing(
+    tmp_path: Path,
+) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-1", agent_name="codex")
+    _write_trajectory(job_dir / "trial-1", agent_name="codex", model_name="gpt-5.5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [
+        ("codex", "gpt-5.5")
+    ]
+
+
+def test_sync_jobs_metadata_preserves_trial_model_info_over_atif(
+    tmp_path: Path,
+) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="codex",
+        provider="openai",
+        model_name="gpt-5",
+    )
+    _write_trajectory(job_dir / "trial-1", agent_name="codex", model_name="gpt-5.5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [
+        ("codex", "openai/gpt-5")
+    ]
+
+
+def test_sync_jobs_metadata_ignores_unreadable_atif(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-1", agent_name="codex")
+    trajectory_path = job_dir / "trial-1" / "agent" / "trajectory.json"
+    trajectory_path.parent.mkdir()
+    trajectory_path.write_text("{")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [("codex", None)]
+
+
 def test_sync_jobs_metadata_skips_jobs_without_readable_trials(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
 
@@ -138,3 +187,25 @@ def _write_trial_result(
         }
     )
     (trial_dir / "result.json").write_text(result.model_dump_json(indent=4))
+
+
+def _write_trajectory(trial_dir: Path, *, agent_name: str, model_name: str) -> None:
+    trajectory_dir = trial_dir / "agent"
+    trajectory_dir.mkdir()
+    (trajectory_dir / "trajectory.json").write_text(
+        f"""{{
+    "schema_version": "ATIF-v1.5",
+    "agent": {{
+        "name": "{agent_name}",
+        "version": "1.0",
+        "model_name": "{model_name}"
+    }},
+    "steps": [
+        {{
+            "step_id": 1,
+            "source": "user",
+            "message": "hello"
+        }}
+    ]
+}}"""
+    )

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from harbor.models.job.config import JobConfig
+from harbor.models.trial.config import AgentConfig
+from harbor.models.trial.result import TrialResult
+
+from runme_harbor.metadata_sync import ORIGINAL_CONFIG_BACKUP, sync_jobs_metadata
+
+
+def test_sync_jobs_metadata_uses_observed_trial_agents(tmp_path: Path) -> None:
+    job_dir = _write_job_config(
+        tmp_path,
+        agents=[AgentConfig(name="planned", model_name="planned-provider/planned-model")],
+    )
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="codex",
+        provider="openai",
+        model_name="gpt-5",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [
+        ("codex", "openai/gpt-5")
+    ]
+
+    backup = JobConfig.model_validate_json((job_dir / ORIGINAL_CONFIG_BACKUP).read_text())
+    assert [(agent.name, agent.model_name) for agent in backup.agents] == [
+        ("planned", "planned-provider/planned-model")
+    ]
+
+
+def test_sync_jobs_metadata_sorts_and_deduplicates_observed_agents(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-z", agent_name="codex", provider=None, model_name="gpt-5")
+    _write_trial_result(job_dir, "trial-a", agent_name="claude-code", provider="anthropic", model_name="sonnet")
+    _write_trial_result(job_dir, "trial-b", agent_name="codex", provider=None, model_name="gpt-5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [
+        ("claude-code", "anthropic/sonnet"),
+        ("codex", "gpt-5"),
+    ]
+
+
+def test_sync_jobs_metadata_omits_missing_model_info(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-1", agent_name="codex")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [("codex", None)]
+
+
+def test_sync_jobs_metadata_skips_jobs_without_readable_trials(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+
+    assert sync_jobs_metadata(tmp_path) == 0
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [("planned", None)]
+    assert not (job_dir / ORIGINAL_CONFIG_BACKUP).exists()
+
+
+def test_sync_jobs_metadata_ignores_unreadable_trials(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    unreadable_dir = job_dir / "bad-trial"
+    unreadable_dir.mkdir()
+    (unreadable_dir / "result.json").write_text("{")
+    _write_trial_result(
+        job_dir,
+        "good-trial",
+        agent_name="claude-code",
+        provider="anthropic",
+        model_name="sonnet",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert [(agent.name, agent.model_name) for agent in config.agents] == [
+        ("claude-code", "anthropic/sonnet")
+    ]
+
+
+def test_sync_jobs_metadata_preserves_original_backup(tmp_path: Path) -> None:
+    job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
+    _write_trial_result(job_dir, "trial-1", agent_name="codex", model_name="gpt-5")
+
+    assert sync_jobs_metadata(tmp_path) == 1
+    backup_path = job_dir / ORIGINAL_CONFIG_BACKUP
+    backup_text = backup_path.read_text()
+
+    assert sync_jobs_metadata(tmp_path) == 0
+    assert backup_path.read_text() == backup_text
+
+
+def _write_job_config(tmp_path: Path, *, agents: list[AgentConfig]) -> Path:
+    job_dir = tmp_path / "job-1"
+    job_dir.mkdir()
+    config = JobConfig(job_name="job-1", jobs_dir=tmp_path, agents=agents)
+    (job_dir / "config.json").write_text(config.model_dump_json(indent=4))
+    return job_dir
+
+
+def _write_trial_result(
+    job_dir: Path,
+    trial_name: str,
+    *,
+    agent_name: str,
+    provider: str | None = None,
+    model_name: str | None = None,
+) -> None:
+    trial_dir = job_dir / trial_name
+    trial_dir.mkdir()
+    agent_info: dict[str, object] = {"name": agent_name, "version": "1.0"}
+    if model_name is not None:
+        agent_info["model_info"] = {"name": model_name, "provider": provider}
+    result = TrialResult.model_validate(
+        {
+            "task_name": "task-a",
+            "trial_name": trial_name,
+            "trial_uri": f"file:///{trial_name}",
+            "task_id": {"path": "task-a"},
+            "source": "dataset",
+            "task_checksum": "checksum",
+            "config": {"task": {"path": "task-a"}},
+            "agent_info": agent_info,
+        }
+    )
+    (trial_dir / "result.json").write_text(result.model_dump_json(indent=4))

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -29,7 +29,8 @@ def test_sync_jobs_metadata_uses_observed_trial_agents(tmp_path: Path) -> None:
         ("codex", "openai/gpt-5")
     ]
 
-    backup = JobConfig.model_validate_json((job_dir / ORIGINAL_CONFIG_BACKUP).read_text())
+    assert ORIGINAL_CONFIG_BACKUP == "config.original.json"
+    backup = JobConfig.model_validate_json((job_dir / "config.original.json").read_text())
     assert [(agent.name, agent.model_name) for agent in backup.agents] == [
         ("planned", "planned-provider/planned-model")
     ]


### PR DESCRIPTION
## Summary

Sync local Harbor job config metadata after `runme-harbor run` completes so stock `harbor view` shows the observed agents and models from completed trial results.

The sync preserves the original planned `config.json` as `config.original.json` before the first update, skips jobs with no readable trial results, and can be disabled during eval runs with `RUNME_HARBOR_SKIP_METADATA_SYNC=1`.

This also adds `runme-harbor sync-metadata --jobs-dir ...` so metadata sync can run independently of a trial run. When Harbor trial metadata has no model info, sync falls back to ATIF `agent/trajectory.json` for the observed model name.

## Validation

- `uv run ruff check .` in `integrations/harbor`
- `uv run pytest` in `integrations/harbor`
- `runme run lint test`
