### PR TITLE
feat: allow Harbor env selection for eval

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -26,6 +26,7 @@ type evalOptions struct {
 	jobsDir     string
 	yes         bool
 	model       string
+	env         string
 	runmeBin    string
 	runmeArgs   []string
 	runmeHarbor string
@@ -73,6 +74,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
 	flags.StringVar(&opts.jobsDir, "jobs-dir", defaultEvalJobsDir, "Eval jobs directory")
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Confirm Harbor prompts")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
+	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
 	flags.StringVar(&opts.runmeBin, "runme-bin", "", "Runme binary used by the Harbor environment")
 	flags.StringArrayVar(&opts.runmeArgs, "runme-arg", nil, "Additional Runme argument used by the Harbor environment")
 	flags.StringVar(&opts.runmeHarbor, "runme-harbor-bin", "", "runme-harbor executable")
@@ -100,6 +102,9 @@ func runEval(opts evalOptions, args []string) error {
 	if opts.model != "" && containsModelFlag(passthrough) {
 		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
 	}
+	if containsEnvironmentFlag(passthrough) {
+		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
+	}
 
 	runmeHarbor, err := resolveRunmeHarbor(opts)
 	if err != nil {
@@ -121,7 +126,7 @@ func runEval(opts evalOptions, args []string) error {
 	}
 	env = append(env, opts.extraEnv...)
 
-	if opts.preflight {
+	if opts.preflight && usesRunmeEnvironment(opts.env) {
 		request := strings.NewReader("{\"id\":\"preflight\",\"preflight\":{}}\n")
 		if err := opts.commandRun(runmeBin, []string{"harbor", "stdio"}, env, request, io.Discard, opts.stderr); err != nil {
 			return fmt.Errorf("runme harbor stdio preflight failed: %w", err)
@@ -235,6 +240,9 @@ func buildRunmeHarborArgs(datasetPath string, opts evalOptions, passthrough []st
 	if opts.debug {
 		args = append(args, "--debug")
 	}
+	if opts.env != "" {
+		args = append(args, "--env", opts.env)
+	}
 	delegatedPassthrough := append([]string(nil), passthrough...)
 	if opts.model != "" {
 		delegatedPassthrough = append(delegatedPassthrough, "--model", opts.model)
@@ -253,6 +261,25 @@ func containsModelFlag(args []string) bool {
 		}
 	}
 	return false
+}
+
+func containsEnvironmentFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--env" || arg == "-e" || arg == "--environment-import-path" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--env=") || strings.HasPrefix(arg, "-e") && len(arg) > 2 {
+			return true
+		}
+		if strings.HasPrefix(arg, "--environment-import-path=") {
+			return true
+		}
+	}
+	return false
+}
+
+func usesRunmeEnvironment(env string) bool {
+	return env == "" || env == "runme"
 }
 
 func runExternalCommand(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -210,6 +210,12 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 	if !strings.Contains(stdout.String(), "When dataset-path is omitted, runme eval uses ./evals/tasks.") {
 		t.Fatalf("help output = %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), `-e, --env string`) {
+		t.Fatalf("help output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `Defaults to "runme"`) {
+		t.Fatalf("help output = %q", stdout.String())
+	}
 }
 
 func TestRunEvalDelegatesModel(t *testing.T) {
@@ -278,6 +284,94 @@ func TestRunEvalRejectsDuplicateModel(t *testing.T) {
 				t.Fatal("expected error")
 			}
 			if !strings.Contains(err.Error(), "--model cannot be used together with passthrough --model") {
+				t.Fatalf("error = %q", err.Error())
+			}
+			if len(calls) != 0 {
+				t.Fatalf("calls = %#v, want none", calls)
+			}
+		})
+	}
+}
+
+func TestRunEvalDelegatesRunmeEnvAlias(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.env = "runme"
+
+	err := runEval(opts, []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantPreflight := recordedCommand{
+		name: "/bin/runme",
+		args: []string{"harbor", "stdio"},
+	}
+	wantDelegate := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultEvalJobsDir,
+		"--env", "runme",
+	}
+	if !sameCommand(calls[0], wantPreflight) {
+		t.Fatalf("preflight = %#v, want %#v", calls[0], wantPreflight)
+	}
+	if !reflect.DeepEqual(calls[1].args, wantDelegate) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, wantDelegate)
+	}
+}
+
+func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.env = "docker"
+	opts.agent = "codex"
+
+	err := runEval(opts, []string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "codex",
+		"--jobs-dir", defaultEvalJobsDir,
+		"--env", "docker",
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %#v, want delegate only", calls)
+	}
+	if !reflect.DeepEqual(calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+}
+
+func TestRunEvalRejectsPassthroughEnvironmentFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		passthrough []string
+	}{
+		{name: "env separate", passthrough: []string{"--env", "docker"}},
+		{name: "env equals", passthrough: []string{"--env=docker"}},
+		{name: "env shorthand separate", passthrough: []string{"-e", "docker"}},
+		{name: "env shorthand joined", passthrough: []string{"-edocker"}},
+		{name: "import path separate", passthrough: []string{"--environment-import-path", "pkg:Env"}},
+		{name: "import path equals", passthrough: []string{"--environment-import-path=pkg:Env"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+
+			err := runEval(opts, append([]string{path}, tt.passthrough...))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "use runme eval --env") {
 				t.Fatalf("error = %q", err.Error())
 			}
 			if len(calls) != 0 {

--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -32,6 +32,15 @@ runme eval examples/harbor/datasets/runme-integration \
   -y
 ```
 
+Run the smoke task with Harbor's Docker environment for a baseline comparison:
+
+```sh {"name":"smoke-docker"}
+runme eval examples/harbor/datasets/runme-integration \
+  --task-dir simple-agent \
+  --env docker \
+  --agent oracle
+```
+
 The dataset root is `examples/harbor/datasets/runme-integration`. Each
 `runme eval` creates Harbor job and trial metadata under `.runme/evals/jobs`.
 The `--task-dir` flag selects a task directory inside the dataset, such as
@@ -40,7 +49,10 @@ The `--task-dir` flag selects a task directory inside the dataset, such as
 `runme eval` delegates to `runme-harbor`, so these examples remain compatible
 with the underlying `harbor run` workflow. The adapter supports `oracle`,
 `codex`, `claude-code`, and `openclaw` agents and runs local agent CLIs through
-`runme harbor stdio`.
+`runme harbor stdio` by default. The default environment is `runme`; pass
+`--env runme` to select it explicitly. Passing a non-Runme Harbor environment,
+such as `--env docker`, delegates the selected environment and agent to Harbor
+without the Runme-specific agent wrappers.
 
 Set `--runme-bin` to use a specific Runme binary. Set `--runme-arg` one or more
 times to pass global Runme flags before `harbor stdio`.

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -77,21 +77,29 @@ def build_harbor_command(args: argparse.Namespace) -> list[str]:
         dataset_path,
         "--jobs-dir",
         args.jobs_dir,
-        "--environment-import-path",
-        ENVIRONMENT_IMPORT_PATH,
     ]
 
-    try:
-        command.extend(AGENT_ARGUMENTS[args.agent])
-    except KeyError as exc:
-        valid_agents = ", ".join(AGENT_ARGUMENTS)
-        raise SystemExit(f"invalid --agent {args.agent!r}: expected {valid_agents}") from exc
+    if _uses_runme_environment(args.env):
+        command.extend(["--environment-import-path", ENVIRONMENT_IMPORT_PATH])
+        try:
+            command.extend(AGENT_ARGUMENTS[args.agent])
+        except KeyError as exc:
+            valid_agents = ", ".join(AGENT_ARGUMENTS)
+            raise SystemExit(f"invalid --agent {args.agent!r}: expected {valid_agents}") from exc
+    else:
+        command.extend(["--env", args.env])
+        command.extend(["--agent", args.agent])
 
     if args.task_dir:
         command.extend(["--include-task-name", args.task_dir])
     if args.yes:
         command.append("-y")
     passthrough = list(args.passthrough)
+    env_flag = _find_environment_flag(passthrough)
+    if env_flag:
+        raise SystemExit(
+            f"use runme-harbor run --env instead of passing Harbor environment flag {env_flag!r} after --"
+        )
     if not _contains_concurrency_flag(passthrough):
         command.extend(["--n-concurrent", "1"])
     command.extend(passthrough)
@@ -104,7 +112,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 
     run_parser = subparsers.add_parser("run", allow_abbrev=False)
     run_parser.add_argument("dataset_path", metavar="dataset-path")
-    run_parser.add_argument("--agent", choices=tuple(AGENT_ARGUMENTS), default="oracle")
+    run_parser.add_argument("--agent", default="oracle")
+    run_parser.add_argument("-e", "--env")
     run_parser.add_argument("--task-dir")
     run_parser.add_argument("--jobs-dir", default=".runme/evals/jobs")
     run_parser.add_argument("-y", "--yes", action="store_true")
@@ -132,6 +141,23 @@ def _find_removed_task_flag(args: list[str]) -> str | None:
         if arg.startswith("--task-name="):
             return "--task-name"
     return None
+
+
+def _find_environment_flag(args: list[str]) -> str | None:
+    for arg in args:
+        if arg in {"--env", "-e", "--environment-import-path"}:
+            return arg
+        if arg.startswith("--env="):
+            return "--env"
+        if arg.startswith("-e") and len(arg) > 2:
+            return "-e"
+        if arg.startswith("--environment-import-path="):
+            return "--environment-import-path"
+    return None
+
+
+def _uses_runme_environment(env: str | None) -> bool:
+    return env in {None, "", "runme"}
 
 
 def _preflight(agent: str) -> None:

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -31,6 +31,55 @@ def test_build_harbor_command_oracle_defaults(tmp_path: Path) -> None:
     ]
 
 
+def test_build_harbor_command_runme_env_alias(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "--env", "runme"])
+
+    assert cli.build_harbor_command(args) == [
+        "harbor",
+        "run",
+        "--path",
+        str(tmp_path.resolve()),
+        "--jobs-dir",
+        ".runme/evals/jobs",
+        "--environment-import-path",
+        "runme_harbor.environment:RunmeEnvironment",
+        "--agent",
+        "oracle",
+        "--n-concurrent",
+        "1",
+    ]
+
+
+def test_build_harbor_command_builtin_env_uses_harbor_agent(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "--env", "docker", "--agent", "codex"])
+
+    command = cli.build_harbor_command(args)
+
+    assert command == [
+        "harbor",
+        "run",
+        "--path",
+        str(tmp_path.resolve()),
+        "--jobs-dir",
+        ".runme/evals/jobs",
+        "--env",
+        "docker",
+        "--agent",
+        "codex",
+        "--n-concurrent",
+        "1",
+    ]
+
+
+def test_build_harbor_command_builtin_env_accepts_unknown_agent(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "-e", "docker", "--agent", "goose"])
+
+    command = cli.build_harbor_command(args)
+
+    assert command[command.index("--env") : command.index("--env") + 2] == ["--env", "docker"]
+    assert command[command.index("--agent") : command.index("--agent") + 2] == ["--agent", "goose"]
+
+
 def test_build_harbor_command_codex(tmp_path: Path) -> None:
     args = parse(["run", str(tmp_path), "--agent", "codex"])
 
@@ -61,6 +110,13 @@ def test_build_harbor_command_openclaw(tmp_path: Path) -> None:
     assert "--agent" not in command
 
 
+def test_build_harbor_command_runme_env_rejects_unknown_agent(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "--agent", "goose"])
+
+    with pytest.raises(SystemExit, match="invalid --agent 'goose'"):
+        cli.build_harbor_command(args)
+
+
 def test_build_harbor_command_task_yes_jobs_and_passthrough(tmp_path: Path) -> None:
     args = parse(
         [
@@ -82,7 +138,9 @@ def test_build_harbor_command_task_yes_jobs_and_passthrough(tmp_path: Path) -> N
     assert ["--include-task-name", "simple-agent"] == command[
         command.index("--include-task-name") : command.index("--include-task-name") + 2
     ]
-    assert ["--jobs-dir", "jobs"] == command[command.index("--jobs-dir") : command.index("--jobs-dir") + 2]
+    assert ["--jobs-dir", "jobs"] == command[
+        command.index("--jobs-dir") : command.index("--jobs-dir") + 2
+    ]
     assert "-y" in command
     assert command[-2:] == ["--model", "gpt-5"]
 
@@ -118,6 +176,27 @@ def test_build_harbor_command_does_not_duplicate_concurrency(
     command = cli.build_harbor_command(args)
 
     assert command.count("--n-concurrent") == passthrough.count("--n-concurrent")
+
+
+@pytest.mark.parametrize(
+    "passthrough",
+    [
+        ["--", "--env", "docker"],
+        ["--", "--env=docker"],
+        ["--", "-e", "docker"],
+        ["--", "-edocker"],
+        ["--", "--environment-import-path", "pkg:Env"],
+        ["--", "--environment-import-path=pkg:Env"],
+    ],
+)
+def test_build_harbor_command_rejects_environment_passthrough(
+    tmp_path: Path,
+    passthrough: list[str],
+) -> None:
+    args = parse(["run", str(tmp_path), *passthrough])
+
+    with pytest.raises(SystemExit, match="use runme-harbor run --env"):
+        cli.build_harbor_command(args)
 
 
 def test_main_runs_harbor_and_prints_debug(
@@ -225,7 +304,9 @@ def test_preflight_requires_runme_agent_cli(
 ) -> None:
     monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
     monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
-    monkeypatch.setattr(cli.shutil, "which", lambda name: None if name == missing else f"/bin/{name}")
+    monkeypatch.setattr(
+        cli.shutil, "which", lambda name: None if name == missing else f"/bin/{name}"
+    )
 
     with pytest.raises(SystemExit, match=message):
         cli._preflight(agent)


### PR DESCRIPTION
## Summary

- add `runme eval --env/-e` and forward it to `runme-harbor`
- keep the default `runme` environment backed by `RunmeEnvironment`
- pass agents verbatim for non-Runme Harbor environments instead of using Runme-specific agent wrappers
- reject raw environment-selection passthrough flags to avoid duplicate Harbor env options
- document Docker baseline usage in the Harbor examples

## Verification

```sh
go test ./cmd
```

```sh
cd integrations/harbor && uv run pytest tests/test_cli.py
```

```sh
runme run test
```

```sh
cd integrations/harbor && uv run pytest
```

```sh
cd integrations/harbor && uv run ruff check src tests
```
