### PR TITLE
feat: add eval agent kwargs flag

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/runmedev/runme/v3/internal/harbor"
 )
@@ -18,6 +19,7 @@ type evalOptions struct {
 	taskDir         string
 	jobsDir         string
 	ask             bool
+	agentKwargs     []string
 	model           string
 	env             string
 	runmeBin        string
@@ -61,10 +63,18 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	}
 
 	flags := cmd.Flags()
+	previousNormalize := flags.GetNormalizeFunc()
+	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "ak" {
+			name = "agent-kwarg"
+		}
+		return previousNormalize(f, name)
+	})
 	flags.StringVar(&opts.agent, "agent", "oracle", "Harbor agent to use")
 	flags.StringVar(&opts.taskDir, "task-dir", "", "Task directory name to include from the Harbor dataset")
 	flags.StringVar(&opts.jobsDir, "jobs-dir", harbor.DefaultEvalJobsDir, "Eval jobs directory")
 	flags.BoolVar(&opts.ask, "ask", false, "Do not auto-accept Harbor confirmation prompts")
+	flags.StringArrayVar(&opts.agentKwargs, "agent-kwarg", nil, "Harbor agent kwarg; can be repeated; alias: --ak")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
 	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
 	flags.StringVar(&opts.runmeBin, "runme-bin", "", "Runme binary used by the Harbor environment")
@@ -81,6 +91,7 @@ func runEval(opts evalOptions, args []string) error {
 		TaskDir:         opts.taskDir,
 		JobsDir:         opts.jobsDir,
 		Ask:             opts.ask,
+		AgentKwargs:     opts.agentKwargs,
 		Model:           opts.model,
 		Env:             opts.env,
 		RunmeBin:        opts.runmeBin,

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -44,6 +44,8 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		"--task-dir", "simple-agent",
 		"--jobs-dir", "jobs",
 		"--ask",
+		"--agent-kwarg", "reasoning_effort=xhigh",
+		"--ak", "sandbox_mode=workspace-write",
 		"--model", "haiku",
 		"--env", "docker",
 		"--runme-bin", "/bin/runme",
@@ -73,6 +75,7 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		gotOpts.JobsDir != "jobs" ||
 		!gotOpts.JobsDirExplicit ||
 		!gotOpts.Ask ||
+		!reflect.DeepEqual(gotOpts.AgentKwargs, []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write"}) ||
 		gotOpts.Model != "haiku" ||
 		gotOpts.Env != "docker" ||
 		gotOpts.RunmeBin != "/bin/runme" ||
@@ -160,6 +163,9 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), `--ask`) {
+		t.Fatalf("help output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `alias: --ak`) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 }

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -29,6 +29,7 @@ type EvalOptions struct {
 	TaskDir         string
 	JobsDir         string
 	Ask             bool
+	AgentKwargs     []string
 	Model           string
 	Env             string
 	RunmeBin        string
@@ -98,6 +99,9 @@ func (r *EvalRunner) Run(args []string) error {
 
 	if opts.Model != "" && containsModelFlag(passthrough) {
 		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
+	}
+	if len(opts.AgentKwargs) > 0 && containsAgentKwargFlag(passthrough) {
+		return fmt.Errorf("--agent-kwarg cannot be used together with passthrough --agent-kwarg/--ak; use only runme eval --agent-kwarg")
 	}
 	if containsEnvironmentFlag(passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
@@ -271,6 +275,9 @@ func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, passthrough []st
 		args = append(args, "--env", opts.Env)
 	}
 	delegatedPassthrough := append([]string(nil), passthrough...)
+	for _, kwarg := range opts.AgentKwargs {
+		delegatedPassthrough = append(delegatedPassthrough, "--agent-kwarg", kwarg)
+	}
 	if opts.Model != "" {
 		delegatedPassthrough = append(delegatedPassthrough, "--model", opts.Model)
 	}
@@ -284,6 +291,18 @@ func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, passthrough []st
 func containsModelFlag(args []string) bool {
 	for _, arg := range args {
 		if arg == "--model" || strings.HasPrefix(arg, "--model=") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAgentKwargFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--agent-kwarg" || arg == "--ak" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--agent-kwarg=") || strings.HasPrefix(arg, "--ak=") {
 			return true
 		}
 	}

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -341,6 +341,32 @@ func TestRunEvalDelegatesModel(t *testing.T) {
 	}
 }
 
+func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.AgentKwargs = []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write"}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"-y",
+		"--",
+		"--agent-kwarg", "reasoning_effort=xhigh",
+		"--agent-kwarg", "sandbox_mode=workspace-write",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
 func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
@@ -359,6 +385,31 @@ func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 		"-y",
 		"--",
 		"--model", "haiku",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalPreservesPassthroughAgentKwargs(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{path, "--ak", "reasoning_effort=xhigh", "--agent-kwarg=sandbox_mode=workspace-write"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"-y",
+		"--",
+		"--ak", "reasoning_effort=xhigh",
+		"--agent-kwarg=sandbox_mode=workspace-write",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -384,6 +435,36 @@ func TestRunEvalRejectsDuplicateModel(t *testing.T) {
 				t.Fatal("expected error")
 			}
 			if !strings.Contains(err.Error(), "--model cannot be used together with passthrough --model") {
+				t.Fatalf("error = %q", err.Error())
+			}
+			if len(calls) != 0 {
+				t.Fatalf("calls = %#v, want none", calls)
+			}
+		})
+	}
+}
+
+func TestRunEvalRejectsDuplicateAgentKwargs(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		passthrough []string
+	}{
+		{name: "long separate arg", passthrough: []string{"--agent-kwarg", "sandbox_mode=workspace-write"}},
+		{name: "long equals arg", passthrough: []string{"--agent-kwarg=sandbox_mode=workspace-write"}},
+		{name: "alias separate arg", passthrough: []string{"--ak", "sandbox_mode=workspace-write"}},
+		{name: "alias equals arg", passthrough: []string{"--ak=sandbox_mode=workspace-write"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.AgentKwargs = []string{"reasoning_effort=xhigh"}
+
+			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "--agent-kwarg cannot be used together with passthrough") {
 				t.Fatalf("error = %q", err.Error())
 			}
 			if len(calls) != 0 {


### PR DESCRIPTION
## Summary

- add top-level repeatable `runme eval --agent-kwarg` support
- add `--ak` as a long alias via Cobra/pflag name normalization
- delegate top-level agent kwargs to Harbor as repeated `--agent-kwarg <value>` passthrough args
- keep passthrough-only `--ak/--agent-kwarg` working, but reject mixed top-level + passthrough usage

## Test

```bash
go test ./cmd ./internal/harbor -run 'TestRunEval|TestEvalCmd|TestEvalRunner'
runme run test
```
