### PR TITLE
fix: delegate copy-pasteable eval paths to Harbor

### DIFF
--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -53,6 +53,15 @@ type EvalRunner struct {
 	opts EvalOptions
 }
 
+type evalPaths struct {
+	datasetPath         string
+	delegateDatasetPath string
+	delegateJobsDir     string
+	passthrough         []string
+	defaultDataset      bool
+	invocationCwd       string
+}
+
 func NewEvalRunner(opts EvalOptions) *EvalRunner {
 	if opts.Agent == "" {
 		opts.Agent = "oracle"
@@ -83,27 +92,27 @@ func NewEvalRunner(opts EvalOptions) *EvalRunner {
 
 func (r *EvalRunner) Run(args []string) error {
 	opts := r.opts
-	datasetPath, passthrough, defaultDataset, evalBaseDir, err := resolveEvalPaths(&opts, args)
+	paths, err := resolveEvalPaths(&opts, args)
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(datasetPath); err != nil {
+	if _, err := os.Stat(paths.datasetPath); err != nil {
 		if os.IsNotExist(err) {
-			if defaultDataset {
+			if paths.defaultDataset {
 				return fmt.Errorf("dataset path does not exist: %s; create it or pass a dataset path explicitly", DefaultEvalDatasetPath)
 			}
-			return fmt.Errorf("dataset path does not exist: %s", datasetPath)
+			return fmt.Errorf("dataset path does not exist: %s", paths.datasetPath)
 		}
 		return err
 	}
 
-	if opts.Model != "" && containsModelFlag(passthrough) {
+	if opts.Model != "" && containsModelFlag(paths.passthrough) {
 		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
 	}
-	if len(opts.AgentKwargs) > 0 && containsAgentKwargFlag(passthrough) {
+	if len(opts.AgentKwargs) > 0 && containsAgentKwargFlag(paths.passthrough) {
 		return fmt.Errorf("--agent-kwarg cannot be used together with passthrough --agent-kwarg/--ak; use only runme eval --agent-kwarg")
 	}
-	if containsEnvironmentFlag(passthrough) {
+	if containsEnvironmentFlag(paths.passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
 	}
 
@@ -131,7 +140,7 @@ func (r *EvalRunner) Run(args []string) error {
 		if err != nil {
 			return err
 		}
-		if err := stager.StageDataset(datasetPath); err != nil {
+		if err := stager.StageDataset(paths.datasetPath); err != nil {
 			return err
 		}
 	}
@@ -143,45 +152,100 @@ func (r *EvalRunner) Run(args []string) error {
 		}
 	}
 
-	delegatedArgs := buildRunmeHarborArgs(datasetPath, opts, passthrough)
+	delegatedArgs := buildRunmeHarborArgs(paths.delegateDatasetPath, opts, paths.delegateJobsDir, paths.passthrough)
 	if opts.Debug {
 		_, _ = fmt.Fprintf(opts.Stderr, "%s\n", shellCommandString(append([]string{runmeHarbor}, delegatedArgs...)))
 	}
 
 	harborStdout := NewResultPathWriter(opts.Stdout)
-	err = opts.CommandRun(runmeHarbor, delegatedArgs, evalBaseDir, env, opts.Stdin, harborStdout, opts.Stderr)
-	if jobDir := JobDirFromResultPath(harborStdout.ResultPath(), evalBaseDir); jobDir != "" {
+	err = opts.CommandRun(runmeHarbor, delegatedArgs, paths.invocationCwd, env, opts.Stdin, harborStdout, opts.Stderr)
+	if jobDir := JobDirFromResultPath(harborStdout.ResultPath(), paths.invocationCwd); jobDir != "" {
 		PrintExceptionDetails(opts.Stdout, jobDir)
 	}
 	return err
 }
 
-func resolveEvalPaths(opts *EvalOptions, args []string) (string, []string, bool, string, error) {
+func resolveEvalPaths(opts *EvalOptions, args []string) (evalPaths, error) {
 	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
-	baseDir, err := evalDefaultBaseDir()
+	invocationCwd, err := os.Getwd()
 	if err != nil {
-		return "", nil, false, "", err
+		return evalPaths{}, err
 	}
+	baseDir := defaultEvalBaseDir(invocationCwd)
+
+	var datasetPath string
+	var delegateDatasetPath string
+	if defaultDataset {
+		datasetPath = filepath.Join(baseDir, DefaultEvalDatasetPath)
+		delegateDatasetPath, err = relativePathFrom(invocationCwd, datasetPath)
+	} else {
+		datasetPath, delegateDatasetPath, err = resolveExplicitDelegatePath(datasetArg, invocationCwd)
+	}
+	if err != nil {
+		return evalPaths{}, err
+	}
+
+	var delegateJobsDir string
 	if !opts.JobsDirExplicit {
 		opts.JobsDir = filepath.Join(baseDir, DefaultEvalJobsDir)
+		delegateJobsDir, err = relativePathFrom(invocationCwd, opts.JobsDir)
+	} else {
+		_, delegateJobsDir, err = resolveExplicitDelegatePath(opts.JobsDir, invocationCwd)
 	}
-	if defaultDataset {
-		return filepath.Join(baseDir, DefaultEvalDatasetPath), passthrough, true, baseDir, nil
+	if err != nil {
+		return evalPaths{}, err
 	}
 
-	datasetPath, err := filepath.Abs(datasetArg)
-	if err != nil {
-		return "", nil, false, "", err
-	}
-	return datasetPath, passthrough, false, baseDir, nil
+	return evalPaths{
+		datasetPath:         datasetPath,
+		delegateDatasetPath: delegateDatasetPath,
+		delegateJobsDir:     delegateJobsDir,
+		passthrough:         passthrough,
+		defaultDataset:      defaultDataset,
+		invocationCwd:       invocationCwd,
+	}, nil
 }
 
-func evalDefaultBaseDir() (string, error) {
-	cwd, err := os.Getwd()
+func resolveExplicitDelegatePath(path, invocationCwd string) (string, string, error) {
+	if filepath.IsAbs(path) {
+		resolved := filepath.Clean(path)
+		delegated, err := relativePathUnder(invocationCwd, resolved)
+		if err != nil {
+			return "", "", err
+		}
+		if delegated == "" {
+			delegated = resolved
+		}
+		return resolved, delegated, nil
+	}
+
+	resolved := filepath.Join(invocationCwd, path)
+	return resolved, filepath.Clean(path), nil
+}
+
+func relativePathFrom(base, path string) (string, error) {
+	relative, err := filepath.Rel(base, path)
 	if err != nil {
 		return "", err
 	}
-	return defaultEvalBaseDir(cwd), nil
+	if relative == "." {
+		return ".", nil
+	}
+	return filepath.Clean(relative), nil
+}
+
+func relativePathUnder(base, path string) (string, error) {
+	relative, err := filepath.Rel(base, path)
+	if err != nil {
+		return "", err
+	}
+	if relative == "." {
+		return ".", nil
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return "", nil
+	}
+	return filepath.Clean(relative), nil
 }
 
 func splitEvalDatasetArg(args []string) (string, bool, []string) {
@@ -255,12 +319,12 @@ func resolveExecutable(name string, lookPath func(string) (string, error)) (stri
 	return lookPath(name)
 }
 
-func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, passthrough []string) []string {
+func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, jobsDir string, passthrough []string) []string {
 	args := []string{
 		"run",
 		datasetPath,
 		"--agent", opts.Agent,
-		"--jobs-dir", opts.JobsDir,
+		"--jobs-dir", jobsDir,
 	}
 	if opts.TaskDir != "" {
 		args = append(args, "--task-dir", opts.TaskDir)

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -53,15 +53,6 @@ type EvalRunner struct {
 	opts EvalOptions
 }
 
-type evalPaths struct {
-	datasetPath         string
-	delegateDatasetPath string
-	delegateJobsDir     string
-	passthrough         []string
-	defaultDataset      bool
-	invocationCwd       string
-}
-
 func NewEvalRunner(opts EvalOptions) *EvalRunner {
 	if opts.Agent == "" {
 		opts.Agent = "oracle"
@@ -158,44 +149,62 @@ func (r *EvalRunner) Run(args []string) error {
 	}
 
 	harborStdout := NewResultPathWriter(opts.Stdout)
-	err = opts.CommandRun(runmeHarbor, delegatedArgs, paths.invocationCwd, env, opts.Stdin, harborStdout, opts.Stderr)
-	if jobDir := JobDirFromResultPath(harborStdout.ResultPath(), paths.invocationCwd); jobDir != "" {
+	err = opts.CommandRun(runmeHarbor, delegatedArgs, paths.executionCwd, env, opts.Stdin, harborStdout, opts.Stderr)
+	if jobDir := JobDirFromResultPath(harborStdout.ResultPath(), paths.executionCwd); jobDir != "" {
 		PrintExceptionDetails(opts.Stdout, jobDir)
 	}
 	return err
 }
 
+type evalPaths struct {
+	datasetPath         string
+	delegateDatasetPath string
+	delegateJobsDir     string
+	passthrough         []string
+	defaultDataset      bool
+	invocationCwd       string
+	executionCwd        string
+}
+
+type evalPathResolver struct {
+	opts          *EvalOptions
+	invocationCwd string
+	baseDir       string
+}
+
 func resolveEvalPaths(opts *EvalOptions, args []string) (evalPaths, error) {
-	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
 	invocationCwd, err := os.Getwd()
 	if err != nil {
 		return evalPaths{}, err
 	}
-	invocationCwd = cleanExistingPath(invocationCwd)
-	baseDir := defaultEvalBaseDir(invocationCwd)
+
+	resolver := evalPathResolver{
+		opts:          opts,
+		invocationCwd: cleanExistingPath(invocationCwd),
+	}
+	resolver.baseDir = defaultEvalBaseDir(resolver.invocationCwd)
+	return resolver.resolve(args), nil
+}
+
+func (r evalPathResolver) resolve(args []string) evalPaths {
+	datasetArg, defaultDataset, passthrough := splitEvalDatasetArg(args)
 
 	var datasetPath string
-	var delegateDatasetPath string
 	if defaultDataset {
-		datasetPath = filepath.Join(baseDir, DefaultEvalDatasetPath)
-		delegateDatasetPath, err = relativePathFrom(invocationCwd, datasetPath)
+		datasetPath = filepath.Join(r.baseDir, DefaultEvalDatasetPath)
 	} else {
-		datasetPath, delegateDatasetPath, err = resolveExplicitDelegatePath(datasetArg, invocationCwd)
-	}
-	if err != nil {
-		return evalPaths{}, err
+		datasetPath = r.inputPath(datasetArg)
 	}
 
-	var delegateJobsDir string
-	if !opts.JobsDirExplicit {
-		opts.JobsDir = filepath.Join(baseDir, DefaultEvalJobsDir)
-		delegateJobsDir, err = relativePathFrom(invocationCwd, opts.JobsDir)
+	executionCwd := r.executionCwd(datasetPath)
+	delegateDatasetPath := r.delegatePath(datasetPath, executionCwd)
+
+	if !r.opts.JobsDirExplicit {
+		r.opts.JobsDir = filepath.Join(r.baseDir, DefaultEvalJobsDir)
 	} else {
-		_, delegateJobsDir, err = resolveExplicitDelegatePath(opts.JobsDir, invocationCwd)
+		r.opts.JobsDir = r.inputPath(r.opts.JobsDir)
 	}
-	if err != nil {
-		return evalPaths{}, err
-	}
+	delegateJobsDir := r.delegateJobsPath(r.opts.JobsDir, executionCwd)
 
 	return evalPaths{
 		datasetPath:         datasetPath,
@@ -203,22 +212,39 @@ func resolveEvalPaths(opts *EvalOptions, args []string) (evalPaths, error) {
 		delegateJobsDir:     delegateJobsDir,
 		passthrough:         passthrough,
 		defaultDataset:      defaultDataset,
-		invocationCwd:       invocationCwd,
-	}, nil
+		invocationCwd:       r.invocationCwd,
+		executionCwd:        executionCwd,
+	}
 }
 
-func resolveExplicitDelegatePath(path, invocationCwd string) (string, string, error) {
+func (r evalPathResolver) inputPath(path string) string {
 	if filepath.IsAbs(path) {
-		resolved := filepath.Clean(path)
-		delegated := relativePathUnder(invocationCwd, resolved)
-		if delegated == "" {
-			delegated = resolved
-		}
-		return resolved, delegated, nil
+		return cleanExistingPath(path)
 	}
 
-	resolved := filepath.Join(invocationCwd, path)
-	return resolved, filepath.Clean(path), nil
+	return filepath.Clean(filepath.Join(r.invocationCwd, path))
+}
+
+func (r evalPathResolver) executionCwd(datasetPath string) string {
+	if relativePathUnder(r.baseDir, datasetPath) != "" {
+		return r.baseDir
+	}
+	return r.invocationCwd
+}
+
+func (r evalPathResolver) delegatePath(path, executionCwd string) string {
+	delegated := relativePathUnder(executionCwd, path)
+	if delegated == "" {
+		return filepath.Clean(path)
+	}
+	return delegated
+}
+
+func (r evalPathResolver) delegateJobsPath(path, executionCwd string) string {
+	if r.invocationCwd == executionCwd {
+		return r.delegatePath(path, executionCwd)
+	}
+	return filepath.Clean(path)
 }
 
 func cleanExistingPath(path string) string {
@@ -228,20 +254,32 @@ func cleanExistingPath(path string) string {
 	}
 	abs, err := filepath.Abs(path)
 	if err == nil {
-		return filepath.Clean(abs)
+		return cleanPathFromExistingParent(abs)
 	}
 	return filepath.Clean(path)
 }
 
-func relativePathFrom(base, path string) (string, error) {
-	relative, err := filepath.Rel(base, path)
-	if err != nil {
-		return filepath.Clean(path), nil
+func cleanPathFromExistingParent(path string) string {
+	cleaned := filepath.Clean(path)
+	current := cleaned
+	missing := []string{}
+
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return cleaned
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
 	}
-	if relative == "." {
-		return ".", nil
-	}
-	return filepath.Clean(relative), nil
 }
 
 func relativePathUnder(base, path string) string {

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -171,6 +171,7 @@ func resolveEvalPaths(opts *EvalOptions, args []string) (evalPaths, error) {
 	if err != nil {
 		return evalPaths{}, err
 	}
+	invocationCwd = cleanExistingPath(invocationCwd)
 	baseDir := defaultEvalBaseDir(invocationCwd)
 
 	var datasetPath string
@@ -209,10 +210,7 @@ func resolveEvalPaths(opts *EvalOptions, args []string) (evalPaths, error) {
 func resolveExplicitDelegatePath(path, invocationCwd string) (string, string, error) {
 	if filepath.IsAbs(path) {
 		resolved := filepath.Clean(path)
-		delegated, err := relativePathUnder(invocationCwd, resolved)
-		if err != nil {
-			return "", "", err
-		}
+		delegated := relativePathUnder(invocationCwd, resolved)
 		if delegated == "" {
 			delegated = resolved
 		}
@@ -223,10 +221,22 @@ func resolveExplicitDelegatePath(path, invocationCwd string) (string, string, er
 	return resolved, filepath.Clean(path), nil
 }
 
+func cleanExistingPath(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return filepath.Clean(resolved)
+	}
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
+}
+
 func relativePathFrom(base, path string) (string, error) {
 	relative, err := filepath.Rel(base, path)
 	if err != nil {
-		return "", err
+		return filepath.Clean(path), nil
 	}
 	if relative == "." {
 		return ".", nil
@@ -234,18 +244,18 @@ func relativePathFrom(base, path string) (string, error) {
 	return filepath.Clean(relative), nil
 }
 
-func relativePathUnder(base, path string) (string, error) {
+func relativePathUnder(base, path string) string {
 	relative, err := filepath.Rel(base, path)
 	if err != nil {
-		return "", err
+		return ""
 	}
 	if relative == "." {
-		return ".", nil
+		return "."
 	}
 	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
-		return "", nil
+		return ""
 	}
-	return filepath.Clean(relative), nil
+	return filepath.Clean(relative)
 }
 
 func splitEvalDatasetArg(args []string) (string, bool, []string) {

--- a/internal/harbor/eval_result_test.go
+++ b/internal/harbor/eval_result_test.go
@@ -38,6 +38,16 @@ func TestResultPathWriterRecordsResultPath(t *testing.T) {
 	}
 }
 
+func TestJobDirFromResultPathResolvesRelativeToBaseDir(t *testing.T) {
+	baseDir := t.TempDir()
+	resultPath := filepath.Join("..", "jobs", "current", "result.json")
+	want := filepath.Join(filepath.Dir(baseDir), "jobs", "current")
+
+	if got := JobDirFromResultPath(resultPath, baseDir); got != want {
+		t.Fatalf("job dir = %q, want %q", got, want)
+	}
+}
+
 func TestPrintExceptionDetailsOnlyUsesReportedJob(t *testing.T) {
 	jobsDir := filepath.Join(t.TempDir(), "jobs")
 	jobDir := filepath.Join(jobsDir, "current")

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -159,7 +159,6 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 
@@ -170,20 +169,20 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 
 	want := []string{
 		"run",
-		filepath.Join(baseDir, DefaultEvalDatasetPath),
+		filepath.Join("..", "..", DefaultEvalDatasetPath),
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+		"--jobs-dir", filepath.Join("..", "..", DefaultEvalJobsDir),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	if calls[1].workingDir != nested {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
 	}
 }
 
-func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
+func TestRunEvalExplicitDatasetUsesInvocationCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 	repoRoot := t.TempDir()
 	if _, err := git.PlainInit(repoRoot, false); err != nil {
 		t.Fatal(err)
@@ -194,7 +193,6 @@ func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 
@@ -205,20 +203,23 @@ func TestRunEvalExplicitDatasetUsesCwdAndDefaultJobsUseGitRoot(t *testing.T) {
 
 	want := []string{
 		"run",
-		dataset,
+		"custom-dataset",
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+		"--jobs-dir", filepath.Join("..", "..", DefaultEvalJobsDir),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	if calls[1].workingDir != nested {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
+	}
+	if _, err := os.Stat(dataset); err != nil {
+		t.Fatal(err)
 	}
 }
 
-func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
+func TestRunEvalExplicitJobsDirUsesInvocationCwd(t *testing.T) {
 	repoRoot := t.TempDir()
 	if _, err := git.PlainInit(repoRoot, false); err != nil {
 		t.Fatal(err)
@@ -231,7 +232,6 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(nested)
-	baseDir := defaultEvalBaseDir(nested)
 	var calls []recordedCommand
 	opts := testEvalOptions(t, &calls, io.Discard)
 	opts.JobsDir = "custom/jobs"
@@ -244,7 +244,7 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 
 	want := []string{
 		"run",
-		filepath.Join(baseDir, DefaultEvalDatasetPath),
+		filepath.Join("..", "..", DefaultEvalDatasetPath),
 		"--agent", "oracle",
 		"--jobs-dir", "custom/jobs",
 		"-y",
@@ -252,8 +252,66 @@ func TestRunEvalExplicitJobsDirIsUnchanged(t *testing.T) {
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != baseDir {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	if calls[1].workingDir != nested {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
+	}
+}
+
+func TestRunEvalExplicitAbsoluteJobsDirUnderCwdUsesRelativeDelegatePath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalDatasetPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.JobsDir = filepath.Join(tmp, "custom", "jobs")
+	opts.JobsDirExplicit = true
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		DefaultEvalDatasetPath,
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join("custom", "jobs"),
+		"-y",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalExplicitAbsolutePathsOutsideCwdStayAbsolute(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	dataset := filepath.Join(t.TempDir(), "tasks")
+	if err := os.MkdirAll(dataset, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := filepath.Join(t.TempDir(), "jobs")
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.JobsDir = jobsDir
+	opts.JobsDirExplicit = true
+
+	err := NewEvalRunner(opts).Run([]string{dataset})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		dataset,
+		"--agent", "oracle",
+		"--jobs-dir", jobsDir,
+		"-y",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
 }
 
@@ -964,7 +1022,11 @@ func defaultJobsDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalJobsDir)
+	path, err := relativePathFrom(cwd, filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalJobsDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func defaultDatasetPath(t *testing.T) string {
@@ -973,7 +1035,11 @@ func defaultDatasetPath(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalDatasetPath)
+	path, err := relativePathFrom(cwd, filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalDatasetPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func envValue(env []string, key string) string {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -166,19 +166,20 @@ func TestRunEvalDefaultsUseGitRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	baseDir := defaultEvalBaseDir(cleanExistingPath(nested))
 
 	want := []string{
 		"run",
-		filepath.Join("..", "..", DefaultEvalDatasetPath),
+		defaultDatasetArg(),
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join("..", "..", DefaultEvalJobsDir),
+		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != nested {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -200,22 +201,91 @@ func TestRunEvalExplicitDatasetUsesInvocationCwdAndDefaultJobsUseGitRoot(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
+	baseDir := defaultEvalBaseDir(cleanExistingPath(nested))
 
 	want := []string{
 		"run",
-		"custom-dataset",
+		filepath.Join("nested", "dir", "custom-dataset"),
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join("..", "..", DefaultEvalJobsDir),
+		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != nested {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 	if _, err := os.Stat(dataset); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRunEvalExplicitCurrentDatasetUnderGitRootRunsHarborFromGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	dataset := filepath.Join(repoRoot, "skills", "world-cup-picks-report", "evals", "regression")
+	if err := os.MkdirAll(dataset, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dataset)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDir := defaultEvalBaseDir(cleanExistingPath(dataset))
+
+	want := []string{
+		"run",
+		filepath.Join("skills", "world-cup-picks-report", "evals", "regression"),
+		"--agent", "oracle",
+		"--jobs-dir", filepath.Join(baseDir, DefaultEvalJobsDir),
+		"-y",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
+	}
+}
+
+func TestRunEvalExplicitNestedDatasetFromGitRootUsesCopyPasteableJobsDir(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	dataset := filepath.Join(repoRoot, "skills", "world-cup-picks-report", "evals", "regression")
+	if err := os.MkdirAll(dataset, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoRoot)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{filepath.Join("skills", "world-cup-picks-report", "evals", "regression")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseDir := defaultEvalBaseDir(cleanExistingPath(repoRoot))
+
+	want := []string{
+		"run",
+		filepath.Join("skills", "world-cup-picks-report", "evals", "regression"),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsArg(),
+		"-y",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -241,19 +311,20 @@ func TestRunEvalExplicitJobsDirUsesInvocationCwd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	baseDir := defaultEvalBaseDir(cleanExistingPath(nested))
 
 	want := []string{
 		"run",
-		filepath.Join("..", "..", DefaultEvalDatasetPath),
+		defaultDatasetArg(),
 		"--agent", "oracle",
-		"--jobs-dir", filepath.Join("custom", "jobs"),
+		"--jobs-dir", filepath.Join(cleanExistingPath(nested), "custom", "jobs"),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
 	}
-	if calls[1].workingDir != nested {
-		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, nested)
+	if calls[1].workingDir != baseDir {
+		t.Fatalf("workingDir = %q, want %q", calls[1].workingDir, baseDir)
 	}
 }
 
@@ -275,7 +346,7 @@ func TestRunEvalExplicitAbsoluteJobsDirUnderCwdUsesRelativeDelegatePath(t *testi
 
 	want := []string{
 		"run",
-		DefaultEvalDatasetPath,
+		defaultDatasetArg(),
 		"--agent", "oracle",
 		"--jobs-dir", filepath.Join("custom", "jobs"),
 		"-y",
@@ -305,9 +376,9 @@ func TestRunEvalExplicitAbsolutePathsOutsideCwdStayAbsolute(t *testing.T) {
 
 	want := []string{
 		"run",
-		dataset,
+		cleanExistingPath(dataset),
 		"--agent", "oracle",
-		"--jobs-dir", jobsDir,
+		"--jobs-dir", cleanExistingPath(jobsDir),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
@@ -1013,7 +1084,15 @@ func mustAbs(t *testing.T, path string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return abs
+	return cleanExistingPath(abs)
+}
+
+func defaultDatasetArg() string {
+	return filepath.FromSlash(DefaultEvalDatasetPath)
+}
+
+func defaultJobsArg() string {
+	return filepath.FromSlash(DefaultEvalJobsDir)
 }
 
 func defaultJobsDir(t *testing.T) string {
@@ -1022,11 +1101,11 @@ func defaultJobsDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	path, err := relativePathFrom(cwd, filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalJobsDir))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return path
+	cwd = cleanExistingPath(cwd)
+	baseDir := defaultEvalBaseDir(cwd)
+	resolver := evalPathResolver{invocationCwd: cwd, baseDir: baseDir}
+	jobsDir := filepath.Join(baseDir, DefaultEvalJobsDir)
+	return resolver.delegateJobsPath(jobsDir, resolver.executionCwd(jobsDir))
 }
 
 func defaultDatasetPath(t *testing.T) string {
@@ -1035,11 +1114,11 @@ func defaultDatasetPath(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	path, err := relativePathFrom(cwd, filepath.Join(defaultEvalBaseDir(cwd), DefaultEvalDatasetPath))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return path
+	cwd = cleanExistingPath(cwd)
+	baseDir := defaultEvalBaseDir(cwd)
+	resolver := evalPathResolver{invocationCwd: cwd, baseDir: baseDir}
+	datasetPath := filepath.Join(baseDir, DefaultEvalDatasetPath)
+	return resolver.delegatePath(datasetPath, resolver.executionCwd(datasetPath))
 }
 
 func envValue(env []string, key string) string {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -246,7 +246,7 @@ func TestRunEvalExplicitJobsDirUsesInvocationCwd(t *testing.T) {
 		"run",
 		filepath.Join("..", "..", DefaultEvalDatasetPath),
 		"--agent", "oracle",
-		"--jobs-dir", "custom/jobs",
+		"--jobs-dir", filepath.Join("custom", "jobs"),
 		"-y",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {


### PR DESCRIPTION
## Summary

- delegate `runme eval` dataset/jobs paths to `runme-harbor` as paths that are valid from the invocation cwd
- keep repo-root defaults while making Harbor's printed `harbor view` / `harbor upload` commands copy-pasteable
- keep Runme-side validation and Docker staging on resolved paths, and resolve relative Harbor result paths for exception printing

## Tests

- `go test ./cmd ./internal/harbor -run 'TestRunEval|TestEvalCmd|TestEvalRunner|TestResultPath|TestJobDirFromResultPath'`
- `runme run test`
