### PR TITLE
fix: use bundled Harbor CLI for runme-harbor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,18 +53,9 @@ jobs:
         working-directory: integrations/harbor
         run: uv run pytest
       - name: Build package
-        working-directory: integrations/harbor
-        run: |
-          set -euo pipefail
-
-          rm -rf dist
-
-          proto_src="../../api/gen/proto/python/runme/harbor/v1"
-          proto_dst="src/runme_harbor/_proto/runme/harbor/v1"
-          mkdir -p "$proto_dst"
-          cp "$proto_src/harbor_pb2.py" "$proto_src/harbor_pb2.pyi" "$proto_dst/"
-
-          uv build
+        uses: stateful/runme-action@v2
+        with:
+          workflows: build-harbor
       - name: Test wheel install
         working-directory: integrations/harbor
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,31 @@ jobs:
       - name: Run tests
         working-directory: integrations/harbor
         run: uv run pytest
+      - name: Build package
+        working-directory: integrations/harbor
+        run: |
+          set -euo pipefail
+
+          rm -rf dist
+
+          proto_src="../../api/gen/proto/python/runme/harbor/v1"
+          proto_dst="src/runme_harbor/_proto/runme/harbor/v1"
+          mkdir -p "$proto_dst"
+          cp "$proto_src/harbor_pb2.py" "$proto_src/harbor_pb2.pyi" "$proto_dst/"
+
+          uv build
+      - name: Test wheel install
+        working-directory: integrations/harbor
+        run: |
+          set -euo pipefail
+
+          uv run --with dist/*.whl python -c "import runme_harbor"
+
+          tmp_tools="$(mktemp -d)"
+          trap 'rm -rf "$tmp_tools"' EXIT
+          UV_TOOL_DIR="$tmp_tools/tools" UV_TOOL_BIN_DIR="$tmp_tools/bin" uv tool install dist/*.whl
+          "$tmp_tools/bin/runme-harbor" --help >/dev/null
+          "$tmp_tools/bin/runme-harbor-harbor" --help >/dev/null
 
   build-and-test:
     # Don't use make here as this job needs to be cross-platform.

--- a/integrations/harbor/README.md
+++ b/integrations/harbor/README.md
@@ -17,7 +17,7 @@ The `runme` CLI must be installed separately and available on `PATH`.
 
 ## Build
 
-Run the full local validation and build workflow:
+Build the distribution artifacts:
 
 ```sh {"name":"build-harbor"}
 set -euo pipefail
@@ -29,16 +29,7 @@ proto_dst="src/runme_harbor/_proto/runme/harbor/v1"
 mkdir -p "$proto_dst"
 cp "$proto_src/harbor_pb2.py" "$proto_src/harbor_pb2.pyi" "$proto_dst/"
 
-uv sync --locked --all-extras --dev
-uv run ruff check .
-uv run pytest
-
-(cd ../.. && go test ./cmd ./internal/harbor)
-
 uv build
-
-uv run --with dist/*.whl python -c "import runme_harbor"
-uv tool run --from dist/*.whl runme-harbor --help >/dev/null
 ```
 
 Publishing is intentionally not part of `build-harbor`. Release automation runs

--- a/integrations/harbor/pyproject.toml
+++ b/integrations/harbor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runme-harbor"
-version = "0.0.1"
+version = "0.0.2"
 description = "Runme Harbor environment adapter"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/integrations/harbor/pyproject.toml
+++ b/integrations/harbor/pyproject.toml
@@ -31,6 +31,7 @@ Issues = "https://github.com/runmedev/runme/issues"
 
 [project.scripts]
 runme-harbor = "runme_harbor.cli:main"
+runme-harbor-harbor = "harbor.cli.main:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -19,6 +19,7 @@ OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
 MIN_HARBOR_VERSION = (0, 13, 1)
 MAX_HARBOR_VERSION = (0, 14, 0)
 SKIP_METADATA_SYNC_ENV = "RUNME_HARBOR_SKIP_METADATA_SYNC"
+BUNDLED_HARBOR_EXECUTABLE = "runme-harbor-harbor"
 AGENT_ARGUMENTS = {
     "oracle": ("--agent", "oracle"),
     "codex": ("--agent-import-path", CODEX_IMPORT_PATH),
@@ -43,8 +44,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def run(args: argparse.Namespace) -> int:
-    _preflight(args.agent)
-    command = build_harbor_command(args)
+    harbor_bin = _preflight(args.agent)
+    command = build_harbor_command(args, harbor_bin=harbor_bin)
     if args.debug:
         print(_command_string(command), file=sys.stderr)
     exit_code = subprocess.call(command)
@@ -68,10 +69,13 @@ def sync_metadata(args: argparse.Namespace) -> int:
     return 0
 
 
-def build_harbor_command(args: argparse.Namespace) -> list[str]:
+def build_harbor_command(
+    args: argparse.Namespace,
+    harbor_bin: str | Path = BUNDLED_HARBOR_EXECUTABLE,
+) -> list[str]:
     dataset_path = str(Path(args.dataset_path).expanduser().resolve())
     command = [
-        "harbor",
+        str(harbor_bin),
         "run",
         "--path",
         dataset_path,
@@ -160,10 +164,14 @@ def _uses_runme_environment(env: str | None) -> bool:
     return env in {None, "", "runme"}
 
 
-def _preflight(agent: str) -> None:
+def _preflight(agent: str) -> Path:
     _preflight_harbor_package()
-    if not shutil.which("harbor"):
-        raise SystemExit("Runme Harbor requires the `harbor` CLI on PATH.")
+    harbor_bin = _bundled_harbor_executable()
+    if not harbor_bin:
+        raise SystemExit(
+            "Runme Harbor expected a bundled `runme-harbor-harbor` executable next to "
+            "`runme-harbor`. Reinstall with:\n  uv tool install runme-harbor --force"
+        )
 
     try:
         importlib.import_module("runme_harbor")
@@ -176,6 +184,35 @@ def _preflight(agent: str) -> None:
         raise SystemExit("`--agent claude-code` requires the `claude` CLI on PATH.")
     if agent == "openclaw" and not shutil.which("openclaw"):
         raise SystemExit("`--agent openclaw` requires the `openclaw` CLI on PATH.")
+    return harbor_bin
+
+
+def _bundled_harbor_executable() -> Path | None:
+    entrypoint = _current_entrypoint()
+    if not entrypoint:
+        return None
+
+    candidate = entrypoint.with_name(_script_name(BUNDLED_HARBOR_EXECUTABLE))
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return candidate
+    return None
+
+
+def _current_entrypoint() -> Path | None:
+    argv0 = Path(sys.argv[0])
+    if argv0.parent != Path("."):
+        return argv0.resolve()
+
+    resolved = shutil.which(argv0.name)
+    if resolved:
+        return Path(resolved).resolve()
+    return None
+
+
+def _script_name(name: str) -> str:
+    if os.name == "nt":
+        return f"{name}.exe"
+    return name
 
 
 def _preflight_harbor_package() -> None:

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -12,11 +14,17 @@ def parse(argv: list[str]):
     return cli._parse_args(argv)
 
 
+def make_executable(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(path.stat().st_mode | 0o111)
+    return path
+
+
 def test_build_harbor_command_oracle_defaults(tmp_path: Path) -> None:
     args = parse(["run", str(tmp_path)])
 
     assert cli.build_harbor_command(args) == [
-        "harbor",
+        "runme-harbor-harbor",
         "run",
         "--path",
         str(tmp_path.resolve()),
@@ -35,7 +43,7 @@ def test_build_harbor_command_runme_env_alias(tmp_path: Path) -> None:
     args = parse(["run", str(tmp_path), "--env", "runme"])
 
     assert cli.build_harbor_command(args) == [
-        "harbor",
+        "runme-harbor-harbor",
         "run",
         "--path",
         str(tmp_path.resolve()),
@@ -56,7 +64,7 @@ def test_build_harbor_command_builtin_env_uses_harbor_agent(tmp_path: Path) -> N
     command = cli.build_harbor_command(args)
 
     assert command == [
-        "harbor",
+        "runme-harbor-harbor",
         "run",
         "--path",
         str(tmp_path.resolve()),
@@ -78,6 +86,14 @@ def test_build_harbor_command_builtin_env_accepts_unknown_agent(tmp_path: Path) 
 
     assert command[command.index("--env") : command.index("--env") + 2] == ["--env", "docker"]
     assert command[command.index("--agent") : command.index("--agent") + 2] == ["--agent", "goose"]
+
+
+def test_build_harbor_command_accepts_resolved_harbor_bin(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path)])
+
+    command = cli.build_harbor_command(args, harbor_bin=tmp_path / "bin" / "runme-harbor-harbor")
+
+    assert command[0] == str(tmp_path / "bin" / "runme-harbor-harbor")
 
 
 def test_build_harbor_command_codex(tmp_path: Path) -> None:
@@ -199,19 +215,20 @@ def test_build_harbor_command_rejects_environment_passthrough(
         cli.build_harbor_command(args)
 
 
-def test_main_runs_harbor_and_prints_debug(
+def test_main_runs_bundled_harbor_and_prints_debug(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     calls: list[list[str]] = []
-    monkeypatch.setattr(cli, "_preflight", lambda _agent: None)
+    harbor_bin = tmp_path / "bin" / "runme-harbor-harbor"
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: harbor_bin)
     monkeypatch.setattr(cli.subprocess, "call", lambda command: calls.append(command) or 7)
 
     assert cli.main(["run", str(tmp_path), "--debug"]) == 7
 
-    assert calls[0][0:2] == ["harbor", "run"]
-    assert "harbor run" in capsys.readouterr().err
+    assert calls[0][0:2] == [str(harbor_bin), "run"]
+    assert f"{harbor_bin} run" in capsys.readouterr().err
 
 
 def test_main_syncs_metadata_after_harbor_run(
@@ -219,7 +236,7 @@ def test_main_syncs_metadata_after_harbor_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     synced: list[str] = []
-    monkeypatch.setattr(cli, "_preflight", lambda _agent: None)
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
     monkeypatch.setattr(cli.subprocess, "call", lambda _command: 7)
     monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
 
@@ -234,7 +251,7 @@ def test_main_skips_metadata_sync_when_disabled(
 ) -> None:
     synced: list[str] = []
     monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
-    monkeypatch.setattr(cli, "_preflight", lambda _agent: None)
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
     monkeypatch.setattr(cli.subprocess, "call", lambda _command: 0)
     monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
 
@@ -288,6 +305,54 @@ def test_main_sync_metadata_command_reports_preflight_errors(
     assert capsys.readouterr().err == "Runme Harbor requires the `harbor` Python package.\n"
 
 
+def test_pyproject_exposes_runme_owned_scripts_only() -> None:
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    scripts = tomllib.loads(pyproject.read_text())["project"]["scripts"]
+
+    assert scripts["runme-harbor"] == "runme_harbor.cli:main"
+    assert scripts["runme-harbor-harbor"] == "harbor.cli.main:app"
+    assert "harbor" not in scripts
+    assert "hr" not in scripts
+    assert "hb" not in scripts
+
+
+def test_preflight_uses_bundled_harbor_executable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    runme_harbor = make_executable(bin_dir / "runme-harbor")
+    bundled_harbor = make_executable(bin_dir / "runme-harbor-harbor")
+
+    monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
+    monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+
+    assert cli._preflight("oracle") == bundled_harbor.resolve()
+
+
+def test_preflight_rejects_global_harbor_without_bundled_sibling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    runme_harbor = make_executable(bin_dir / "runme-harbor")
+    global_bin = tmp_path / "global-bin"
+    global_bin.mkdir()
+    make_executable(global_bin / "harbor")
+
+    monkeypatch.setenv("PATH", str(global_bin))
+    monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
+    monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
+
+    with pytest.raises(SystemExit, match="bundled `runme-harbor-harbor` executable"):
+        cli._preflight("oracle")
+
+
 @pytest.mark.parametrize(
     ("agent", "missing", "message"),
     [
@@ -298,10 +363,17 @@ def test_main_sync_metadata_command_reports_preflight_errors(
 )
 def test_preflight_requires_runme_agent_cli(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     agent: str,
     missing: str,
     message: str,
 ) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    runme_harbor = make_executable(bin_dir / "runme-harbor")
+    make_executable(bin_dir / "runme-harbor-harbor")
+
+    monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
     monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
     monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
     monkeypatch.setattr(

--- a/integrations/harbor/uv.lock
+++ b/integrations/harbor/uv.lock
@@ -2048,7 +2048,7 @@ wheels = [
 
 [[package]]
 name = "runme-harbor"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "harbor" },


### PR DESCRIPTION
## Summary

- re-export Harbor's CLI as `runme-harbor-harbor` from the `runme-harbor` package
- make `runme-harbor run` resolve the bundled sibling executable instead of ambient `harbor` on `PATH`
- add tests for the script metadata, strict preflight, global `harbor` rejection, and debug command output
- keep `runme run build-harbor` scoped to building `dist`
- add CI-only wheel smoke coverage that installs the wheel into isolated uv tool dirs and verifies both executables

## Test plan

- `uv run pytest tests/test_cli.py -q`
- `uv run ruff check .`
- `runme run build-harbor`
- `runme run test`
