### PR TITLE
fix: root eval defaults at project root

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/runmedev/runme/v3/internal/harbor"
+	"github.com/runmedev/runme/v3/project"
 )
 
 const (
@@ -23,23 +24,24 @@ const (
 var errRunmeHarborMissing = errors.New("runme-harbor missing")
 
 type evalOptions struct {
-	agent       string
-	taskDir     string
-	jobsDir     string
-	yes         bool
-	model       string
-	env         string
-	runmeBin    string
-	runmeArgs   []string
-	runmeHarbor string
-	debug       bool
-	commandRun  commandRunFunc
-	lookPath    func(string) (string, error)
-	executable  func() (string, error)
-	stdout      io.Writer
-	stderr      io.Writer
-	extraEnv    []string
-	preflight   bool
+	agent           string
+	taskDir         string
+	jobsDir         string
+	yes             bool
+	model           string
+	env             string
+	runmeBin        string
+	runmeArgs       []string
+	runmeHarbor     string
+	debug           bool
+	jobsDirExplicit bool
+	commandRun      commandRunFunc
+	lookPath        func(string) (string, error)
+	executable      func() (string, error)
+	stdout          io.Writer
+	stderr          io.Writer
+	extraEnv        []string
+	preflight       bool
 }
 
 type commandRunFunc func(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
@@ -66,6 +68,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()
 			opts.stderr = cmd.ErrOrStderr()
+			opts.jobsDirExplicit = cmd.Flags().Changed("jobs-dir")
 			return runEval(opts, args)
 		},
 	}
@@ -86,17 +89,16 @@ When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
 }
 
 func runEval(opts evalOptions, args []string) error {
-	datasetArg, passthrough := splitEvalDatasetArg(args)
-	datasetPath, err := filepath.Abs(datasetArg)
+	datasetPath, passthrough, defaultDataset, err := resolveEvalPaths(&opts, args)
 	if err != nil {
 		return err
 	}
 	if _, err := os.Stat(datasetPath); err != nil {
 		if os.IsNotExist(err) {
-			if datasetArg == defaultEvalDatasetPath {
-				return fmt.Errorf("dataset path does not exist: %s; create it or pass a dataset path explicitly", datasetArg)
+			if defaultDataset {
+				return fmt.Errorf("dataset path does not exist: %s; create it or pass a dataset path explicitly", defaultEvalDatasetPath)
 			}
-			return fmt.Errorf("dataset path does not exist: %s", datasetArg)
+			return fmt.Errorf("dataset path does not exist: %s", datasetPath)
 		}
 		return err
 	}
@@ -167,6 +169,41 @@ func runEval(opts evalOptions, args []string) error {
 	return err
 }
 
+func resolveEvalPaths(opts *evalOptions, args []string) (string, []string, bool, error) {
+	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
+	if defaultDataset {
+		baseDir, err := evalDefaultBaseDir()
+		if err != nil {
+			return "", nil, false, err
+		}
+		if !opts.jobsDirExplicit {
+			opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
+		}
+		return filepath.Join(baseDir, defaultEvalDatasetPath), passthrough, true, nil
+	}
+
+	datasetPath, err := filepath.Abs(datasetArg)
+	if err != nil {
+		return "", nil, false, err
+	}
+	if !opts.jobsDirExplicit {
+		baseDir, err := evalDefaultBaseDir()
+		if err != nil {
+			return "", nil, false, err
+		}
+		opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
+	}
+	return datasetPath, passthrough, false, nil
+}
+
+func evalDefaultBaseDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return defaultEvalBaseDir(cwd), nil
+}
+
 func validateEvalArgs(_ *cobra.Command, args []string) error {
 	if len(args) < 2 {
 		return nil
@@ -180,11 +217,24 @@ func validateEvalArgs(_ *cobra.Command, args []string) error {
 	return fmt.Errorf("accepts at most 1 dataset path, received %d", len(args))
 }
 
-func splitEvalDatasetArg(args []string) (string, []string) {
+func splitEvalDatasetArg(args []string) (string, bool, []string) {
 	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return defaultEvalDatasetPath, args
+		return defaultEvalDatasetPath, true, args
 	}
-	return args[0], args[1:]
+	return args[0], false, args[1:]
+}
+
+func defaultEvalBaseDir(cwd string) string {
+	proj, err := project.NewDirProject(
+		cwd,
+		project.WithFindRepoUpward(),
+		project.WithAllowUnsupportedGitExtensions(true),
+		project.WithRespectGitignore(false),
+	)
+	if err != nil {
+		return cwd
+	}
+	return proj.Root()
 }
 
 func resolveRunmeHarbor(opts evalOptions) (string, error) {

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -35,6 +35,7 @@ type evalOptions struct {
 	runmeHarbor     string
 	debug           bool
 	jobsDirExplicit bool
+	evalBaseDir     string
 	commandRun      commandRunFunc
 	lookPath        func(string) (string, error)
 	executable      func() (string, error)
@@ -44,7 +45,7 @@ type evalOptions struct {
 	preflight       bool
 }
 
-type commandRunFunc func(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+type commandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
 
 func evalCmd() *cobra.Command {
 	opts := evalOptions{
@@ -144,7 +145,7 @@ func runEval(opts evalOptions, args []string) error {
 
 	if opts.preflight && usesRunmeEnvironment(opts.env) {
 		request := strings.NewReader("{\"id\":\"preflight\",\"preflight\":{}}\n")
-		if err := opts.commandRun(runmeBin, []string{"harbor", "stdio"}, env, request, io.Discard, opts.stderr); err != nil {
+		if err := opts.commandRun(runmeBin, []string{"harbor", "stdio"}, "", env, request, io.Discard, opts.stderr); err != nil {
 			return fmt.Errorf("runme harbor stdio preflight failed: %w", err)
 		}
 	}
@@ -154,7 +155,7 @@ func runEval(opts evalOptions, args []string) error {
 		_, _ = fmt.Fprintf(opts.stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
 	}
 
-	err = opts.commandRun(runmeHarbor, delegatedArgs, env, os.Stdin, opts.stdout, opts.stderr)
+	err = opts.commandRun(runmeHarbor, delegatedArgs, opts.evalBaseDir, env, os.Stdin, opts.stdout, opts.stderr)
 	if err == nil {
 		return nil
 	}
@@ -179,6 +180,7 @@ func resolveEvalPaths(opts *evalOptions, args []string) (string, []string, bool,
 		if !opts.jobsDirExplicit {
 			opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
 		}
+		opts.evalBaseDir = baseDir
 		return filepath.Join(baseDir, defaultEvalDatasetPath), passthrough, true, nil
 	}
 
@@ -192,6 +194,13 @@ func resolveEvalPaths(opts *evalOptions, args []string) (string, []string, bool,
 			return "", nil, false, err
 		}
 		opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
+		opts.evalBaseDir = baseDir
+	} else {
+		baseDir, err := evalDefaultBaseDir()
+		if err != nil {
+			return "", nil, false, err
+		}
+		opts.evalBaseDir = baseDir
 	}
 	return datasetPath, passthrough, false, nil
 }
@@ -350,8 +359,9 @@ func usesHarborDockerEnvironment(env string) bool {
 	return env == "docker"
 }
 
-func runExternalCommand(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+func runExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd := exec.Command(name, args...)
+	cmd.Dir = workingDir
 	cmd.Env = env
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -14,9 +14,10 @@ import (
 )
 
 type recordedCommand struct {
-	name string
-	args []string
-	env  []string
+	name       string
+	args       []string
+	workingDir string
+	env        []string
 }
 
 type fakeExitError struct {
@@ -95,12 +96,15 @@ func TestRunEvalDefaultsDatasetPath(t *testing.T) {
 
 	want := []string{
 		"run",
-		mustAbs(t, defaultEvalDatasetPath),
+		defaultDatasetPath(t),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
 	}
 }
 
@@ -120,7 +124,7 @@ func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
 
 	want := []string{
 		"run",
-		mustAbs(t, defaultEvalDatasetPath),
+		defaultDatasetPath(t),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
 		"--",
@@ -128,6 +132,9 @@ func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
 	}
 }
 
@@ -144,6 +151,7 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 
@@ -154,12 +162,15 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 
 	want := []string{
 		"run",
-		filepath.Join(repoRoot, defaultEvalDatasetPath),
+		filepath.Join(baseDir, defaultEvalDatasetPath),
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(repoRoot, defaultEvalJobsDir),
+		"--jobs-dir", filepath.Join(baseDir, defaultEvalJobsDir),
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -174,6 +185,7 @@ func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 
@@ -186,10 +198,13 @@ func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 		"run",
 		dataset,
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(repoRoot, defaultEvalJobsDir),
+		"--jobs-dir", filepath.Join(baseDir, defaultEvalJobsDir),
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -206,6 +221,7 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 	opts.jobsDir = "custom/jobs"
@@ -218,12 +234,15 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 
 	want := []string{
 		"run",
-		filepath.Join(repoRoot, defaultEvalDatasetPath),
+		filepath.Join(baseDir, defaultEvalDatasetPath),
 		"--agent", "oracle",
 		"--jobs-dir", "custom/jobs",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -637,8 +656,8 @@ func TestRunEvalPropagatesDelegateExitCode(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.commandRun = func(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
-		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), env: env})
+	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
 		if len(calls) == 2 {
 			return fakeExitError{code: 42}
 		}
@@ -672,11 +691,12 @@ func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) e
 }
 
 func recordCommand(calls *[]recordedCommand) commandRunFunc {
-	return func(name string, args []string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	return func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		*calls = append(*calls, recordedCommand{
-			name: name,
-			args: append([]string(nil), args...),
-			env:  append([]string(nil), env...),
+			name:       name,
+			args:       append([]string(nil), args...),
+			workingDir: workingDir,
+			env:        append([]string(nil), env...),
 		})
 		return nil
 	}
@@ -713,6 +733,15 @@ func defaultJobsDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	return filepath.Join(defaultEvalBaseDir(cwd), defaultEvalJobsDir)
+}
+
+func defaultDatasetPath(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(defaultEvalBaseDir(cwd), defaultEvalDatasetPath)
 }
 
 func envValue(env []string, key string) string {

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
 )
 
 type recordedCommand struct {
@@ -55,7 +57,7 @@ func TestRunEvalDelegatesOracle(t *testing.T) {
 			"run",
 			mustAbs(t, path),
 			"--agent", "oracle",
-			"--jobs-dir", defaultEvalJobsDir,
+			"--jobs-dir", defaultJobsDir(t),
 			"--debug",
 			"--",
 			"--extra",
@@ -95,7 +97,7 @@ func TestRunEvalDefaultsDatasetPath(t *testing.T) {
 		"run",
 		mustAbs(t, defaultEvalDatasetPath),
 		"--agent", "oracle",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -120,9 +122,105 @@ func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
 		"run",
 		mustAbs(t, defaultEvalDatasetPath),
 		"--agent", "oracle",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 		"--",
 		"--model", "haiku",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, defaultEvalDatasetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := runEval(opts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		filepath.Join(repoRoot, defaultEvalDatasetPath),
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join(repoRoot, defaultEvalJobsDir),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	dataset := filepath.Join(nested, "custom-dataset")
+	if err := os.MkdirAll(dataset, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := runEval(opts, []string{"./custom-dataset"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		dataset,
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join(repoRoot, defaultEvalJobsDir),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, defaultEvalDatasetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.jobsDir = "custom/jobs"
+	opts.jobsDirExplicit = true
+
+	err := runEval(opts, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		filepath.Join(repoRoot, defaultEvalDatasetPath),
+		"--agent", "oracle",
+		"--jobs-dir", "custom/jobs",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -144,6 +242,7 @@ func TestRunEvalDelegatesCodexAndClaudeOptions(t *testing.T) {
 			opts.agent = tt.agent
 			opts.taskDir = "simple-agent"
 			opts.jobsDir = "jobs"
+			opts.jobsDirExplicit = true
 			opts.yes = true
 
 			err := runEval(opts, []string{path})
@@ -233,7 +332,7 @@ func TestRunEvalDelegatesModel(t *testing.T) {
 		"run",
 		mustAbs(t, path),
 		"--agent", "oracle",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 		"--",
 		"--model", "haiku",
 	}
@@ -256,7 +355,7 @@ func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 		"run",
 		mustAbs(t, path),
 		"--agent", "oracle",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 		"--",
 		"--model", "haiku",
 	}
@@ -312,7 +411,7 @@ func TestRunEvalDelegatesRunmeEnvAlias(t *testing.T) {
 		"run",
 		mustAbs(t, path),
 		"--agent", "oracle",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 		"--env", "runme",
 	}
 	if !sameCommand(calls[0], wantPreflight) {
@@ -339,7 +438,7 @@ func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
 		"run",
 		mustAbs(t, path),
 		"--agent", "codex",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 		"--env", "docker",
 	}
 	if len(calls) != 1 {
@@ -481,7 +580,7 @@ func TestRunEvalDelegatesUnknownAgent(t *testing.T) {
 		"run",
 		mustAbs(t, path),
 		"--agent", "bad",
-		"--jobs-dir", defaultEvalJobsDir,
+		"--jobs-dir", defaultJobsDir(t),
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -605,6 +704,15 @@ func mustAbs(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return abs
+}
+
+func defaultJobsDir(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(defaultEvalBaseDir(cwd), defaultEvalJobsDir)
 }
 
 func envValue(env []string, key string) string {


### PR DESCRIPTION
## Summary

- resolve omitted `runme eval` dataset paths from the project root when inside a git repo
- resolve default eval jobs output under the same project root while preserving explicit `--jobs-dir`
- cover nested git cwd, explicit dataset, and explicit jobs-dir behavior with tests

## Test plan

- `go test ./cmd -run 'TestRunEvalDefaults|TestRunEvalExplicit|TestRunEvalDelegates|TestRunEvalPreserves|TestRunEvalMissingDefaultPath|TestEvalCmdRejectsMultipleDatasetPaths'`
- `go test ./cmd`
- `runme run test`
