### PR TITLE
fix: auto-confirm runme eval by default

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -17,7 +17,7 @@ type evalOptions struct {
 	agent           string
 	taskDir         string
 	jobsDir         string
-	yes             bool
+	ask             bool
 	model           string
 	env             string
 	runmeBin        string
@@ -64,7 +64,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags.StringVar(&opts.agent, "agent", "oracle", "Harbor agent to use")
 	flags.StringVar(&opts.taskDir, "task-dir", "", "Task directory name to include from the Harbor dataset")
 	flags.StringVar(&opts.jobsDir, "jobs-dir", harbor.DefaultEvalJobsDir, "Eval jobs directory")
-	flags.BoolVarP(&opts.yes, "yes", "y", false, "Confirm Harbor prompts")
+	flags.BoolVar(&opts.ask, "ask", false, "Do not auto-accept Harbor confirmation prompts")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
 	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
 	flags.StringVar(&opts.runmeBin, "runme-bin", "", "Runme binary used by the Harbor environment")
@@ -80,7 +80,7 @@ func runEval(opts evalOptions, args []string) error {
 		Agent:           opts.agent,
 		TaskDir:         opts.taskDir,
 		JobsDir:         opts.jobsDir,
-		Yes:             opts.yes,
+		Ask:             opts.ask,
 		Model:           opts.model,
 		Env:             opts.env,
 		RunmeBin:        opts.runmeBin,

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -43,7 +43,7 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		"--agent", "codex",
 		"--task-dir", "simple-agent",
 		"--jobs-dir", "jobs",
-		"--yes",
+		"--ask",
 		"--model", "haiku",
 		"--env", "docker",
 		"--runme-bin", "/bin/runme",
@@ -72,7 +72,7 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		gotOpts.TaskDir != "simple-agent" ||
 		gotOpts.JobsDir != "jobs" ||
 		!gotOpts.JobsDirExplicit ||
-		!gotOpts.Yes ||
+		!gotOpts.Ask ||
 		gotOpts.Model != "haiku" ||
 		gotOpts.Env != "docker" ||
 		gotOpts.RunmeBin != "/bin/runme" ||
@@ -116,6 +116,29 @@ func TestEvalCmdRejectsTaskNameFlag(t *testing.T) {
 	}
 }
 
+func TestEvalCmdRejectsYesFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{t.TempDir(), "-y"},
+		{t.TempDir(), "--yes"},
+	} {
+		t.Run(strings.Join(args[1:], " "), func(t *testing.T) {
+			cmd := evalCmd()
+			cmd.SetArgs(args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "unknown shorthand flag: 'y'") &&
+				!strings.Contains(err.Error(), "unknown flag: --yes") {
+				t.Fatalf("error = %q", err.Error())
+			}
+		})
+	}
+}
+
 func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 	cmd := evalCmd()
 	var stdout bytes.Buffer
@@ -134,6 +157,9 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), `Defaults to "runme"`) {
+		t.Fatalf("help output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `--ask`) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 }

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -28,7 +28,7 @@ type EvalOptions struct {
 	Agent           string
 	TaskDir         string
 	JobsDir         string
-	Yes             bool
+	Ask             bool
 	Model           string
 	Env             string
 	RunmeBin        string
@@ -261,7 +261,7 @@ func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, passthrough []st
 	if opts.TaskDir != "" {
 		args = append(args, "--task-dir", opts.TaskDir)
 	}
-	if opts.Yes {
+	if !opts.Ask {
 		args = append(args, "-y")
 	}
 	if opts.Debug {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -64,6 +64,7 @@ func TestRunEvalDelegatesOracle(t *testing.T) {
 			mustAbs(t, path),
 			"--agent", "oracle",
 			"--jobs-dir", defaultJobsDir(t),
+			"-y",
 			"--debug",
 			"--",
 			"--extra",
@@ -104,6 +105,7 @@ func TestRunEvalDefaultsDatasetPath(t *testing.T) {
 		defaultDatasetPath(t),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -132,6 +134,7 @@ func TestRunEvalDefaultsDatasetPathWithPassthrough(t *testing.T) {
 		defaultDatasetPath(t),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 		"--",
 		"--model", "haiku",
 	}
@@ -170,6 +173,7 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 		filepath.Join(baseDir, DefaultEvalDatasetPath),
 		"--agent", "oracle",
 		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -204,6 +208,7 @@ func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 		dataset,
 		"--agent", "oracle",
 		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -242,6 +247,7 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 		filepath.Join(baseDir, DefaultEvalDatasetPath),
 		"--agent", "oracle",
 		"--jobs-dir", "custom/jobs",
+		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -267,7 +273,6 @@ func TestRunEvalDelegatesCodexAndClaudeOptions(t *testing.T) {
 			opts.TaskDir = "simple-agent"
 			opts.JobsDir = "jobs"
 			opts.JobsDirExplicit = true
-			opts.Yes = true
 
 			err := NewEvalRunner(opts).Run([]string{path})
 			if err != nil {
@@ -289,6 +294,28 @@ func TestRunEvalDelegatesCodexAndClaudeOptions(t *testing.T) {
 	}
 }
 
+func TestRunEvalAskDoesNotDelegateYes(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Ask = true
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
 func TestRunEvalDelegatesModel(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
@@ -305,6 +332,7 @@ func TestRunEvalDelegatesModel(t *testing.T) {
 		mustAbs(t, path),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 		"--",
 		"--model", "haiku",
 	}
@@ -328,6 +356,7 @@ func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 		mustAbs(t, path),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 		"--",
 		"--model", "haiku",
 	}
@@ -384,6 +413,7 @@ func TestRunEvalDelegatesRunmeEnvAlias(t *testing.T) {
 		mustAbs(t, path),
 		"--agent", "oracle",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 		"--env", "runme",
 	}
 	if !sameCommand(calls[0], wantPreflight) {
@@ -411,6 +441,7 @@ func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
 		mustAbs(t, path),
 		"--agent", "codex",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 		"--env", "docker",
 	}
 	if len(calls) != 1 {
@@ -553,6 +584,7 @@ func TestRunEvalDelegatesUnknownAgent(t *testing.T) {
 		mustAbs(t, path),
 		"--agent", "bad",
 		"--jobs-dir", defaultJobsDir(t),
+		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)


### PR DESCRIPTION
## Summary
- forward Harbor `-y` by default from `runme eval`
- add `--ask` to request Harbor confirmation prompts instead
- remove public `-y/--yes` from `runme eval`; `-y` is now only the internal Harbor delegation detail

## Tests
- `go test ./cmd -run 'TestRunEval|TestEvalCmd'`\n- `runme run test`