### PR TITLE
fix: drain PTY output before cleanup

### DIFF
--- a/runner/command.go
+++ b/runner/command.go
@@ -52,8 +52,9 @@ type command struct {
 
 	tempScriptFile string
 
-	context context.Context
-	wg      sync.WaitGroup
+	context  context.Context
+	ptyInWg  sync.WaitGroup
+	ptyOutWg sync.WaitGroup
 
 	mu sync.Mutex
 	// +checklocks:mu
@@ -294,7 +295,7 @@ func (c *command) cleanup() {
 		}
 	}
 	if c.pty != nil {
-		if e := c.pty.Close(); err != nil {
+		if e := c.pty.Close(); e != nil {
 			c.logger.Info("failed to close pty", zap.Error(e))
 			err = multierr.Append(err, e)
 		}
@@ -384,9 +385,9 @@ func (c *command) StartWithOpts(ctx context.Context, opts *startOpts) error {
 	}
 
 	if c.pty != nil {
-		c.wg.Add(1)
+		c.ptyInWg.Add(1)
 		go func() {
-			defer c.wg.Done()
+			defer c.ptyInWg.Done()
 			n, err := io.Copy(c.pty, c.Stdin)
 			if err != nil {
 				c.logger.Info("failed to copy from stdin to pty", zap.Error(err))
@@ -396,20 +397,20 @@ func (c *command) StartWithOpts(ctx context.Context, opts *startOpts) error {
 			}
 		}()
 
-		c.wg.Add(1)
+		c.ptyOutWg.Add(1)
 		go func() {
-			defer c.wg.Done()
+			defer c.ptyOutWg.Done()
 			n, err := io.Copy(c.Stdout, c.pty)
 			if err != nil {
 				// Linux kernel returns EIO when attempting to read from
 				// a master pseudo-terminal which no longer has an open slave.
 				// See https://github.com/creack/pty/issues/21.
 				if errors.Is(err, syscall.EIO) {
-					c.logger.Debug("failed to copy from pty to stdout; handled EIO")
+					c.logger.Debug("failed to copy from pty to stdout; handled EIO", zap.Int64("count", n))
 					return
 				}
 				if errors.Is(err, os.ErrClosed) {
-					c.logger.Debug("failed to copy from pty to stdout; handled ErrClosed")
+					c.logger.Debug("failed to copy from pty to stdout; handled ErrClosed", zap.Int64("count", n))
 					return
 				}
 
@@ -544,9 +545,13 @@ func (c *command) Finalize() (err error) {
 		c.collectEnvs()
 	}
 
+	// Let the PTY output reader drain before cleanup closes the PTY master.
+	// Closing the PTY first can race short-lived commands and drop their final output.
+	c.ptyOutWg.Wait()
+
 	c.cleanup()
 
-	c.wg.Wait()
+	c.ptyInWg.Wait()
 
 	c.mu.Lock()
 	err = c.err

--- a/runner/service_test.go
+++ b/runner/service_test.go
@@ -812,6 +812,29 @@ func Test_runnerService(t *testing.T) {
 		assert.EqualValues(t, "24\r\n80", strings.TrimRight(string(result.Stdout), "\r\n"))
 	})
 
+	t.Run("ExecuteTTYShortLivedOutput", func(t *testing.T) {
+		for range 25 {
+			stream, err := client.Execute(context.Background())
+			require.NoError(t, err)
+
+			execResult := make(chan executeResult)
+			go getExecuteResult(stream, execResult)
+
+			err = stream.Send(&runnerv1.ExecuteRequest{
+				ProgramName: "bash",
+				CommandMode: runnerv1.CommandMode_COMMAND_MODE_INLINE_SHELL,
+				Commands:    []string{`printf 'tiny\n'`},
+				Tty:         true,
+			})
+			require.NoError(t, err)
+
+			result := <-execResult
+			assert.NoError(t, result.Err)
+			assert.EqualValues(t, 0, result.ExitCode)
+			assert.EqualValues(t, "tiny", strings.TrimRight(string(result.Stdout), "\r\n"))
+		}
+	})
+
 	t.Run("ExecuteWinsizeSet", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

- drain PTY stdout before closing the PTY during command finalization
- split PTY stdin/stdout copy wait groups so cleanup no longer races output copying
- add a serial runner service regression for short-lived PTY output
- fix the PTY close error check and include copied byte counts on handled PTY shutdown logs

## Verification

```bash
go test -count=50 -failfast -run '^Test_runnerService$/^ExecuteTTYShortLivedOutput$' -timeout=5m ./runner
go test -count=200 -failfast -run '^Test_runnerService$/^ExecuteWinsizeSet$' -timeout=5m ./runner
go test -count=100 -failfast -run '^Test_command$/^Winsize$' -timeout=5m ./runner
go test -count=100 -failfast -run '^Test_runnerService$' -timeout=10m ./runner
go test -race -count=25 -failfast -run '^Test_runnerService$' -timeout=10m ./runner
docker volume create dev.runme.test-env-gocache >/dev/null && docker run --rm -e RUNME_TEST_ENV=docker -e GOTOOLCHAIN=auto -v "$PWD":/workspace -v dev.runme.test-env-gocache:/root/.cache/go-build -w /workspace ghcr.io/runmedev/runme-build-env:latest bash -c 'CGO_ENABLED=0 go build -o /usr/local/bin/runme main.go && TZ=UTC go test -count=100 -failfast -run '\''^Test_runnerService$'\'' -timeout=10m -race ./runner'
runme run test
```
