### PR TITLE
[codex] Show Runme eval exception details

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -1,17 +1,23 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
+	"syscall"
 
+	"github.com/creack/pty"
 	"github.com/spf13/cobra"
 
+	"github.com/runmedev/runme/v3/internal/ansi"
 	"github.com/runmedev/runme/v3/internal/harbor"
 	"github.com/runmedev/runme/v3/project"
 )
@@ -19,6 +25,7 @@ import (
 const (
 	defaultEvalDatasetPath = "evals/tasks"
 	defaultEvalJobsDir     = ".runme/evals/jobs"
+	maxHarborResultLineLen = 64 * 1024
 )
 
 var errRunmeHarborMissing = errors.New("runme-harbor missing")
@@ -46,6 +53,13 @@ type evalOptions struct {
 }
 
 type commandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+
+type harborResultPathWriter struct {
+	dst         io.Writer
+	line        []byte
+	lineTooLong bool
+	resultPath  string
+}
 
 func evalCmd() *cobra.Command {
 	opts := evalOptions{
@@ -155,7 +169,11 @@ func runEval(opts evalOptions, args []string) error {
 		_, _ = fmt.Fprintf(opts.stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
 	}
 
-	err = opts.commandRun(runmeHarbor, delegatedArgs, opts.evalBaseDir, env, os.Stdin, opts.stdout, opts.stderr)
+	harborStdout := &harborResultPathWriter{dst: opts.stdout}
+	err = opts.commandRun(runmeHarbor, delegatedArgs, opts.evalBaseDir, env, os.Stdin, harborStdout, opts.stderr)
+	if jobDir := evalJobDirFromResultPath(harborStdout.ResultPath(), opts.evalBaseDir); jobDir != "" {
+		printEvalExceptionDetails(opts.stdout, jobDir)
+	}
 	if err == nil {
 		return nil
 	}
@@ -359,14 +377,169 @@ func usesHarborDockerEnvironment(env string) bool {
 	return env == "docker"
 }
 
+func (w *harborResultPathWriter) Write(p []byte) (int, error) {
+	// Forward Harbor output before inspecting it so progress and tables keep streaming.
+	n, err := w.dst.Write(p)
+	remaining := p[:n]
+	for len(remaining) > 0 {
+		index := bytes.IndexByte(remaining, '\n')
+		if index < 0 {
+			w.appendLine(remaining)
+			break
+		}
+		w.appendLine(remaining[:index])
+		if !w.lineTooLong {
+			w.recordLine(w.line)
+		}
+		w.line = w.line[:0]
+		w.lineTooLong = false
+		remaining = remaining[index+1:]
+	}
+	return n, err
+}
+
+func (w *harborResultPathWriter) ResultPath() string {
+	if len(w.line) > 0 && !w.lineTooLong {
+		w.recordLine(w.line)
+		w.line = nil
+	}
+	return w.resultPath
+}
+
+func (w *harborResultPathWriter) StdoutFile() *os.File {
+	file, _ := w.dst.(*os.File)
+	return file
+}
+
+func (w *harborResultPathWriter) appendLine(p []byte) {
+	if w.lineTooLong {
+		return
+	}
+	if len(w.line)+len(p) > maxHarborResultLineLen {
+		w.line = w.line[:0]
+		w.lineTooLong = true
+		return
+	}
+	w.line = append(w.line, p...)
+}
+
+func (w *harborResultPathWriter) recordLine(line []byte) {
+	const prefix = "Results written to "
+	text := strings.TrimSpace(string(ansi.Strip(line)))
+	index := strings.Index(text, prefix)
+	if index == -1 {
+		return
+	}
+	w.resultPath = strings.TrimSpace(text[index+len(prefix):])
+}
+
+func evalJobDirFromResultPath(resultPath, evalBaseDir string) string {
+	if resultPath == "" {
+		return ""
+	}
+	if !filepath.IsAbs(resultPath) && evalBaseDir != "" {
+		resultPath = filepath.Join(evalBaseDir, resultPath)
+	}
+	return filepath.Dir(resultPath)
+}
+
+func printEvalExceptionDetails(w io.Writer, jobDir string) {
+	paths := evalExceptionFiles(jobDir)
+	if len(paths) == 0 {
+		return
+	}
+
+	printed := false
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		detail := strings.TrimSpace(string(content))
+		if detail == "" {
+			continue
+		}
+		if !printed {
+			_, _ = fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w, ansi.Color("Harbor Exception Details", "red+b"))
+			printed = true
+		}
+		_, _ = fmt.Fprintf(w, "\nFile: %s\n%s\n", evalExceptionDisplayPath(jobDir, path), detail)
+	}
+}
+
+func evalExceptionDisplayPath(jobsDir, path string) string {
+	relative, err := filepath.Rel(jobsDir, path)
+	if err != nil || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || relative == ".." {
+		return path
+	}
+	return relative
+}
+
+func evalExceptionFiles(jobDir string) []string {
+	var paths []string
+	_ = filepath.WalkDir(jobDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Base(path) != "exception.txt" {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	sort.Strings(paths)
+	return paths
+}
+
 func runExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = workingDir
 	cmd.Env = env
+	if provider, ok := stdout.(interface{ StdoutFile() *os.File }); ok {
+		if file := provider.StdoutFile(); file != nil && isTerminal(file.Fd()) {
+			return runExternalCommandWithPtyStdout(cmd, stdin, stdout, stderr, file)
+		}
+	}
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin
 	return cmd.Run()
+}
+
+func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer, stdoutFile *os.File) error {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = tty.Close() }()
+	_ = pty.InheritSize(stdoutFile, ptmx)
+
+	cmd.Stdout = tty
+	cmd.Stderr = stderr
+	cmd.Stdin = stdin
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_ = tty.Close()
+
+	copyDone := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(stdout, ptmx)
+		copyDone <- err
+	}()
+
+	waitErr := cmd.Wait()
+	_ = ptmx.Close()
+	copyErr := <-copyDone
+	if waitErr != nil {
+		return waitErr
+	}
+	if copyErr != nil && !errors.Is(copyErr, os.ErrClosed) {
+		if errors.Is(copyErr, syscall.EIO) {
+			return nil
+		}
+		return copyErr
+	}
+	return nil
 }
 
 func setEnv(env []string, key, value string) []string {

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -1,23 +1,19 @@
 package cmd
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"syscall"
 
 	"github.com/creack/pty"
 	"github.com/spf13/cobra"
 
-	"github.com/runmedev/runme/v3/internal/ansi"
 	"github.com/runmedev/runme/v3/internal/harbor"
 	"github.com/runmedev/runme/v3/project"
 )
@@ -25,7 +21,6 @@ import (
 const (
 	defaultEvalDatasetPath = "evals/tasks"
 	defaultEvalJobsDir     = ".runme/evals/jobs"
-	maxHarborResultLineLen = 64 * 1024
 )
 
 var errRunmeHarborMissing = errors.New("runme-harbor missing")
@@ -53,13 +48,6 @@ type evalOptions struct {
 }
 
 type commandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
-
-type harborResultPathWriter struct {
-	dst         io.Writer
-	line        []byte
-	lineTooLong bool
-	resultPath  string
-}
 
 func evalCmd() *cobra.Command {
 	opts := evalOptions{
@@ -169,10 +157,10 @@ func runEval(opts evalOptions, args []string) error {
 		_, _ = fmt.Fprintf(opts.stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
 	}
 
-	harborStdout := &harborResultPathWriter{dst: opts.stdout}
+	harborStdout := harbor.NewResultPathWriter(opts.stdout)
 	err = opts.commandRun(runmeHarbor, delegatedArgs, opts.evalBaseDir, env, os.Stdin, harborStdout, opts.stderr)
-	if jobDir := evalJobDirFromResultPath(harborStdout.ResultPath(), opts.evalBaseDir); jobDir != "" {
-		printEvalExceptionDetails(opts.stdout, jobDir)
+	if jobDir := harbor.JobDirFromResultPath(harborStdout.ResultPath(), opts.evalBaseDir); jobDir != "" {
+		harbor.PrintExceptionDetails(opts.stdout, jobDir)
 	}
 	if err == nil {
 		return nil
@@ -375,118 +363,6 @@ func usesRunmeEnvironment(env string) bool {
 
 func usesHarborDockerEnvironment(env string) bool {
 	return env == "docker"
-}
-
-func (w *harborResultPathWriter) Write(p []byte) (int, error) {
-	// Forward Harbor output before inspecting it so progress and tables keep streaming.
-	n, err := w.dst.Write(p)
-	remaining := p[:n]
-	for len(remaining) > 0 {
-		index := bytes.IndexByte(remaining, '\n')
-		if index < 0 {
-			w.appendLine(remaining)
-			break
-		}
-		w.appendLine(remaining[:index])
-		if !w.lineTooLong {
-			w.recordLine(w.line)
-		}
-		w.line = w.line[:0]
-		w.lineTooLong = false
-		remaining = remaining[index+1:]
-	}
-	return n, err
-}
-
-func (w *harborResultPathWriter) ResultPath() string {
-	if len(w.line) > 0 && !w.lineTooLong {
-		w.recordLine(w.line)
-		w.line = nil
-	}
-	return w.resultPath
-}
-
-func (w *harborResultPathWriter) StdoutFile() *os.File {
-	file, _ := w.dst.(*os.File)
-	return file
-}
-
-func (w *harborResultPathWriter) appendLine(p []byte) {
-	if w.lineTooLong {
-		return
-	}
-	if len(w.line)+len(p) > maxHarborResultLineLen {
-		w.line = w.line[:0]
-		w.lineTooLong = true
-		return
-	}
-	w.line = append(w.line, p...)
-}
-
-func (w *harborResultPathWriter) recordLine(line []byte) {
-	const prefix = "Results written to "
-	text := strings.TrimSpace(string(ansi.Strip(line)))
-	index := strings.Index(text, prefix)
-	if index == -1 {
-		return
-	}
-	w.resultPath = strings.TrimSpace(text[index+len(prefix):])
-}
-
-func evalJobDirFromResultPath(resultPath, evalBaseDir string) string {
-	if resultPath == "" {
-		return ""
-	}
-	if !filepath.IsAbs(resultPath) && evalBaseDir != "" {
-		resultPath = filepath.Join(evalBaseDir, resultPath)
-	}
-	return filepath.Dir(resultPath)
-}
-
-func printEvalExceptionDetails(w io.Writer, jobDir string) {
-	paths := evalExceptionFiles(jobDir)
-	if len(paths) == 0 {
-		return
-	}
-
-	printed := false
-	for _, path := range paths {
-		content, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-		detail := strings.TrimSpace(string(content))
-		if detail == "" {
-			continue
-		}
-		if !printed {
-			_, _ = fmt.Fprintln(w)
-			_, _ = fmt.Fprintln(w, ansi.Color("Harbor Exception Details", "red+b"))
-			printed = true
-		}
-		_, _ = fmt.Fprintf(w, "\nFile: %s\n%s\n", evalExceptionDisplayPath(jobDir, path), detail)
-	}
-}
-
-func evalExceptionDisplayPath(jobsDir, path string) string {
-	relative, err := filepath.Rel(jobsDir, path)
-	if err != nil || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || relative == ".." {
-		return path
-	}
-	return relative
-}
-
-func evalExceptionFiles(jobDir string) []string {
-	var paths []string
-	_ = filepath.WalkDir(jobDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || filepath.Base(path) != "exception.txt" {
-			return nil
-		}
-		paths = append(paths, path)
-		return nil
-	})
-	sort.Strings(paths)
-	return paths
 }
 
 func runExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -6,24 +6,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 
-	"github.com/creack/pty"
 	"github.com/spf13/cobra"
 
 	"github.com/runmedev/runme/v3/internal/harbor"
-	"github.com/runmedev/runme/v3/project"
 )
-
-const (
-	defaultEvalDatasetPath = "evals/tasks"
-	defaultEvalJobsDir     = ".runme/evals/jobs"
-)
-
-var errRunmeHarborMissing = errors.New("runme-harbor missing")
 
 type evalOptions struct {
 	agent           string
@@ -37,28 +25,24 @@ type evalOptions struct {
 	runmeHarbor     string
 	debug           bool
 	jobsDirExplicit bool
-	evalBaseDir     string
-	commandRun      commandRunFunc
-	lookPath        func(string) (string, error)
-	executable      func() (string, error)
 	stdout          io.Writer
 	stderr          io.Writer
-	extraEnv        []string
-	preflight       bool
 }
 
-type commandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+type evalRunner interface {
+	Run(args []string) error
+}
+
+var newEvalRunner = func(opts harbor.EvalOptions) evalRunner {
+	return harbor.NewEvalRunner(opts)
+}
 
 func evalCmd() *cobra.Command {
 	opts := evalOptions{
-		agent:      "oracle",
-		jobsDir:    defaultEvalJobsDir,
-		commandRun: runExternalCommand,
-		lookPath:   exec.LookPath,
-		executable: os.Executable,
-		stdout:     os.Stdout,
-		stderr:     os.Stderr,
-		preflight:  true,
+		agent:   "oracle",
+		jobsDir: harbor.DefaultEvalJobsDir,
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
 	}
 
 	cmd := &cobra.Command{
@@ -66,7 +50,7 @@ func evalCmd() *cobra.Command {
 		Short: "Run Harbor eval tasks with Runme",
 		Long: fmt.Sprintf(`Run Harbor eval tasks with Runme.
 
-When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
+When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetPath),
 		Args: validateEvalArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()
@@ -79,7 +63,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
 	flags := cmd.Flags()
 	flags.StringVar(&opts.agent, "agent", "oracle", "Harbor agent to use")
 	flags.StringVar(&opts.taskDir, "task-dir", "", "Task directory name to include from the Harbor dataset")
-	flags.StringVar(&opts.jobsDir, "jobs-dir", defaultEvalJobsDir, "Eval jobs directory")
+	flags.StringVar(&opts.jobsDir, "jobs-dir", harbor.DefaultEvalJobsDir, "Eval jobs directory")
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Confirm Harbor prompts")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
 	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
@@ -92,78 +76,27 @@ When dataset-path is omitted, runme eval uses ./%s.`, defaultEvalDatasetPath),
 }
 
 func runEval(opts evalOptions, args []string) error {
-	datasetPath, passthrough, defaultDataset, err := resolveEvalPaths(&opts, args)
-	if err != nil {
-		return err
-	}
-	if _, err := os.Stat(datasetPath); err != nil {
-		if os.IsNotExist(err) {
-			if defaultDataset {
-				return fmt.Errorf("dataset path does not exist: %s; create it or pass a dataset path explicitly", defaultEvalDatasetPath)
-			}
-			return fmt.Errorf("dataset path does not exist: %s", datasetPath)
-		}
-		return err
-	}
-
-	if opts.model != "" && containsModelFlag(passthrough) {
-		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
-	}
-	if containsEnvironmentFlag(passthrough) {
-		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
-	}
-
-	runmeHarbor, err := resolveRunmeHarbor(opts)
-	if err != nil {
-		if errors.Is(err, errRunmeHarborMissing) {
-			return fmt.Errorf("`runme eval` requires the optional Python package `runme-harbor`.\n\nInstall it with:\n  uv tool install runme-harbor\n\nThen retry:\n  runme eval\n\nOr pass a dataset path explicitly:\n  runme eval <dataset-path>")
-		}
-		return err
-	}
-
-	runmeBin, err := resolveRunmeBin(opts)
-	if err != nil {
-		return err
-	}
-
-	env := os.Environ()
-	env = setEnv(env, "RUNME_BIN", runmeBin)
-	if len(opts.runmeArgs) > 0 {
-		env = setEnv(env, "RUNME_ARGS", joinShellArgs(opts.runmeArgs))
-	}
-	env = append(env, opts.extraEnv...)
-
-	if usesHarborDockerEnvironment(opts.env) {
-		stager, err := harbor.NewDockerWorkdirStager(harbor.DockerWorkdirStagerOptions{
-			Stderr: opts.stderr,
-		})
-		if err != nil {
-			return err
-		}
-		if err := stager.StageDataset(datasetPath); err != nil {
-			return err
-		}
-	}
-
-	if opts.preflight && usesRunmeEnvironment(opts.env) {
-		request := strings.NewReader("{\"id\":\"preflight\",\"preflight\":{}}\n")
-		if err := opts.commandRun(runmeBin, []string{"harbor", "stdio"}, "", env, request, io.Discard, opts.stderr); err != nil {
-			return fmt.Errorf("runme harbor stdio preflight failed: %w", err)
-		}
-	}
-
-	delegatedArgs := buildRunmeHarborArgs(datasetPath, opts, passthrough)
-	if opts.debug {
-		_, _ = fmt.Fprintf(opts.stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
-	}
-
-	harborStdout := harbor.NewResultPathWriter(opts.stdout)
-	err = opts.commandRun(runmeHarbor, delegatedArgs, opts.evalBaseDir, env, os.Stdin, harborStdout, opts.stderr)
-	if jobDir := harbor.JobDirFromResultPath(harborStdout.ResultPath(), opts.evalBaseDir); jobDir != "" {
-		harbor.PrintExceptionDetails(opts.stdout, jobDir)
-	}
+	err := newEvalRunner(harbor.EvalOptions{
+		Agent:           opts.agent,
+		TaskDir:         opts.taskDir,
+		JobsDir:         opts.jobsDir,
+		Yes:             opts.yes,
+		Model:           opts.model,
+		Env:             opts.env,
+		RunmeBin:        opts.runmeBin,
+		RunmeArgs:       opts.runmeArgs,
+		RunmeHarborBin:  opts.runmeHarbor,
+		Debug:           opts.debug,
+		JobsDirExplicit: opts.jobsDirExplicit,
+		Stdout:          opts.stdout,
+		Stderr:          opts.stderr,
+		Preflight:       true,
+	}).Run(args)
 	if err == nil {
 		return nil
+	}
+	if errors.Is(err, harbor.ErrRunmeHarborMissing) {
+		return fmt.Errorf("`runme eval` requires the optional Python package `runme-harbor`.\n\nInstall it with:\n  uv tool install runme-harbor\n\nThen retry:\n  runme eval\n\nOr pass a dataset path explicitly:\n  runme eval <dataset-path>")
 	}
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
@@ -174,49 +107,6 @@ func runEval(opts evalOptions, args []string) error {
 		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
 	}
 	return err
-}
-
-func resolveEvalPaths(opts *evalOptions, args []string) (string, []string, bool, error) {
-	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
-	if defaultDataset {
-		baseDir, err := evalDefaultBaseDir()
-		if err != nil {
-			return "", nil, false, err
-		}
-		if !opts.jobsDirExplicit {
-			opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
-		}
-		opts.evalBaseDir = baseDir
-		return filepath.Join(baseDir, defaultEvalDatasetPath), passthrough, true, nil
-	}
-
-	datasetPath, err := filepath.Abs(datasetArg)
-	if err != nil {
-		return "", nil, false, err
-	}
-	if !opts.jobsDirExplicit {
-		baseDir, err := evalDefaultBaseDir()
-		if err != nil {
-			return "", nil, false, err
-		}
-		opts.jobsDir = filepath.Join(baseDir, defaultEvalJobsDir)
-		opts.evalBaseDir = baseDir
-	} else {
-		baseDir, err := evalDefaultBaseDir()
-		if err != nil {
-			return "", nil, false, err
-		}
-		opts.evalBaseDir = baseDir
-	}
-	return datasetPath, passthrough, false, nil
-}
-
-func evalDefaultBaseDir() (string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	return defaultEvalBaseDir(cwd), nil
 }
 
 func validateEvalArgs(_ *cobra.Command, args []string) error {
@@ -230,232 +120,4 @@ func validateEvalArgs(_ *cobra.Command, args []string) error {
 		return nil
 	}
 	return fmt.Errorf("accepts at most 1 dataset path, received %d", len(args))
-}
-
-func splitEvalDatasetArg(args []string) (string, bool, []string) {
-	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
-		return defaultEvalDatasetPath, true, args
-	}
-	return args[0], false, args[1:]
-}
-
-func defaultEvalBaseDir(cwd string) string {
-	proj, err := project.NewDirProject(
-		cwd,
-		project.WithFindRepoUpward(),
-		project.WithAllowUnsupportedGitExtensions(true),
-		project.WithRespectGitignore(false),
-	)
-	if err != nil {
-		return cwd
-	}
-	return proj.Root()
-}
-
-func resolveRunmeHarbor(opts evalOptions) (string, error) {
-	candidates := []string{}
-	if value := os.Getenv("RUNME_HARBOR_BIN"); value != "" {
-		candidates = append(candidates, value)
-	}
-	if opts.runmeHarbor != "" {
-		candidates = append(candidates, opts.runmeHarbor)
-	}
-	candidates = append(candidates, "runme-harbor")
-
-	for _, candidate := range candidates {
-		resolved, err := resolveExecutable(candidate, opts.lookPath)
-		if err == nil {
-			return resolved, nil
-		}
-		if candidate != "runme-harbor" {
-			return "", fmt.Errorf("runme-harbor executable %q not found: %w", candidate, err)
-		}
-	}
-	return "", errRunmeHarborMissing
-}
-
-func resolveRunmeBin(opts evalOptions) (string, error) {
-	if opts.runmeBin != "" {
-		return opts.runmeBin, nil
-	}
-	if opts.executable != nil {
-		if current, err := opts.executable(); err == nil && current != "" {
-			return current, nil
-		}
-	}
-	return "runme", nil
-}
-
-func resolveExecutable(name string, lookPath func(string) (string, error)) (string, error) {
-	if strings.ContainsRune(name, rune(os.PathSeparator)) {
-		info, err := os.Stat(name)
-		if err != nil {
-			return "", err
-		}
-		if info.IsDir() {
-			return "", fmt.Errorf("%s is a directory", name)
-		}
-		if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
-			return "", fmt.Errorf("%s is not executable", name)
-		}
-		return name, nil
-	}
-	return lookPath(name)
-}
-
-func buildRunmeHarborArgs(datasetPath string, opts evalOptions, passthrough []string) []string {
-	args := []string{
-		"run",
-		datasetPath,
-		"--agent", opts.agent,
-		"--jobs-dir", opts.jobsDir,
-	}
-	if opts.taskDir != "" {
-		args = append(args, "--task-dir", opts.taskDir)
-	}
-	if opts.yes {
-		args = append(args, "-y")
-	}
-	if opts.debug {
-		args = append(args, "--debug")
-	}
-	if opts.env != "" {
-		args = append(args, "--env", opts.env)
-	}
-	delegatedPassthrough := append([]string(nil), passthrough...)
-	if opts.model != "" {
-		delegatedPassthrough = append(delegatedPassthrough, "--model", opts.model)
-	}
-	if len(delegatedPassthrough) > 0 {
-		args = append(args, "--")
-		args = append(args, delegatedPassthrough...)
-	}
-	return args
-}
-
-func containsModelFlag(args []string) bool {
-	for _, arg := range args {
-		if arg == "--model" || strings.HasPrefix(arg, "--model=") {
-			return true
-		}
-	}
-	return false
-}
-
-func containsEnvironmentFlag(args []string) bool {
-	for _, arg := range args {
-		if arg == "--env" || arg == "-e" || arg == "--environment-import-path" {
-			return true
-		}
-		if strings.HasPrefix(arg, "--env=") || strings.HasPrefix(arg, "-e") && len(arg) > 2 {
-			return true
-		}
-		if strings.HasPrefix(arg, "--environment-import-path=") {
-			return true
-		}
-	}
-	return false
-}
-
-func usesRunmeEnvironment(env string) bool {
-	return env == "" || env == "runme"
-}
-
-func usesHarborDockerEnvironment(env string) bool {
-	return env == "docker"
-}
-
-func runExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
-	cmd := exec.Command(name, args...)
-	cmd.Dir = workingDir
-	cmd.Env = env
-	if provider, ok := stdout.(interface{ StdoutFile() *os.File }); ok {
-		if file := provider.StdoutFile(); file != nil && isTerminal(file.Fd()) {
-			return runExternalCommandWithPtyStdout(cmd, stdin, stdout, stderr, file)
-		}
-	}
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
-	cmd.Stdin = stdin
-	return cmd.Run()
-}
-
-func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer, stdoutFile *os.File) error {
-	ptmx, tty, err := pty.Open()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = ptmx.Close() }()
-	defer func() { _ = tty.Close() }()
-	_ = pty.InheritSize(stdoutFile, ptmx)
-
-	cmd.Stdout = tty
-	cmd.Stderr = stderr
-	cmd.Stdin = stdin
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	_ = tty.Close()
-
-	copyDone := make(chan error, 1)
-	go func() {
-		_, err := io.Copy(stdout, ptmx)
-		copyDone <- err
-	}()
-
-	waitErr := cmd.Wait()
-	_ = ptmx.Close()
-	copyErr := <-copyDone
-	if waitErr != nil {
-		return waitErr
-	}
-	if copyErr != nil && !errors.Is(copyErr, os.ErrClosed) {
-		if errors.Is(copyErr, syscall.EIO) {
-			return nil
-		}
-		return copyErr
-	}
-	return nil
-}
-
-func setEnv(env []string, key, value string) []string {
-	prefix := key + "="
-	for i, item := range env {
-		if strings.HasPrefix(item, prefix) {
-			env[i] = prefix + value
-			return env
-		}
-	}
-	return append(env, prefix+value)
-}
-
-func joinShellArgs(args []string) string {
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func shellCommandString(args []string) string {
-	quoted := make([]string, 0, len(args))
-	for _, arg := range args {
-		quoted = append(quoted, shellQuote(arg))
-	}
-	return strings.Join(quoted, " ")
-}
-
-func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	if strings.IndexFunc(value, func(r rune) bool {
-		return (r < 'A' || r > 'Z') &&
-			(r < 'a' || r > 'z') &&
-			(r < '0' || r > '9') &&
-			!strings.ContainsRune("@%_+=:,./-", r)
-	}) == -1 {
-		return value
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -784,21 +784,6 @@ func TestRunEvalOnlyPrintsExceptionDetailsForReportedJob(t *testing.T) {
 	}
 }
 
-func TestHarborResultPathWriterStreamsBeforeNewline(t *testing.T) {
-	var stdout bytes.Buffer
-	writer := &harborResultPathWriter{dst: &stdout}
-
-	if _, err := writer.Write([]byte("1/1 Mean: 0.000")); err != nil {
-		t.Fatal(err)
-	}
-	if got := stdout.String(); got != "1/1 Mean: 0.000" {
-		t.Fatalf("stdout = %q, want streamed partial line", got)
-	}
-	if got := writer.ResultPath(); got != "" {
-		t.Fatalf("result path = %q, want empty before result line", got)
-	}
-}
-
 func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) evalOptions {
 	t.Helper()
 	return evalOptions{

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -3,24 +3,20 @@ package cmd
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v5"
-
-	"github.com/runmedev/runme/v3/internal/ansi"
+	"github.com/runmedev/runme/v3/internal/harbor"
 )
 
-type recordedCommand struct {
-	name       string
-	args       []string
-	workingDir string
-	env        []string
+type fakeEvalRunner struct {
+	err error
+}
+
+func (r fakeEvalRunner) Run([]string) error {
+	return r.err
 }
 
 type fakeExitError struct {
@@ -35,255 +31,58 @@ func (e fakeExitError) ExitCode() int {
 	return e.code
 }
 
-func TestRunEvalDelegatesOracle(t *testing.T) {
-	path := t.TempDir()
-	var stderr bytes.Buffer
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, &stderr)
-	opts.debug = true
-
-	err := runEval(opts, []string{
-		path,
-		"--extra",
-		"value",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wantPreflight := recordedCommand{
-		name: "/bin/runme",
-		args: []string{"harbor", "stdio"},
-	}
-	wantDelegate := recordedCommand{
-		name: "/bin/runme-harbor",
-		args: []string{
-			"run",
-			mustAbs(t, path),
-			"--agent", "oracle",
-			"--jobs-dir", defaultJobsDir(t),
-			"--debug",
-			"--",
-			"--extra",
-			"value",
-		},
-	}
-	if !sameCommand(calls[0], wantPreflight) {
-		t.Fatalf("preflight = %#v, want %#v", calls[0], wantPreflight)
-	}
-	if !sameCommand(calls[1], wantDelegate) {
-		t.Fatalf("delegate = %#v, want %#v", calls[1], wantDelegate)
-	}
-	wantDebug := shellCommandString(append([]string{wantDelegate.name}, wantDelegate.args...)) + "\n"
-	if stderr.String() != wantDebug {
-		t.Fatalf("debug output = %q, want %q", stderr.String(), wantDebug)
-	}
-	if got := envValue(calls[1].env, "RUNME_BIN"); got != "/bin/runme" {
-		t.Fatalf("RUNME_BIN = %q, want /bin/runme", got)
-	}
-}
-
-func TestRunEvalDefaultsDatasetPath(t *testing.T) {
-	tmp := t.TempDir()
-	t.Chdir(tmp)
-	if err := os.MkdirAll(defaultEvalDatasetPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		defaultDatasetPath(t),
-		"--agent", "oracle",
-		"--jobs-dir", defaultJobsDir(t),
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
-	}
-}
-
-func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
-	tmp := t.TempDir()
-	t.Chdir(tmp)
-	if err := os.MkdirAll(defaultEvalDatasetPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, []string{"--model", "haiku"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		defaultDatasetPath(t),
-		"--agent", "oracle",
-		"--jobs-dir", defaultJobsDir(t),
-		"--",
+func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
+	var gotOpts harbor.EvalOptions
+	var gotArgs []string
+	cmd := evalCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"dataset",
+		"--agent", "codex",
+		"--task-dir", "simple-agent",
+		"--jobs-dir", "jobs",
+		"--yes",
 		"--model", "haiku",
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
-	}
-}
-
-func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
-	repoRoot := t.TempDir()
-	if _, err := git.PlainInit(repoRoot, false); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(repoRoot, defaultEvalDatasetPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	nested := filepath.Join(repoRoot, "nested", "dir")
-	if err := os.MkdirAll(nested, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		filepath.Join(baseDir, defaultEvalDatasetPath),
-		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(baseDir, defaultEvalJobsDir),
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
-	}
-}
-
-func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
-	repoRoot := t.TempDir()
-	if _, err := git.PlainInit(repoRoot, false); err != nil {
-		t.Fatal(err)
-	}
-	nested := filepath.Join(repoRoot, "nested", "dir")
-	dataset := filepath.Join(nested, "custom-dataset")
-	if err := os.MkdirAll(dataset, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, []string{"./custom-dataset"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		dataset,
-		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(baseDir, defaultEvalJobsDir),
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
-	}
-}
-
-func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
-	repoRoot := t.TempDir()
-	if _, err := git.PlainInit(repoRoot, false); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(repoRoot, defaultEvalDatasetPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	nested := filepath.Join(repoRoot, "nested", "dir")
-	if err := os.MkdirAll(nested, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.jobsDir = "custom/jobs"
-	opts.jobsDirExplicit = true
-
-	err := runEval(opts, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		filepath.Join(baseDir, defaultEvalDatasetPath),
-		"--agent", "oracle",
-		"--jobs-dir", "custom/jobs",
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
-	}
-}
-
-func TestRunEvalDelegatesCodexAndClaudeOptions(t *testing.T) {
-	for _, tt := range []struct {
-		name  string
-		agent string
-	}{
-		{name: "codex", agent: "codex"},
-		{name: "claude-code", agent: "claude-code"},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
-			var calls []recordedCommand
-			opts := testEvalOptions(t, &calls, io.Discard)
-			opts.agent = tt.agent
-			opts.taskDir = "simple-agent"
-			opts.jobsDir = "jobs"
-			opts.jobsDirExplicit = true
-			opts.yes = true
-
-			err := runEval(opts, []string{path})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			want := []string{
-				"run",
-				mustAbs(t, path),
-				"--agent", tt.agent,
-				"--jobs-dir", "jobs",
-				"--task-dir", "simple-agent",
-				"-y",
-			}
-			if !reflect.DeepEqual(calls[1].args, want) {
-				t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-			}
+		"--env", "docker",
+		"--runme-bin", "/bin/runme",
+		"--runme-arg", "--skip-prompts",
+		"--runme-harbor-bin", "/bin/runme-harbor",
+		"--debug",
+		"--",
+		"--extra",
+	})
+	restoreEvalRunner(t, func(opts harbor.EvalOptions) evalRunner {
+		gotOpts = opts
+		return evalRunnerFunc(func(args []string) error {
+			gotArgs = append([]string(nil), args...)
+			return nil
 		})
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotArgs, []string{"dataset", "--extra"}) {
+		t.Fatalf("args = %#v", gotArgs)
+	}
+	if gotOpts.Agent != "codex" ||
+		gotOpts.TaskDir != "simple-agent" ||
+		gotOpts.JobsDir != "jobs" ||
+		!gotOpts.JobsDirExplicit ||
+		!gotOpts.Yes ||
+		gotOpts.Model != "haiku" ||
+		gotOpts.Env != "docker" ||
+		gotOpts.RunmeBin != "/bin/runme" ||
+		!reflect.DeepEqual(gotOpts.RunmeArgs, []string{"--skip-prompts"}) ||
+		gotOpts.RunmeHarborBin != "/bin/runme-harbor" ||
+		!gotOpts.Debug ||
+		gotOpts.Stdout != &stdout ||
+		gotOpts.Stderr != &stderr ||
+		!gotOpts.Preflight {
+		t.Fatalf("options = %#v", gotOpts)
 	}
 }
 
@@ -339,307 +138,6 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 	}
 }
 
-func TestRunEvalDelegatesModel(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.model = "haiku"
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		mustAbs(t, path),
-		"--agent", "oracle",
-		"--jobs-dir", defaultJobsDir(t),
-		"--",
-		"--model", "haiku",
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-}
-
-func TestRunEvalPreservesPassthroughModel(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, []string{path, "--model", "haiku"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		mustAbs(t, path),
-		"--agent", "oracle",
-		"--jobs-dir", defaultJobsDir(t),
-		"--",
-		"--model", "haiku",
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-}
-
-func TestRunEvalRejectsDuplicateModel(t *testing.T) {
-	for _, tt := range []struct {
-		name        string
-		passthrough []string
-	}{
-		{name: "separate arg", passthrough: []string{"--model", "sonnet"}},
-		{name: "equals arg", passthrough: []string{"--model=sonnet"}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
-			var calls []recordedCommand
-			opts := testEvalOptions(t, &calls, io.Discard)
-			opts.model = "haiku"
-
-			err := runEval(opts, append([]string{path}, tt.passthrough...))
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), "--model cannot be used together with passthrough --model") {
-				t.Fatalf("error = %q", err.Error())
-			}
-			if len(calls) != 0 {
-				t.Fatalf("calls = %#v, want none", calls)
-			}
-		})
-	}
-}
-
-func TestRunEvalDelegatesRunmeEnvAlias(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.env = "runme"
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wantPreflight := recordedCommand{
-		name: "/bin/runme",
-		args: []string{"harbor", "stdio"},
-	}
-	wantDelegate := []string{
-		"run",
-		mustAbs(t, path),
-		"--agent", "oracle",
-		"--jobs-dir", defaultJobsDir(t),
-		"--env", "runme",
-	}
-	if !sameCommand(calls[0], wantPreflight) {
-		t.Fatalf("preflight = %#v, want %#v", calls[0], wantPreflight)
-	}
-	if !reflect.DeepEqual(calls[1].args, wantDelegate) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, wantDelegate)
-	}
-}
-
-func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.env = "docker"
-	opts.agent = "codex"
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := []string{
-		"run",
-		mustAbs(t, path),
-		"--agent", "codex",
-		"--jobs-dir", defaultJobsDir(t),
-		"--env", "docker",
-	}
-	if len(calls) != 1 {
-		t.Fatalf("calls = %#v, want delegate only", calls)
-	}
-	if !reflect.DeepEqual(calls[0].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
-	}
-}
-
-func TestRunEvalDoesNotStageNonDockerWorkdir(t *testing.T) {
-	workspace := t.TempDir()
-	t.Chdir(workspace)
-	dataset, workdir, target := makeHarborDockerDataset(t, workspace, "/app/source/workdir")
-	if err := os.WriteFile(filepath.Join(workdir, "keep.txt"), []byte("keep"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.env = "podman"
-
-	err := runEval(opts, []string{dataset})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(target); !os.IsNotExist(err) {
-		t.Fatalf("target stat err = %v, want not exist", err)
-	}
-}
-
-func TestRunEvalRejectsPassthroughEnvironmentFlags(t *testing.T) {
-	for _, tt := range []struct {
-		name        string
-		passthrough []string
-	}{
-		{name: "env separate", passthrough: []string{"--env", "docker"}},
-		{name: "env equals", passthrough: []string{"--env=docker"}},
-		{name: "env shorthand separate", passthrough: []string{"-e", "docker"}},
-		{name: "env shorthand joined", passthrough: []string{"-edocker"}},
-		{name: "import path separate", passthrough: []string{"--environment-import-path", "pkg:Env"}},
-		{name: "import path equals", passthrough: []string{"--environment-import-path=pkg:Env"}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
-			var calls []recordedCommand
-			opts := testEvalOptions(t, &calls, io.Discard)
-
-			err := runEval(opts, append([]string{path}, tt.passthrough...))
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), "use runme eval --env") {
-				t.Fatalf("error = %q", err.Error())
-			}
-			if len(calls) != 0 {
-				t.Fatalf("calls = %#v, want none", calls)
-			}
-		})
-	}
-}
-
-func TestRunEvalUsesEnvAndRunmeArgs(t *testing.T) {
-	envHarbor := makeExecutable(t, "env-runme-harbor")
-	flagHarbor := makeExecutable(t, "flag-runme-harbor")
-	t.Setenv("RUNME_HARBOR_BIN", envHarbor)
-	t.Setenv("RUNME_ARGS", "--existing")
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.runmeHarbor = flagHarbor
-	opts.runmeBin = "/flag/runme"
-	opts.runmeArgs = []string{"--chdir", "/tmp/with space", "--label=can't-$expand`this`\\path"}
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if calls[1].name != envHarbor {
-		t.Fatalf("runme-harbor = %q, want env override", calls[1].name)
-	}
-	if got := envValue(calls[1].env, "RUNME_BIN"); got != "/flag/runme" {
-		t.Fatalf("RUNME_BIN = %q, want /flag/runme", got)
-	}
-	if got := envValue(calls[1].env, "RUNME_ARGS"); got != "--chdir '/tmp/with space' '--label=can'\\''t-$expand`this`\\path'" {
-		t.Fatalf("RUNME_ARGS = %q", got)
-	}
-}
-
-func TestRunEvalPreservesExistingRunmeArgs(t *testing.T) {
-	t.Setenv("RUNME_ARGS", "--existing")
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if got := envValue(calls[1].env, "RUNME_ARGS"); got != "--existing" {
-		t.Fatalf("RUNME_ARGS = %q, want preserved env", got)
-	}
-}
-
-func TestRunEvalMissingRunmeHarbor(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.lookPath = func(string) (string, error) {
-		return "", os.ErrNotExist
-	}
-
-	err := runEval(opts, []string{path})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "uv tool install runme-harbor") {
-		t.Fatalf("error = %q", err.Error())
-	}
-	if len(calls) != 0 {
-		t.Fatalf("calls = %#v, want none", calls)
-	}
-}
-
-func TestRunEvalDelegatesUnknownAgent(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.agent = "bad"
-
-	err := runEval(opts, []string{path})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []string{
-		"run",
-		mustAbs(t, path),
-		"--agent", "bad",
-		"--jobs-dir", defaultJobsDir(t),
-	}
-	if !reflect.DeepEqual(calls[1].args, want) {
-		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
-	}
-}
-
-func TestRunEvalMissingPath(t *testing.T) {
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, []string{filepath.Join(t.TempDir(), "missing")})
-	if err == nil || !strings.Contains(err.Error(), "dataset path does not exist") {
-		t.Fatalf("error = %v", err)
-	}
-}
-
-func TestRunEvalMissingDefaultPath(t *testing.T) {
-	tmp := t.TempDir()
-	t.Chdir(tmp)
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-
-	err := runEval(opts, nil)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if !strings.Contains(err.Error(), "dataset path does not exist: evals/tasks") {
-		t.Fatalf("error = %q", err.Error())
-	}
-	if !strings.Contains(err.Error(), "pass a dataset path explicitly") {
-		t.Fatalf("error = %q", err.Error())
-	}
-	if len(calls) != 0 {
-		t.Fatalf("calls = %#v, want none", calls)
-	}
-}
-
 func TestEvalCmdRejectsMultipleDatasetPaths(t *testing.T) {
 	cmd := evalCmd()
 	cmd.SetArgs([]string{"first", "second"})
@@ -656,18 +154,11 @@ func TestEvalCmdRejectsMultipleDatasetPaths(t *testing.T) {
 }
 
 func TestRunEvalPropagatesDelegateExitCode(t *testing.T) {
-	path := t.TempDir()
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
-		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
-		if len(calls) == 2 {
-			return fakeExitError{code: 42}
-		}
-		return nil
-	}
+	restoreEvalRunner(t, func(harbor.EvalOptions) evalRunner {
+		return fakeEvalRunner{err: fakeExitError{code: 42}}
+	})
 
-	err := runEval(opts, []string{path})
+	err := runEval(evalOptions{}, []string{"dataset"})
 	var exitErr ExitCodeError
 	if !errors.As(err, &exitErr) {
 		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
@@ -677,228 +168,31 @@ func TestRunEvalPropagatesDelegateExitCode(t *testing.T) {
 	}
 }
 
-func TestRunEvalPrintsExceptionDetailsAfterHarborOutput(t *testing.T) {
-	path := t.TempDir()
-	jobsDir := filepath.Join(t.TempDir(), "jobs")
-	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
-	resultPath := filepath.Join(jobDir, "result.json")
-	var stdout bytes.Buffer
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.jobsDir = jobsDir
-	opts.jobsDirExplicit = true
-	opts.stdout = &stdout
-	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
-		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
-		if len(calls) == 2 {
-			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
-			writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "HarborProtocolError: runme failed with useful context\n")
-			return fakeExitError{code: 7}
-		}
-		return nil
-	}
+func TestRunEvalMissingRunmeHarborMessage(t *testing.T) {
+	restoreEvalRunner(t, func(harbor.EvalOptions) evalRunner {
+		return fakeEvalRunner{err: harbor.ErrRunmeHarborMissing}
+	})
 
-	err := runEval(opts, []string{path})
-	var exitErr ExitCodeError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	err := runEval(evalOptions{}, []string{"dataset"})
+	if err == nil {
+		t.Fatal("expected error")
 	}
-
-	output := string(ansi.Strip(stdout.Bytes()))
-	if !strings.Contains(output, "Exception           Count\nHarborProtocolError 1\nResults written to "+resultPath+"\n\nHarbor Exception Details\n") {
-		t.Fatalf("output = %q", output)
-	}
-	if !strings.Contains(output, "File: end-to-end__abc/exception.txt") {
-		t.Fatalf("output = %q", output)
-	}
-	if !strings.Contains(output, "HarborProtocolError: runme failed with useful context") {
-		t.Fatalf("output = %q", output)
+	if !strings.Contains(err.Error(), "uv tool install runme-harbor") {
+		t.Fatalf("error = %q", err.Error())
 	}
 }
 
-func TestRunEvalPrintsExceptionDetailsForDockerEnvironment(t *testing.T) {
-	workspace := t.TempDir()
-	t.Chdir(workspace)
-	dataset, _, _ := makeHarborDockerDataset(t, workspace, "/app/source/workdir")
-	jobsDir := filepath.Join(t.TempDir(), "jobs")
-	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
-	resultPath := filepath.Join(jobDir, "result.json")
-	var stdout bytes.Buffer
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.env = "docker"
-	opts.jobsDir = jobsDir
-	opts.jobsDirExplicit = true
-	opts.stdout = &stdout
-	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
-		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
-		_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
-		writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "ValueError: docker detail should be visible\n")
-		return fakeExitError{code: 7}
-	}
+type evalRunnerFunc func([]string) error
 
-	err := runEval(opts, []string{dataset})
-	var exitErr ExitCodeError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
-	}
-	output := string(ansi.Strip(stdout.Bytes()))
-	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "ValueError: docker detail should be visible") {
-		t.Fatalf("output = %q", stdout.String())
-	}
+func (f evalRunnerFunc) Run(args []string) error {
+	return f(args)
 }
 
-func TestRunEvalOnlyPrintsExceptionDetailsForReportedJob(t *testing.T) {
-	path := t.TempDir()
-	jobsDir := filepath.Join(t.TempDir(), "jobs")
-	jobDir := filepath.Join(jobsDir, "current")
-	resultPath := filepath.Join(jobDir, "result.json")
-	writeEvalException(t, jobsDir, "other/attempt/exception.txt", "other detail\n")
-	writeEvalException(t, jobDir, "attempt/exception.txt", "current detail\n")
-	var stdout bytes.Buffer
-	var calls []recordedCommand
-	opts := testEvalOptions(t, &calls, io.Discard)
-	opts.jobsDir = jobsDir
-	opts.jobsDirExplicit = true
-	opts.stdout = &stdout
-	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
-		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
-		if len(calls) == 2 {
-			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
-			return fakeExitError{code: 7}
-		}
-		return nil
-	}
-
-	err := runEval(opts, []string{path})
-	var exitErr ExitCodeError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
-	}
-	output := string(ansi.Strip(stdout.Bytes()))
-	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "current detail") {
-		t.Fatalf("output = %q", stdout.String())
-	}
-	if strings.Contains(output, "other detail") {
-		t.Fatalf("output = %q", stdout.String())
-	}
-}
-
-func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) evalOptions {
+func restoreEvalRunner(t *testing.T, fn func(harbor.EvalOptions) evalRunner) {
 	t.Helper()
-	return evalOptions{
-		agent:       "oracle",
-		jobsDir:     defaultEvalJobsDir,
-		runmeBin:    "/bin/runme",
-		commandRun:  recordCommand(calls),
-		lookPath:    fakeLookPath,
-		executable:  func() (string, error) { return "/bin/current-runme", nil },
-		stdout:      io.Discard,
-		stderr:      stderr,
-		preflight:   true,
-		runmeHarbor: "",
-	}
-}
-
-func recordCommand(calls *[]recordedCommand) commandRunFunc {
-	return func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
-		*calls = append(*calls, recordedCommand{
-			name:       name,
-			args:       append([]string(nil), args...),
-			workingDir: workingDir,
-			env:        append([]string(nil), env...),
-		})
-		return nil
-	}
-}
-
-func fakeLookPath(name string) (string, error) {
-	switch name {
-	case "runme-harbor":
-		return "/bin/runme-harbor", nil
-	case "/env/runme-harbor", "/flag/runme-harbor":
-		return name, nil
-	default:
-		return "", os.ErrNotExist
-	}
-}
-
-func sameCommand(got, want recordedCommand) bool {
-	return got.name == want.name && reflect.DeepEqual(got.args, want.args)
-}
-
-func mustAbs(t *testing.T, path string) string {
-	t.Helper()
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return abs
-}
-
-func defaultJobsDir(t *testing.T) string {
-	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return filepath.Join(defaultEvalBaseDir(cwd), defaultEvalJobsDir)
-}
-
-func defaultDatasetPath(t *testing.T) string {
-	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	return filepath.Join(defaultEvalBaseDir(cwd), defaultEvalDatasetPath)
-}
-
-func envValue(env []string, key string) string {
-	prefix := key + "="
-	for _, item := range env {
-		if strings.HasPrefix(item, prefix) {
-			return strings.TrimPrefix(item, prefix)
-		}
-	}
-	return ""
-}
-
-func makeExecutable(t *testing.T, name string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	return path
-}
-
-func makeHarborDockerDataset(t *testing.T, workspace string, remoteWorkdir string) (string, string, string) {
-	t.Helper()
-	dataset := filepath.Join(workspace, "evals", "tasks")
-	task := filepath.Join(dataset, "example-task")
-	workdir := filepath.Join(workspace, "source", "workdir")
-	target := filepath.Join(task, "environment", "workdir")
-	if err := os.MkdirAll(workdir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(task, "environment"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	config := "schema_version = \"1.1\"\n\n[environment]\nworkdir = \"" + remoteWorkdir + "\"\n"
-	if err := os.WriteFile(filepath.Join(task, "task.toml"), []byte(config), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	return dataset, workdir, target
-}
-
-func writeEvalException(t *testing.T, jobsDir, relativePath, content string) {
-	t.Helper()
-	path := filepath.Join(jobsDir, relativePath)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	previous := newEvalRunner
+	newEvalRunner = fn
+	t.Cleanup(func() {
+		newEvalRunner = previous
+	})
 }

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
 )
 
 type recordedCommand struct {
@@ -674,6 +677,128 @@ func TestRunEvalPropagatesDelegateExitCode(t *testing.T) {
 	}
 }
 
+func TestRunEvalPrintsExceptionDetailsAfterHarborOutput(t *testing.T) {
+	path := t.TempDir()
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
+	resultPath := filepath.Join(jobDir, "result.json")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.jobsDir = jobsDir
+	opts.jobsDirExplicit = true
+	opts.stdout = &stdout
+	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		if len(calls) == 2 {
+			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+			writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "HarborProtocolError: runme failed with useful context\n")
+			return fakeExitError{code: 7}
+		}
+		return nil
+	}
+
+	err := runEval(opts, []string{path})
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Exception           Count\nHarborProtocolError 1\nResults written to "+resultPath+"\n\nHarbor Exception Details\n") {
+		t.Fatalf("output = %q", output)
+	}
+	if !strings.Contains(output, "File: end-to-end__abc/exception.txt") {
+		t.Fatalf("output = %q", output)
+	}
+	if !strings.Contains(output, "HarborProtocolError: runme failed with useful context") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunEvalPrintsExceptionDetailsForDockerEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	dataset, _, _ := makeHarborDockerDataset(t, workspace, "/app/source/workdir")
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
+	resultPath := filepath.Join(jobDir, "result.json")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.env = "docker"
+	opts.jobsDir = jobsDir
+	opts.jobsDirExplicit = true
+	opts.stdout = &stdout
+	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+		writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "ValueError: docker detail should be visible\n")
+		return fakeExitError{code: 7}
+	}
+
+	err := runEval(opts, []string{dataset})
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "ValueError: docker detail should be visible") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+}
+
+func TestRunEvalOnlyPrintsExceptionDetailsForReportedJob(t *testing.T) {
+	path := t.TempDir()
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "current")
+	resultPath := filepath.Join(jobDir, "result.json")
+	writeEvalException(t, jobsDir, "other/attempt/exception.txt", "other detail\n")
+	writeEvalException(t, jobDir, "attempt/exception.txt", "current detail\n")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.jobsDir = jobsDir
+	opts.jobsDirExplicit = true
+	opts.stdout = &stdout
+	opts.commandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		if len(calls) == 2 {
+			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+			return fakeExitError{code: 7}
+		}
+		return nil
+	}
+
+	err := runEval(opts, []string{path})
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "current detail") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+	if strings.Contains(output, "other detail") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+}
+
+func TestHarborResultPathWriterStreamsBeforeNewline(t *testing.T) {
+	var stdout bytes.Buffer
+	writer := &harborResultPathWriter{dst: &stdout}
+
+	if _, err := writer.Write([]byte("1/1 Mean: 0.000")); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "1/1 Mean: 0.000" {
+		t.Fatalf("stdout = %q, want streamed partial line", got)
+	}
+	if got := writer.ResultPath(); got != "" {
+		t.Fatalf("result path = %q, want empty before result line", got)
+	}
+}
+
 func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) evalOptions {
 	t.Helper()
 	return evalOptions{
@@ -780,4 +905,15 @@ func makeHarborDockerDataset(t *testing.T, workspace string, remoteWorkdir strin
 		t.Fatal(err)
 	}
 	return dataset, workdir, target
+}
+
+func writeEvalException(t *testing.T, jobsDir, relativePath, content string) {
+	t.Helper()
+	path := filepath.Join(jobsDir, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/internal/ansi/color.go
+++ b/internal/ansi/color.go
@@ -1,8 +1,10 @@
 package ansi
 
 import (
+	"io"
 	"os"
 
+	"github.com/mattn/go-isatty"
 	"github.com/mgutz/ansi"
 )
 
@@ -23,4 +25,28 @@ func Color(s string, style string) string {
 	}
 
 	return ansi.Color(s, style)
+}
+
+// ColorForWriter colors s only when w is connected to a terminal.
+func ColorForWriter(w io.Writer, s, style string) string {
+	if !WriterSupportsColor(w) {
+		return s
+	}
+	return Color(s, style)
+}
+
+// WriterSupportsColor reports whether w is connected to a terminal that can display ANSI colors.
+func WriterSupportsColor(w io.Writer) bool {
+	if file, ok := w.(*os.File); ok {
+		return isTerminal(file.Fd())
+	}
+	if provider, ok := w.(interface{ StdoutFile() *os.File }); ok {
+		file := provider.StdoutFile()
+		return file != nil && isTerminal(file.Fd())
+	}
+	return false
+}
+
+func isTerminal(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
 }

--- a/internal/ansi/color_test.go
+++ b/internal/ansi/color_test.go
@@ -1,0 +1,49 @@
+package ansi
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type stdoutFileWriter struct {
+	file *os.File
+}
+
+func (w stdoutFileWriter) Write(p []byte) (int, error) {
+	return w.file.Write(p)
+}
+
+func (w stdoutFileWriter) StdoutFile() *os.File {
+	return w.file
+}
+
+func TestColorForWriterLeavesNonTerminalOutputPlain(t *testing.T) {
+	var stdout bytes.Buffer
+
+	got := ColorForWriter(&stdout, "plain", "red+b")
+
+	if got != "plain" {
+		t.Fatalf("ColorForWriter() = %q, want plain", got)
+	}
+}
+
+func TestWriterSupportsColorRejectsNonTerminalFile(t *testing.T) {
+	file, err := os.Create(filepath.Join(t.TempDir(), "stdout"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = file.Close() }()
+
+	if WriterSupportsColor(file) {
+		t.Fatal("WriterSupportsColor() = true, want false for regular file")
+	}
+	if WriterSupportsColor(stdoutFileWriter{file: file}) {
+		t.Fatal("WriterSupportsColor() = true, want false for wrapper around regular file")
+	}
+	if strings.Contains(ColorForWriter(stdoutFileWriter{file: file}, "plain", "red+b"), "\x1b[") {
+		t.Fatal("ColorForWriter() returned ANSI escapes for wrapper around regular file")
+	}
+}

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -337,6 +337,8 @@ func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, std
 	defer func() { _ = tty.Close() }()
 	_ = pty.InheritSize(stdoutFile, ptmx)
 
+	// Only stdout is bridged through a PTY so Harbor's Rich progress output
+	// keeps terminal rendering while eval itself stays non-interactive.
 	cmd.Stdout = tty
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -1,0 +1,413 @@
+package harbor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/creack/pty"
+	"github.com/mattn/go-isatty"
+
+	"github.com/runmedev/runme/v3/project"
+)
+
+const (
+	DefaultEvalDatasetPath = "evals/tasks"
+	DefaultEvalJobsDir     = ".runme/evals/jobs"
+)
+
+var ErrRunmeHarborMissing = errors.New("runme-harbor missing")
+
+type EvalOptions struct {
+	Agent           string
+	TaskDir         string
+	JobsDir         string
+	Yes             bool
+	Model           string
+	Env             string
+	RunmeBin        string
+	RunmeArgs       []string
+	RunmeHarborBin  string
+	Debug           bool
+	JobsDirExplicit bool
+	CommandRun      CommandRunFunc
+	LookPath        func(string) (string, error)
+	Executable      func() (string, error)
+	Stdin           io.Reader
+	Stdout          io.Writer
+	Stderr          io.Writer
+	ExtraEnv        []string
+	Preflight       bool
+}
+
+type CommandRunFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error
+
+type EvalRunner struct {
+	opts EvalOptions
+}
+
+func NewEvalRunner(opts EvalOptions) *EvalRunner {
+	if opts.Agent == "" {
+		opts.Agent = "oracle"
+	}
+	if opts.JobsDir == "" {
+		opts.JobsDir = DefaultEvalJobsDir
+	}
+	if opts.CommandRun == nil {
+		opts.CommandRun = runExternalCommand
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	if opts.Executable == nil {
+		opts.Executable = os.Executable
+	}
+	if opts.Stdin == nil {
+		opts.Stdin = os.Stdin
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	return &EvalRunner{opts: opts}
+}
+
+func (r *EvalRunner) Run(args []string) error {
+	opts := r.opts
+	datasetPath, passthrough, defaultDataset, evalBaseDir, err := resolveEvalPaths(&opts, args)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(datasetPath); err != nil {
+		if os.IsNotExist(err) {
+			if defaultDataset {
+				return fmt.Errorf("dataset path does not exist: %s; create it or pass a dataset path explicitly", DefaultEvalDatasetPath)
+			}
+			return fmt.Errorf("dataset path does not exist: %s", datasetPath)
+		}
+		return err
+	}
+
+	if opts.Model != "" && containsModelFlag(passthrough) {
+		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
+	}
+	if containsEnvironmentFlag(passthrough) {
+		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
+	}
+
+	runmeHarbor, err := resolveRunmeHarbor(opts)
+	if err != nil {
+		return err
+	}
+
+	runmeBin, err := resolveRunmeBin(opts)
+	if err != nil {
+		return err
+	}
+
+	env := os.Environ()
+	env = setEnv(env, "RUNME_BIN", runmeBin)
+	if len(opts.RunmeArgs) > 0 {
+		env = setEnv(env, "RUNME_ARGS", joinShellArgs(opts.RunmeArgs))
+	}
+	env = append(env, opts.ExtraEnv...)
+
+	if usesHarborDockerEnvironment(opts.Env) {
+		stager, err := NewDockerWorkdirStager(DockerWorkdirStagerOptions{
+			Stderr: opts.Stderr,
+		})
+		if err != nil {
+			return err
+		}
+		if err := stager.StageDataset(datasetPath); err != nil {
+			return err
+		}
+	}
+
+	if opts.Preflight && usesRunmeEnvironment(opts.Env) {
+		request := strings.NewReader("{\"id\":\"preflight\",\"preflight\":{}}\n")
+		if err := opts.CommandRun(runmeBin, []string{"harbor", "stdio"}, "", env, request, io.Discard, opts.Stderr); err != nil {
+			return fmt.Errorf("runme harbor stdio preflight failed: %w", err)
+		}
+	}
+
+	delegatedArgs := buildRunmeHarborArgs(datasetPath, opts, passthrough)
+	if opts.Debug {
+		_, _ = fmt.Fprintf(opts.Stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
+	}
+
+	harborStdout := NewResultPathWriter(opts.Stdout)
+	err = opts.CommandRun(runmeHarbor, delegatedArgs, evalBaseDir, env, opts.Stdin, harborStdout, opts.Stderr)
+	if jobDir := JobDirFromResultPath(harborStdout.ResultPath(), evalBaseDir); jobDir != "" {
+		PrintExceptionDetails(opts.Stdout, jobDir)
+	}
+	return err
+}
+
+func resolveEvalPaths(opts *EvalOptions, args []string) (string, []string, bool, string, error) {
+	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
+	baseDir, err := evalDefaultBaseDir()
+	if err != nil {
+		return "", nil, false, "", err
+	}
+	if !opts.JobsDirExplicit {
+		opts.JobsDir = filepath.Join(baseDir, DefaultEvalJobsDir)
+	}
+	if defaultDataset {
+		return filepath.Join(baseDir, DefaultEvalDatasetPath), passthrough, true, baseDir, nil
+	}
+
+	datasetPath, err := filepath.Abs(datasetArg)
+	if err != nil {
+		return "", nil, false, "", err
+	}
+	return datasetPath, passthrough, false, baseDir, nil
+}
+
+func evalDefaultBaseDir() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return defaultEvalBaseDir(cwd), nil
+}
+
+func splitEvalDatasetArg(args []string) (string, bool, []string) {
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return DefaultEvalDatasetPath, true, args
+	}
+	return args[0], false, args[1:]
+}
+
+func defaultEvalBaseDir(cwd string) string {
+	proj, err := project.NewDirProject(
+		cwd,
+		project.WithFindRepoUpward(),
+		project.WithAllowUnsupportedGitExtensions(true),
+		project.WithRespectGitignore(false),
+	)
+	if err != nil {
+		return cwd
+	}
+	return proj.Root()
+}
+
+func resolveRunmeHarbor(opts EvalOptions) (string, error) {
+	candidates := []string{}
+	if value := os.Getenv("RUNME_HARBOR_BIN"); value != "" {
+		candidates = append(candidates, value)
+	}
+	if opts.RunmeHarborBin != "" {
+		candidates = append(candidates, opts.RunmeHarborBin)
+	}
+	candidates = append(candidates, "runme-harbor")
+
+	for _, candidate := range candidates {
+		resolved, err := resolveExecutable(candidate, opts.LookPath)
+		if err == nil {
+			return resolved, nil
+		}
+		if candidate != "runme-harbor" {
+			return "", fmt.Errorf("runme-harbor executable %q not found: %w", candidate, err)
+		}
+	}
+	return "", ErrRunmeHarborMissing
+}
+
+func resolveRunmeBin(opts EvalOptions) (string, error) {
+	if opts.RunmeBin != "" {
+		return opts.RunmeBin, nil
+	}
+	if opts.Executable != nil {
+		if current, err := opts.Executable(); err == nil && current != "" {
+			return current, nil
+		}
+	}
+	return "runme", nil
+}
+
+func resolveExecutable(name string, lookPath func(string) (string, error)) (string, error) {
+	if strings.ContainsRune(name, rune(os.PathSeparator)) {
+		info, err := os.Stat(name)
+		if err != nil {
+			return "", err
+		}
+		if info.IsDir() {
+			return "", fmt.Errorf("%s is a directory", name)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+			return "", fmt.Errorf("%s is not executable", name)
+		}
+		return name, nil
+	}
+	return lookPath(name)
+}
+
+func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, passthrough []string) []string {
+	args := []string{
+		"run",
+		datasetPath,
+		"--agent", opts.Agent,
+		"--jobs-dir", opts.JobsDir,
+	}
+	if opts.TaskDir != "" {
+		args = append(args, "--task-dir", opts.TaskDir)
+	}
+	if opts.Yes {
+		args = append(args, "-y")
+	}
+	if opts.Debug {
+		args = append(args, "--debug")
+	}
+	if opts.Env != "" {
+		args = append(args, "--env", opts.Env)
+	}
+	delegatedPassthrough := append([]string(nil), passthrough...)
+	if opts.Model != "" {
+		delegatedPassthrough = append(delegatedPassthrough, "--model", opts.Model)
+	}
+	if len(delegatedPassthrough) > 0 {
+		args = append(args, "--")
+		args = append(args, delegatedPassthrough...)
+	}
+	return args
+}
+
+func containsModelFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--model" || strings.HasPrefix(arg, "--model=") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEnvironmentFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--env" || arg == "-e" || arg == "--environment-import-path" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--env=") || strings.HasPrefix(arg, "-e") && len(arg) > 2 {
+			return true
+		}
+		if strings.HasPrefix(arg, "--environment-import-path=") {
+			return true
+		}
+	}
+	return false
+}
+
+func usesRunmeEnvironment(env string) bool {
+	return env == "" || env == "runme"
+}
+
+func usesHarborDockerEnvironment(env string) bool {
+	return env == "docker"
+}
+
+func runExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workingDir
+	cmd.Env = env
+	if provider, ok := stdout.(interface{ StdoutFile() *os.File }); ok {
+		if file := provider.StdoutFile(); file != nil && isTerminal(file.Fd()) {
+			return runExternalCommandWithPtyStdout(cmd, stdin, stdout, stderr, file)
+		}
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Stdin = stdin
+	return cmd.Run()
+}
+
+func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer, stdoutFile *os.File) error {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = tty.Close() }()
+	_ = pty.InheritSize(stdoutFile, ptmx)
+
+	cmd.Stdout = tty
+	cmd.Stderr = stderr
+	cmd.Stdin = stdin
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_ = tty.Close()
+
+	copyDone := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(stdout, ptmx)
+		copyDone <- err
+	}()
+
+	waitErr := cmd.Wait()
+	_ = ptmx.Close()
+	copyErr := <-copyDone
+	if waitErr != nil {
+		return waitErr
+	}
+	if copyErr != nil && !errors.Is(copyErr, os.ErrClosed) {
+		if errors.Is(copyErr, syscall.EIO) {
+			return nil
+		}
+		return copyErr
+	}
+	return nil
+}
+
+func isTerminal(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	for i, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			env[i] = prefix + value
+			return env
+		}
+	}
+	return append(env, prefix+value)
+}
+
+func joinShellArgs(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellCommandString(args []string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		quoted = append(quoted, shellQuote(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.IndexFunc(value, func(r rune) bool {
+		return (r < 'A' || r > 'Z') &&
+			(r < 'a' || r > 'z') &&
+			(r < '0' || r > '9') &&
+			!strings.ContainsRune("@%_+=:,./-", r)
+	}) == -1 {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}

--- a/internal/harbor/eval_result.go
+++ b/internal/harbor/eval_result.go
@@ -128,7 +128,7 @@ func exceptionDisplayPath(jobDir, path string) string {
 	if err != nil || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || relative == ".." {
 		return path
 	}
-	return relative
+	return filepath.ToSlash(relative)
 }
 
 func exceptionFiles(jobDir string) []string {

--- a/internal/harbor/eval_result.go
+++ b/internal/harbor/eval_result.go
@@ -117,11 +117,24 @@ func PrintExceptionDetails(w io.Writer, jobDir string) {
 		}
 		if !printed {
 			_, _ = fmt.Fprintln(w)
-			_, _ = fmt.Fprintln(w, ansi.Color("Harbor Exception Details", "red+b"))
+			_, _ = fmt.Fprintln(w, exceptionDetailsHeading(w))
 			printed = true
 		}
 		_, _ = fmt.Fprintf(w, "\nFile: %s\n%s\n", exceptionDisplayPath(jobDir, path), detail)
 	}
+}
+
+func exceptionDetailsHeading(w io.Writer) string {
+	const heading = "Harbor Exception Details"
+	if file, ok := w.(*os.File); ok && isTerminal(file.Fd()) {
+		return ansi.Color(heading, "red+b")
+	}
+	if provider, ok := w.(interface{ StdoutFile() *os.File }); ok {
+		if file := provider.StdoutFile(); file != nil && isTerminal(file.Fd()) {
+			return ansi.Color(heading, "red+b")
+		}
+	}
+	return heading
 }
 
 func exceptionDisplayPath(jobDir, path string) string {

--- a/internal/harbor/eval_result.go
+++ b/internal/harbor/eval_result.go
@@ -48,6 +48,7 @@ func (w *ResultPathWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// ResultPath finalizes any pending output line and returns the last result path seen.
 func (w *ResultPathWriter) ResultPath() string {
 	if len(w.line) > 0 && !w.lineTooLong {
 		w.recordLine(w.line)
@@ -75,6 +76,8 @@ func (w *ResultPathWriter) appendLine(p []byte) {
 }
 
 func (w *ResultPathWriter) recordLine(line []byte) {
+	// Harbor currently reports result locations only through this human-readable line.
+	// Keep this coupling local until Harbor exposes a machine-readable marker.
 	const prefix = "Results written to "
 	text := strings.TrimSpace(string(ansi.Strip(line)))
 	index := strings.Index(text, prefix)
@@ -121,8 +124,8 @@ func PrintExceptionDetails(w io.Writer, jobDir string) {
 	}
 }
 
-func exceptionDisplayPath(jobsDir, path string) string {
-	relative, err := filepath.Rel(jobsDir, path)
+func exceptionDisplayPath(jobDir, path string) string {
+	relative, err := filepath.Rel(jobDir, path)
 	if err != nil || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || relative == ".." {
 		return path
 	}

--- a/internal/harbor/eval_result.go
+++ b/internal/harbor/eval_result.go
@@ -1,0 +1,143 @@
+package harbor
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
+)
+
+const maxResultLineLen = 64 * 1024
+
+type ResultPathWriter struct {
+	dst         io.Writer
+	line        []byte
+	lineTooLong bool
+	resultPath  string
+}
+
+// NewResultPathWriter returns a writer that forwards Harbor output while capturing the result path.
+func NewResultPathWriter(dst io.Writer) *ResultPathWriter {
+	return &ResultPathWriter{dst: dst}
+}
+
+func (w *ResultPathWriter) Write(p []byte) (int, error) {
+	// Forward Harbor output before inspecting it so progress and tables keep streaming.
+	n, err := w.dst.Write(p)
+	remaining := p[:n]
+	for len(remaining) > 0 {
+		index := bytes.IndexByte(remaining, '\n')
+		if index < 0 {
+			w.appendLine(remaining)
+			break
+		}
+		w.appendLine(remaining[:index])
+		if !w.lineTooLong {
+			w.recordLine(w.line)
+		}
+		w.line = w.line[:0]
+		w.lineTooLong = false
+		remaining = remaining[index+1:]
+	}
+	return n, err
+}
+
+func (w *ResultPathWriter) ResultPath() string {
+	if len(w.line) > 0 && !w.lineTooLong {
+		w.recordLine(w.line)
+		w.line = nil
+	}
+	return w.resultPath
+}
+
+// StdoutFile returns the forwarded stdout file when Harbor output is connected to one.
+func (w *ResultPathWriter) StdoutFile() *os.File {
+	file, _ := w.dst.(*os.File)
+	return file
+}
+
+func (w *ResultPathWriter) appendLine(p []byte) {
+	if w.lineTooLong {
+		return
+	}
+	if len(w.line)+len(p) > maxResultLineLen {
+		w.line = w.line[:0]
+		w.lineTooLong = true
+		return
+	}
+	w.line = append(w.line, p...)
+}
+
+func (w *ResultPathWriter) recordLine(line []byte) {
+	const prefix = "Results written to "
+	text := strings.TrimSpace(string(ansi.Strip(line)))
+	index := strings.Index(text, prefix)
+	if index == -1 {
+		return
+	}
+	w.resultPath = strings.TrimSpace(text[index+len(prefix):])
+}
+
+// JobDirFromResultPath returns the eval job directory containing Harbor's result file.
+func JobDirFromResultPath(resultPath, evalBaseDir string) string {
+	if resultPath == "" {
+		return ""
+	}
+	if !filepath.IsAbs(resultPath) && evalBaseDir != "" {
+		resultPath = filepath.Join(evalBaseDir, resultPath)
+	}
+	return filepath.Dir(resultPath)
+}
+
+// PrintExceptionDetails appends Harbor exception file details for an eval job.
+func PrintExceptionDetails(w io.Writer, jobDir string) {
+	paths := exceptionFiles(jobDir)
+	if len(paths) == 0 {
+		return
+	}
+
+	printed := false
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		detail := strings.TrimSpace(string(content))
+		if detail == "" {
+			continue
+		}
+		if !printed {
+			_, _ = fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w, ansi.Color("Harbor Exception Details", "red+b"))
+			printed = true
+		}
+		_, _ = fmt.Fprintf(w, "\nFile: %s\n%s\n", exceptionDisplayPath(jobDir, path), detail)
+	}
+}
+
+func exceptionDisplayPath(jobsDir, path string) string {
+	relative, err := filepath.Rel(jobsDir, path)
+	if err != nil || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) || relative == ".." {
+		return path
+	}
+	return relative
+}
+
+func exceptionFiles(jobDir string) []string {
+	var paths []string
+	_ = filepath.WalkDir(jobDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Base(path) != "exception.txt" {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	sort.Strings(paths)
+	return paths
+}

--- a/internal/harbor/eval_result.go
+++ b/internal/harbor/eval_result.go
@@ -116,25 +116,11 @@ func PrintExceptionDetails(w io.Writer, jobDir string) {
 			continue
 		}
 		if !printed {
-			_, _ = fmt.Fprintln(w)
-			_, _ = fmt.Fprintln(w, exceptionDetailsHeading(w))
+			_, _ = fmt.Fprintln(w, ansi.ColorForWriter(w, "Harbor Exception Details", "red+b"))
 			printed = true
 		}
 		_, _ = fmt.Fprintf(w, "\nFile: %s\n%s\n", exceptionDisplayPath(jobDir, path), detail)
 	}
-}
-
-func exceptionDetailsHeading(w io.Writer) string {
-	const heading = "Harbor Exception Details"
-	if file, ok := w.(*os.File); ok && isTerminal(file.Fd()) {
-		return ansi.Color(heading, "red+b")
-	}
-	if provider, ok := w.(interface{ StdoutFile() *os.File }); ok {
-		if file := provider.StdoutFile(); file != nil && isTerminal(file.Fd()) {
-			return ansi.Color(heading, "red+b")
-		}
-	}
-	return heading
 }
 
 func exceptionDisplayPath(jobDir, path string) string {

--- a/internal/harbor/eval_result_test.go
+++ b/internal/harbor/eval_result_test.go
@@ -1,0 +1,70 @@
+package harbor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
+)
+
+func TestResultPathWriterStreamsBeforeNewline(t *testing.T) {
+	var stdout bytes.Buffer
+	writer := NewResultPathWriter(&stdout)
+
+	if _, err := writer.Write([]byte("1/1 Mean: 0.000")); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "1/1 Mean: 0.000" {
+		t.Fatalf("stdout = %q, want streamed partial line", got)
+	}
+	if got := writer.ResultPath(); got != "" {
+		t.Fatalf("result path = %q, want empty before result line", got)
+	}
+}
+
+func TestResultPathWriterRecordsResultPath(t *testing.T) {
+	var stdout bytes.Buffer
+	writer := NewResultPathWriter(&stdout)
+	resultPath := filepath.Join(t.TempDir(), "result.json")
+
+	if _, err := writer.Write([]byte("Results written to " + resultPath + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got := writer.ResultPath(); got != resultPath {
+		t.Fatalf("result path = %q, want %q", got, resultPath)
+	}
+}
+
+func TestPrintExceptionDetailsOnlyUsesReportedJob(t *testing.T) {
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "current")
+	writeException(t, filepath.Join(jobsDir, "other", "attempt", "exception.txt"), "other detail\n")
+	writeException(t, filepath.Join(jobDir, "attempt", "exception.txt"), "current detail\n")
+
+	var stdout bytes.Buffer
+	PrintExceptionDetails(&stdout, jobDir)
+
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "current detail") {
+		t.Fatalf("output = %q", output)
+	}
+	if strings.Contains(output, "other detail") {
+		t.Fatalf("output = %q", output)
+	}
+	if !strings.Contains(output, "File: attempt/exception.txt") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func writeException(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/harbor/eval_result_test.go
+++ b/internal/harbor/eval_result_test.go
@@ -59,6 +59,21 @@ func TestPrintExceptionDetailsOnlyUsesReportedJob(t *testing.T) {
 	}
 }
 
+func TestPrintExceptionDetailsDoesNotColorNonTerminalOutput(t *testing.T) {
+	jobDir := t.TempDir()
+	writeException(t, filepath.Join(jobDir, "attempt", "exception.txt"), "current detail\n")
+
+	var stdout bytes.Buffer
+	PrintExceptionDetails(&stdout, jobDir)
+
+	if strings.Contains(stdout.String(), "\x1b[") {
+		t.Fatalf("output contains ANSI escape sequence: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Harbor Exception Details") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+}
+
 func writeException(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/harbor/eval_result_test.go
+++ b/internal/harbor/eval_result_test.go
@@ -69,6 +69,9 @@ func TestPrintExceptionDetailsDoesNotColorNonTerminalOutput(t *testing.T) {
 	if strings.Contains(stdout.String(), "\x1b[") {
 		t.Fatalf("output contains ANSI escape sequence: %q", stdout.String())
 	}
+	if strings.HasPrefix(stdout.String(), "\n") {
+		t.Fatalf("output starts with extra newline: %q", stdout.String())
+	}
 	if !strings.Contains(stdout.String(), "Harbor Exception Details") {
 		t.Fatalf("output = %q", stdout.String())
 	}

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -640,7 +640,7 @@ func TestRunEvalPrintsExceptionDetailsAfterHarborOutput(t *testing.T) {
 	}
 
 	output := string(ansi.Strip(stdout.Bytes()))
-	if !strings.Contains(output, "Exception           Count\nHarborProtocolError 1\nResults written to "+resultPath+"\n\nHarbor Exception Details\n") {
+	if !strings.Contains(output, "Exception           Count\nHarborProtocolError 1\nResults written to "+resultPath+"\nHarbor Exception Details\n") {
 		t.Fatalf("output = %q", output)
 	}
 	if !strings.Contains(output, "File: end-to-end__abc/exception.txt") {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -1,0 +1,837 @@
+package harbor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
+)
+
+type recordedCommand struct {
+	name       string
+	args       []string
+	workingDir string
+	env        []string
+}
+
+type fakeExitError struct {
+	code int
+}
+
+func (e fakeExitError) Error() string {
+	return "failed"
+}
+
+func (e fakeExitError) ExitCode() int {
+	return e.code
+}
+
+func TestRunEvalDelegatesOracle(t *testing.T) {
+	path := t.TempDir()
+	var stderr bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, &stderr)
+	opts.Debug = true
+
+	err := NewEvalRunner(opts).Run([]string{
+		path,
+		"--extra",
+		"value",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantPreflight := recordedCommand{
+		name: "/bin/runme",
+		args: []string{"harbor", "stdio"},
+	}
+	wantDelegate := recordedCommand{
+		name: "/bin/runme-harbor",
+		args: []string{
+			"run",
+			mustAbs(t, path),
+			"--agent", "oracle",
+			"--jobs-dir", defaultJobsDir(t),
+			"--debug",
+			"--",
+			"--extra",
+			"value",
+		},
+	}
+	if !sameCommand(calls[0], wantPreflight) {
+		t.Fatalf("preflight = %#v, want %#v", calls[0], wantPreflight)
+	}
+	if !sameCommand(calls[1], wantDelegate) {
+		t.Fatalf("delegate = %#v, want %#v", calls[1], wantDelegate)
+	}
+	wantDebug := shellCommandString(append([]string{wantDelegate.name}, wantDelegate.args...)) + "\n"
+	if stderr.String() != wantDebug {
+		t.Fatalf("debug output = %q, want %q", stderr.String(), wantDebug)
+	}
+	if got := envValue(calls[1].env, "RUNME_BIN"); got != "/bin/runme" {
+		t.Fatalf("RUNME_BIN = %q, want /bin/runme", got)
+	}
+}
+
+func TestRunEvalDefaultsDatasetPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalDatasetPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		defaultDatasetPath(t),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
+	}
+}
+
+func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalDatasetPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{"--model", "haiku"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		defaultDatasetPath(t),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"--",
+		"--model", "haiku",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != defaultEvalBaseDir(tmp) {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, defaultEvalBaseDir(tmp))
+	}
+}
+
+func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, DefaultEvalDatasetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		filepath.Join(baseDir, DefaultEvalDatasetPath),
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	}
+}
+
+func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	dataset := filepath.Join(nested, "custom-dataset")
+	if err := os.MkdirAll(dataset, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{"./custom-dataset"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		dataset,
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	}
+}
+
+func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, DefaultEvalDatasetPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+	baseDir := defaultEvalBaseDir(nested)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.JobsDir = "custom/jobs"
+	opts.JobsDirExplicit = true
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		filepath.Join(baseDir, DefaultEvalDatasetPath),
+		"--agent", "oracle",
+		"--jobs-dir", "custom/jobs",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	}
+}
+
+func TestRunEvalDelegatesCodexAndClaudeOptions(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		agent string
+	}{
+		{name: "codex", agent: "codex"},
+		{name: "claude-code", agent: "claude-code"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.Agent = tt.agent
+			opts.TaskDir = "simple-agent"
+			opts.JobsDir = "jobs"
+			opts.JobsDirExplicit = true
+			opts.Yes = true
+
+			err := NewEvalRunner(opts).Run([]string{path})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := []string{
+				"run",
+				mustAbs(t, path),
+				"--agent", tt.agent,
+				"--jobs-dir", "jobs",
+				"--task-dir", "simple-agent",
+				"-y",
+			}
+			if !reflect.DeepEqual(calls[1].args, want) {
+				t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+			}
+		})
+	}
+}
+
+func TestRunEvalDelegatesModel(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Model = "haiku"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"--",
+		"--model", "haiku",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalPreservesPassthroughModel(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{path, "--model", "haiku"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"--",
+		"--model", "haiku",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalRejectsDuplicateModel(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		passthrough []string
+	}{
+		{name: "separate arg", passthrough: []string{"--model", "sonnet"}},
+		{name: "equals arg", passthrough: []string{"--model=sonnet"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.Model = "haiku"
+
+			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "--model cannot be used together with passthrough --model") {
+				t.Fatalf("error = %q", err.Error())
+			}
+			if len(calls) != 0 {
+				t.Fatalf("calls = %#v, want none", calls)
+			}
+		})
+	}
+}
+
+func TestRunEvalDelegatesRunmeEnvAlias(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Env = "runme"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantPreflight := recordedCommand{
+		name: "/bin/runme",
+		args: []string{"harbor", "stdio"},
+	}
+	wantDelegate := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"--env", "runme",
+	}
+	if !sameCommand(calls[0], wantPreflight) {
+		t.Fatalf("preflight = %#v, want %#v", calls[0], wantPreflight)
+	}
+	if !reflect.DeepEqual(calls[1].args, wantDelegate) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, wantDelegate)
+	}
+}
+
+func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Env = "docker"
+	opts.Agent = "codex"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "codex",
+		"--jobs-dir", defaultJobsDir(t),
+		"--env", "docker",
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %#v, want delegate only", calls)
+	}
+	if !reflect.DeepEqual(calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+}
+
+func TestRunEvalDoesNotStageNonDockerWorkdir(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	dataset, workdir, target := makeHarborDockerDataset(t, workspace, "/app/source/workdir")
+	if err := os.WriteFile(filepath.Join(workdir, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Env = "podman"
+
+	err := NewEvalRunner(opts).Run([]string{dataset})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target stat err = %v, want not exist", err)
+	}
+}
+
+func TestRunEvalRejectsPassthroughEnvironmentFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		passthrough []string
+	}{
+		{name: "env separate", passthrough: []string{"--env", "docker"}},
+		{name: "env equals", passthrough: []string{"--env=docker"}},
+		{name: "env shorthand separate", passthrough: []string{"-e", "docker"}},
+		{name: "env shorthand joined", passthrough: []string{"-edocker"}},
+		{name: "import path separate", passthrough: []string{"--environment-import-path", "pkg:Env"}},
+		{name: "import path equals", passthrough: []string{"--environment-import-path=pkg:Env"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+
+			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "use runme eval --env") {
+				t.Fatalf("error = %q", err.Error())
+			}
+			if len(calls) != 0 {
+				t.Fatalf("calls = %#v, want none", calls)
+			}
+		})
+	}
+}
+
+func TestRunEvalUsesEnvAndRunmeArgs(t *testing.T) {
+	envHarbor := makeExecutable(t, "env-runme-harbor")
+	flagHarbor := makeExecutable(t, "flag-runme-harbor")
+	t.Setenv("RUNME_HARBOR_BIN", envHarbor)
+	t.Setenv("RUNME_ARGS", "--existing")
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.RunmeHarborBin = flagHarbor
+	opts.RunmeBin = "/flag/runme"
+	opts.RunmeArgs = []string{"--chdir", "/tmp/with space", "--label=can't-$expand`this`\\path"}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if calls[1].name != envHarbor {
+		t.Fatalf("runme-harbor = %q, want env override", calls[1].name)
+	}
+	if got := envValue(calls[1].env, "RUNME_BIN"); got != "/flag/runme" {
+		t.Fatalf("RUNME_BIN = %q, want /flag/runme", got)
+	}
+	if got := envValue(calls[1].env, "RUNME_ARGS"); got != "--chdir '/tmp/with space' '--label=can'\\''t-$expand`this`\\path'" {
+		t.Fatalf("RUNME_ARGS = %q", got)
+	}
+}
+
+func TestRunEvalPreservesExistingRunmeArgs(t *testing.T) {
+	t.Setenv("RUNME_ARGS", "--existing")
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := envValue(calls[1].env, "RUNME_ARGS"); got != "--existing" {
+		t.Fatalf("RUNME_ARGS = %q, want preserved env", got)
+	}
+}
+
+func TestRunEvalMissingRunmeHarbor(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.LookPath = func(string) (string, error) {
+		return "", os.ErrNotExist
+	}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrRunmeHarborMissing) {
+		t.Fatalf("error = %q, want ErrRunmeHarborMissing", err.Error())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls = %#v, want none", calls)
+	}
+}
+
+func TestRunEvalDelegatesUnknownAgent(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Agent = "bad"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "bad",
+		"--jobs-dir", defaultJobsDir(t),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalMissingPath(t *testing.T) {
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{filepath.Join(t.TempDir(), "missing")})
+	if err == nil || !strings.Contains(err.Error(), "dataset path does not exist") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunEvalMissingDefaultPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "dataset path does not exist: evals/tasks") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "pass a dataset path explicitly") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls = %#v, want none", calls)
+	}
+}
+
+func TestRunEvalPropagatesDelegateExitCode(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.CommandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		if len(calls) == 2 {
+			return fakeExitError{code: 42}
+		}
+		return nil
+	}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	var exitErr fakeExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want fakeExitError", err, err)
+	}
+	if exitErr.ExitCode() != 42 {
+		t.Fatalf("exit code = %d, want 42", exitErr.ExitCode())
+	}
+}
+
+func TestRunEvalPrintsExceptionDetailsAfterHarborOutput(t *testing.T) {
+	path := t.TempDir()
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
+	resultPath := filepath.Join(jobDir, "result.json")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.JobsDir = jobsDir
+	opts.JobsDirExplicit = true
+	opts.Stdout = &stdout
+	opts.CommandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		if len(calls) == 2 {
+			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+			writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "HarborProtocolError: runme failed with useful context\n")
+			return fakeExitError{code: 7}
+		}
+		return nil
+	}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	var exitErr fakeExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want fakeExitError", err, err)
+	}
+
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Exception           Count\nHarborProtocolError 1\nResults written to "+resultPath+"\n\nHarbor Exception Details\n") {
+		t.Fatalf("output = %q", output)
+	}
+	if !strings.Contains(output, "File: end-to-end__abc/exception.txt") {
+		t.Fatalf("output = %q", output)
+	}
+	if !strings.Contains(output, "HarborProtocolError: runme failed with useful context") {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunEvalPrintsExceptionDetailsForDockerEnvironment(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	dataset, _, _ := makeHarborDockerDataset(t, workspace, "/app/source/workdir")
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "2026-06-18__10-51-14")
+	resultPath := filepath.Join(jobDir, "result.json")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Env = "docker"
+	opts.JobsDir = jobsDir
+	opts.JobsDirExplicit = true
+	opts.Stdout = &stdout
+	opts.CommandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+		writeEvalException(t, jobDir, "end-to-end__abc/exception.txt", "ValueError: docker detail should be visible\n")
+		return fakeExitError{code: 7}
+	}
+
+	err := NewEvalRunner(opts).Run([]string{dataset})
+	var exitErr fakeExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want fakeExitError", err, err)
+	}
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "ValueError: docker detail should be visible") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+}
+
+func TestRunEvalOnlyPrintsExceptionDetailsForReportedJob(t *testing.T) {
+	path := t.TempDir()
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	jobDir := filepath.Join(jobsDir, "current")
+	resultPath := filepath.Join(jobDir, "result.json")
+	writeEvalException(t, jobsDir, "other/attempt/exception.txt", "other detail\n")
+	writeEvalException(t, jobDir, "attempt/exception.txt", "current detail\n")
+	var stdout bytes.Buffer
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.JobsDir = jobsDir
+	opts.JobsDirExplicit = true
+	opts.Stdout = &stdout
+	opts.CommandRun = func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdoutWriter, stderr io.Writer) error {
+		calls = append(calls, recordedCommand{name: name, args: append([]string(nil), args...), workingDir: workingDir, env: env})
+		if len(calls) == 2 {
+			_, _ = fmt.Fprintf(stdoutWriter, "Exception           Count\nHarborProtocolError 1\nResults written to %s\n", resultPath)
+			return fakeExitError{code: 7}
+		}
+		return nil
+	}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	var exitErr fakeExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want fakeExitError", err, err)
+	}
+	output := string(ansi.Strip(stdout.Bytes()))
+	if !strings.Contains(output, "Harbor Exception Details") || !strings.Contains(output, "current detail") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+	if strings.Contains(output, "other detail") {
+		t.Fatalf("output = %q", stdout.String())
+	}
+}
+
+func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) EvalOptions {
+	t.Helper()
+	return EvalOptions{
+		Agent:          "oracle",
+		JobsDir:        DefaultEvalJobsDir,
+		RunmeBin:       "/bin/runme",
+		CommandRun:     recordCommand(calls),
+		LookPath:       fakeLookPath,
+		Executable:     func() (string, error) { return "/bin/current-runme", nil },
+		Stdout:         io.Discard,
+		Stderr:         stderr,
+		Preflight:      true,
+		RunmeHarborBin: "",
+	}
+}
+
+func recordCommand(calls *[]recordedCommand) CommandRunFunc {
+	return func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) error {
+		*calls = append(*calls, recordedCommand{
+			name:       name,
+			args:       append([]string(nil), args...),
+			workingDir: workingDir,
+			env:        append([]string(nil), env...),
+		})
+		return nil
+	}
+}
+
+func fakeLookPath(name string) (string, error) {
+	switch name {
+	case "runme-harbor":
+		return "/bin/runme-harbor", nil
+	case "/env/runme-harbor", "/flag/runme-harbor":
+		return name, nil
+	default:
+		return "", os.ErrNotExist
+	}
+}
+
+func sameCommand(got, want recordedCommand) bool {
+	return got.name == want.name && reflect.DeepEqual(got.args, want.args)
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+func defaultJobsDir(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalJobsDir)
+}
+
+func defaultDatasetPath(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalDatasetPath)
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
+}
+
+func makeExecutable(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func makeHarborDockerDataset(t *testing.T, workspace string, remoteWorkdir string) (string, string, string) {
+	t.Helper()
+	dataset := filepath.Join(workspace, "evals", "tasks")
+	task := filepath.Join(dataset, "example-task")
+	workdir := filepath.Join(workspace, "source", "workdir")
+	target := filepath.Join(task, "environment", "workdir")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(task, "environment"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := "schema_version = \"1.1\"\n\n[environment]\nworkdir = \"" + remoteWorkdir + "\"\n"
+	if err := os.WriteFile(filepath.Join(task, "task.toml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dataset, workdir, target
+}
+
+func writeEvalException(t *testing.T, jobsDir, relativePath, content string) {
+	t.Helper()
+	path := filepath.Join(jobsDir, relativePath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/creack/pty"
 	"github.com/go-git/go-git/v5"
 
 	"github.com/runmedev/runme/v3/internal/ansi"
@@ -717,6 +719,62 @@ func TestRunEvalOnlyPrintsExceptionDetailsForReportedJob(t *testing.T) {
 	}
 }
 
+func TestRunExternalCommandUsesPtyWhenStdoutIsTerminal(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("open pty: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = tty.Close() }()
+
+	stdout := &terminalCapture{file: tty}
+	err = runExternalCommand(
+		testShell(t),
+		[]string{"-c", "if [ -t 1 ]; then printf tty; else printf pipe; fi"},
+		"",
+		os.Environ(),
+		nil,
+		stdout,
+		io.Discard,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "tty" {
+		t.Fatalf("stdout = %q, want tty", got)
+	}
+}
+
+func TestRunExternalCommandWithPtyStdoutReturnsExitError(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("open pty: %v", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+	defer func() { _ = tty.Close() }()
+
+	stdout := &terminalCapture{file: tty}
+	err = runExternalCommand(
+		testShell(t),
+		[]string{"-c", "printf before-exit; exit 7"},
+		"",
+		os.Environ(),
+		nil,
+		stdout,
+		io.Discard,
+	)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %[1]v, want *exec.ExitError", err)
+	}
+	if exitErr.ExitCode() != 7 {
+		t.Fatalf("exit code = %d, want 7", exitErr.ExitCode())
+	}
+	if got := stdout.String(); got != "before-exit" {
+		t.Fatalf("stdout = %q, want before-exit", got)
+	}
+}
+
 func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) EvalOptions {
 	t.Helper()
 	return EvalOptions{
@@ -731,6 +789,24 @@ func testEvalOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) E
 		Preflight:      true,
 		RunmeHarborBin: "",
 	}
+}
+
+type terminalCapture struct {
+	bytes.Buffer
+	file *os.File
+}
+
+func (w *terminalCapture) StdoutFile() *os.File {
+	return w.file
+}
+
+func testShell(t *testing.T) string {
+	t.Helper()
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not found")
+	}
+	return shell
 }
 
 func recordCommand(calls *[]recordedCommand) CommandRunFunc {


### PR DESCRIPTION
## Summary

Append Harbor exception details below Harbor's normal eval summary output when `runme eval` produces exception files for the reported Harbor job.

The CLI now wraps delegated Harbor stdout with an in-process tee writer: it forwards Harbor output unchanged while capturing Harbor's `Results written to .../result.json` line. After Harbor exits, Runme scans only that result file's job directory for `exception.txt` files, avoiding stale or concurrent jobs in the same jobs root.

The appended section uses a bold red Harbor-style heading and labels each source as a relative `File:` path, keeping the traceback readable without repeating a long absolute jobs path.

## Validation

- `go test ./cmd -run 'TestRunEval(PrintsExceptionDetailsAfterHarborOutput|PrintsExceptionDetailsForDockerEnvironment|OnlyPrintsExceptionDetailsForReportedJob)'`
- `runme run lint test`