### PR TITLE
feat: add Runme Cursor CLI Harbor agent

### DIFF
--- a/integrations/harbor/src/runme_harbor/__init__.py
+++ b/integrations/harbor/src/runme_harbor/__init__.py
@@ -1,10 +1,11 @@
 from .environment import HarborProtocolError, RunmeEnvironment
-from .runme_agents import RunmeClaudeCode, RunmeCodex, RunmeOpenClaw
+from .runme_agents import RunmeClaudeCode, RunmeCodex, RunmeCursorCli, RunmeOpenClaw
 
 __all__ = [
     "HarborProtocolError",
     "RunmeClaudeCode",
     "RunmeCodex",
+    "RunmeCursorCli",
     "RunmeOpenClaw",
     "RunmeEnvironment",
 ]

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -15,6 +15,7 @@ from typing import Sequence
 ENVIRONMENT_IMPORT_PATH = "runme_harbor.environment:RunmeEnvironment"
 CODEX_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCodex"
 CLAUDE_IMPORT_PATH = "runme_harbor.runme_agents:RunmeClaudeCode"
+CURSOR_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCursorCli"
 OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
 MIN_HARBOR_VERSION = (0, 13, 1)
 MAX_HARBOR_VERSION = (0, 14, 0)
@@ -24,6 +25,7 @@ AGENT_ARGUMENTS = {
     "oracle": ("--agent", "oracle"),
     "codex": ("--agent-import-path", CODEX_IMPORT_PATH),
     "claude-code": ("--agent-import-path", CLAUDE_IMPORT_PATH),
+    "cursor-cli": ("--agent-import-path", CURSOR_IMPORT_PATH),
     "openclaw": ("--agent-import-path", OPENCLAW_IMPORT_PATH),
 }
 
@@ -182,6 +184,8 @@ def _preflight(agent: str) -> Path:
         raise SystemExit("`--agent codex` requires the `codex` CLI on PATH.")
     if agent == "claude-code" and not shutil.which("claude"):
         raise SystemExit("`--agent claude-code` requires the `claude` CLI on PATH.")
+    if agent == "cursor-cli" and not shutil.which("cursor-agent"):
+        raise SystemExit("`--agent cursor-cli` requires the `cursor-agent` CLI on PATH.")
     if agent == "openclaw" and not shutil.which("openclaw"):
         raise SystemExit("`--agent openclaw` requires the `openclaw` CLI on PATH.")
     return harbor_bin

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from harbor.agents.installed.base import CliFlag, with_prompt_template
 from harbor.agents.installed.claude_code import ClaudeCode
 from harbor.agents.installed.codex import Codex
+from harbor.agents.installed.cursor_cli import CursorCli
 from harbor.agents.installed.openclaw import OpenClaw
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
@@ -227,6 +228,74 @@ class RunmeCodex(Codex):
             self.populate_context_post_run(context)
 
 
+class RunmeCursorCli(CursorCli):
+    """Cursor CLI-backed Runme agent without container bootstrap.
+
+    Harbor's installed Cursor agent assumes a disposable container and requires
+    API-key setup before running. Runme Harbor executes through Runme's runtime,
+    so this wrapper expects `cursor-agent` to already be available and uses the
+    user's ambient Cursor authentication when present.
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "cursor-cli"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    def _runtime_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+        if cursor_api_key := os.environ.get("CURSOR_API_KEY"):
+            env["CURSOR_API_KEY"] = cursor_api_key
+        env.update(self._resolved_env_vars)
+        return env
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        escaped_instruction = shlex.quote(instruction)
+
+        if self.model_name and "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        model_arg = (
+            f"--model={shlex.quote(self.model_name.split('/')[-1])} " if self.model_name else ""
+        )
+        env = self._runtime_env()
+
+        mcp_command = self._build_register_mcp_servers_command()
+        if mcp_command:
+            await self.exec_as_agent(environment, command=mcp_command, env=env)
+
+        cli_flags = self.build_cli_flags()
+        cli_flags_arg = f"{cli_flags} " if cli_flags else ""
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -o pipefail\n"
+                'export PATH="$HOME/.local/bin:$PATH"\n'
+                "cursor-agent --yolo --print --output-format=stream-json "
+                f"{cli_flags_arg}"
+                f"{model_arg}"
+                f"-- {escaped_instruction} "
+                f"2>&1 </dev/null | tee "
+                f"{EnvironmentPaths.agent_dir / self._OUTPUT_FILENAME}"
+            ),
+            env=env,
+        )
+
+        self.populate_context_post_run(context)
+
+
 class RunmeOpenClaw(OpenClaw):
     """OpenClaw-backed Runme agent without container bootstrap.
 
@@ -333,9 +402,7 @@ class RunmeOpenClaw(OpenClaw):
         shutil.copy2(source, target)
 
     def _session_key_arg(self) -> str:
-        if self._resolved_flags.get("session_id") or self._resolved_flags.get(
-            "session_key"
-        ):
+        if self._resolved_flags.get("session_id") or self._resolved_flags.get("session_key"):
             return ""
 
         digest = sha256(str(self.logs_dir.resolve()).encode()).hexdigest()[:16]
@@ -364,9 +431,7 @@ class RunmeOpenClaw(OpenClaw):
         cli_flags = self.build_cli_flags()
         cli_flags_arg = f"{cli_flags} " if cli_flags else ""
         session_key_arg = self._session_key_arg()
-        model_arg = (
-            f"--model {shlex.quote(self.model_name)} " if self.model_name else ""
-        )
+        model_arg = f"--model {shlex.quote(self.model_name)} " if self.model_name else ""
 
         try:
             await self.exec_as_agent(

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -116,6 +116,16 @@ def test_build_harbor_command_claude(tmp_path: Path) -> None:
     assert "--agent" not in command
 
 
+def test_build_harbor_command_cursor_cli(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "--agent", "cursor-cli"])
+
+    command = cli.build_harbor_command(args)
+
+    assert "--agent-import-path" in command
+    assert "runme_harbor.runme_agents:RunmeCursorCli" in command
+    assert "--agent" not in command
+
+
 def test_build_harbor_command_openclaw(tmp_path: Path) -> None:
     args = parse(["run", str(tmp_path), "--agent", "openclaw"])
 
@@ -130,6 +140,13 @@ def test_build_harbor_command_runme_env_rejects_unknown_agent(tmp_path: Path) ->
     args = parse(["run", str(tmp_path), "--agent", "goose"])
 
     with pytest.raises(SystemExit, match="invalid --agent 'goose'"):
+        cli.build_harbor_command(args)
+
+
+def test_build_harbor_command_runme_env_rejects_cursor_alias(tmp_path: Path) -> None:
+    args = parse(["run", str(tmp_path), "--agent", "cursor"])
+
+    with pytest.raises(SystemExit, match="invalid --agent 'cursor'"):
         cli.build_harbor_command(args)
 
 
@@ -238,7 +255,9 @@ def test_main_syncs_metadata_after_harbor_run(
     synced: list[str] = []
     monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
     monkeypatch.setattr(cli.subprocess, "call", lambda _command: 7)
-    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
+    )
 
     assert cli.main(["run", str(tmp_path), "--jobs-dir", "jobs"]) == 7
 
@@ -253,7 +272,9 @@ def test_main_skips_metadata_sync_when_disabled(
     monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
     monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
     monkeypatch.setattr(cli.subprocess, "call", lambda _command: 0)
-    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
+    )
 
     assert cli.main(["run", str(tmp_path), "--jobs-dir", "jobs"]) == 0
 
@@ -267,7 +288,9 @@ def test_main_sync_metadata_command_uses_default_jobs_dir(
     synced: list[str] = []
     preflighted: list[bool] = []
     monkeypatch.setattr(cli, "_preflight_harbor_package", lambda: preflighted.append(True))
-    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 3)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 3
+    )
 
     assert cli.main(["sync-metadata"]) == 0
 
@@ -281,7 +304,9 @@ def test_main_sync_metadata_command_accepts_jobs_dir(
 ) -> None:
     synced: list[str] = []
     monkeypatch.setattr(cli, "_preflight_harbor_package", lambda: None)
-    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
+    )
 
     assert cli.main(["sync-metadata", "--jobs-dir", "jobs"]) == 0
 
@@ -297,7 +322,9 @@ def test_main_sync_metadata_command_reports_preflight_errors(
 
     synced: list[str] = []
     monkeypatch.setattr(cli, "_preflight_harbor_package", fail_preflight)
-    monkeypatch.setattr(metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
+    )
 
     assert cli.main(["sync-metadata"]) == 1
 
@@ -358,6 +385,7 @@ def test_preflight_rejects_global_harbor_without_bundled_sibling(
     [
         ("codex", "codex", "`--agent codex` requires the `codex` CLI"),
         ("claude-code", "claude", "`--agent claude-code` requires the `claude` CLI"),
+        ("cursor-cli", "cursor-agent", "`--agent cursor-cli` requires the `cursor-agent` CLI"),
         ("openclaw", "openclaw", "`--agent openclaw` requires the `openclaw` CLI"),
     ],
 )

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -9,6 +9,7 @@ from harbor.models.trial.result import TrialResult
 from runme_harbor.cli import (
     CLAUDE_IMPORT_PATH,
     CODEX_IMPORT_PATH,
+    CURSOR_IMPORT_PATH,
     ENVIRONMENT_IMPORT_PATH,
 )
 from runme_harbor.metadata_sync import (
@@ -39,9 +40,7 @@ def test_sync_jobs_metadata_uses_observed_runme_agent_import_paths(tmp_path: Pat
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")
-    ]
+    assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")]
     assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
 
     assert ORIGINAL_CONFIG_BACKUP == "config.original.json"
@@ -57,7 +56,9 @@ def test_sync_jobs_metadata_uses_observed_runme_agent_import_paths(tmp_path: Pat
 
 def test_sync_jobs_metadata_sorts_and_deduplicates_observed_agents(tmp_path: Path) -> None:
     job_dir = _write_job_config(tmp_path, agents=[AgentConfig(name="planned")])
-    _write_trial_result(job_dir, "trial-z", agent_name="runme-codex", provider=None, model_name="gpt-5")
+    _write_trial_result(
+        job_dir, "trial-z", agent_name="runme-codex", provider=None, model_name="gpt-5"
+    )
     _write_trial_result(
         job_dir,
         "trial-a",
@@ -65,7 +66,9 @@ def test_sync_jobs_metadata_sorts_and_deduplicates_observed_agents(tmp_path: Pat
         provider="anthropic",
         model_name="sonnet",
     )
-    _write_trial_result(job_dir, "trial-b", agent_name="runme-codex", provider=None, model_name="gpt-5")
+    _write_trial_result(
+        job_dir, "trial-b", agent_name="runme-codex", provider=None, model_name="gpt-5"
+    )
 
     assert sync_jobs_metadata(tmp_path) == 1
 
@@ -88,6 +91,31 @@ def test_sync_jobs_metadata_sorts_same_agent_with_missing_model_info(tmp_path: P
         ("runme-codex", CODEX_IMPORT_PATH, None),
         ("runme-codex", CODEX_IMPORT_PATH, "gpt-5"),
     ]
+
+
+def test_sync_jobs_metadata_uses_cursor_cli_import_path(tmp_path: Path) -> None:
+    job_dir = _write_job_config(
+        tmp_path,
+        agents=[
+            AgentConfig(
+                import_path=CURSOR_IMPORT_PATH,
+                model_name="cursor/planned-model",
+            )
+        ],
+    )
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="cursor-cli",
+        provider="cursor",
+        model_name="composer-2",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [("cursor-cli", CURSOR_IMPORT_PATH, "cursor/composer-2")]
+    assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
 
 
 def test_sync_jobs_metadata_omits_missing_model_info(tmp_path: Path) -> None:
@@ -120,9 +148,7 @@ def test_sync_jobs_metadata_uses_atif_model_when_trial_model_info_missing(
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
-    ]
+    assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")]
     result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
     assert result.agent_info.model_info is not None
     assert result.agent_info.model_info.name == "gpt-5.5"
@@ -154,9 +180,7 @@ def test_sync_jobs_metadata_prefers_atif_over_trial_model_info(
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
-    ]
+    assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")]
     result = TrialResult.model_validate_json((job_dir / "trial-1" / "result.json").read_text())
     assert result.agent_info.model_info is not None
     assert result.agent_info.model_info.name == "gpt-5.5"
@@ -236,9 +260,7 @@ def test_sync_jobs_metadata_ignores_unreadable_atif(tmp_path: Path) -> None:
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, None)
-    ]
+    assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, None)]
 
 
 def test_sync_jobs_metadata_skips_jobs_without_readable_trials(tmp_path: Path) -> None:
@@ -301,9 +323,7 @@ def test_sync_jobs_metadata_corrects_prior_runme_agent_name_sync(tmp_path: Path)
     assert sync_jobs_metadata(tmp_path) == 1
 
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
-    assert _agent_summaries(config) == [
-        ("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")
-    ]
+    assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, "gpt-5.5")]
     assert (job_dir / ORIGINAL_CONFIG_BACKUP).read_text() == backup_text
 
 

--- a/integrations/harbor/tests/test_runme_cursor_cli.py
+++ b/integrations/harbor/tests/test_runme_cursor_cli.py
@@ -1,0 +1,99 @@
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from runme_harbor.runme_agents import RunmeCursorCli
+
+
+class FakeEnvironment:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path | str, str]] = []
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        self.uploads.append((source_path, target_path))
+
+
+def test_runme_cursor_cli_name() -> None:
+    assert RunmeCursorCli.name() == "cursor-cli"
+
+
+def test_runme_cursor_cli_uses_ambient_user_auth(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+    environment = FakeEnvironment()
+    agent = RunmeCursorCli(logs_dir=tmp_path, model_name="cursor/composer-2")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    assert environment.uploads == []
+    assert "\ncursor-agent --yolo --print --output-format=stream-json " in calls[0][0]
+    assert "--model=composer-2 -- 'write result.txt'" in calls[0][0]
+    assert "cursor-cli.txt" in calls[0][0]
+    assert calls[0][1] == {}
+    assert all("CURSOR_API_KEY" not in (env or {}) for _, env in calls)
+    assert all("register" not in command for command, _ in calls)
+
+
+def test_runme_cursor_cli_passes_cursor_api_key_when_present(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("CURSOR_API_KEY", "ambient-key")
+
+    environment = FakeEnvironment()
+    agent = RunmeCursorCli(logs_dir=tmp_path, model_name="cursor/composer-2")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    assert calls[0][1] == {"CURSOR_API_KEY": "ambient-key"}
+
+
+def test_runme_cursor_cli_can_use_cursor_default_model(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("CURSOR_API_KEY", raising=False)
+
+    environment = FakeEnvironment()
+    agent = RunmeCursorCli(logs_dir=tmp_path, model_name=None)
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    assert "--model=" not in calls[0][0]
+    assert "-- 'write result.txt'" in calls[0][0]


### PR DESCRIPTION
## Summary

- add a Runme Harbor wrapper for upstream Harbor's `cursor-cli` agent name
- wire `runme eval --agent cursor-cli` through the Runme environment import path without adding a `cursor` alias
- preserve ambient Cursor auth, passing `CURSOR_API_KEY` only when present
- add CLI, metadata sync, and wrapper tests

## Tests

```sh
cd integrations/harbor && uv run pytest tests/test_cli.py tests/test_metadata_sync.py tests/test_runme_cursor_cli.py
cd integrations/harbor && uv run pytest
runme run test
```
