### PR TITLE
chore: upgrade runme-harbor to Harbor 0.15

### DIFF
--- a/integrations/harbor/pyproject.toml
+++ b/integrations/harbor/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: System :: Shells",
 ]
 dependencies = [
-  "harbor>=0.13.1,<0.14",
+  "harbor>=0.15,<0.16",
   "protobuf>=7.35.1",
 ]
 license-files = ["LICENSE", "NOTICE"]

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -17,8 +17,8 @@ CODEX_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCodex"
 CLAUDE_IMPORT_PATH = "runme_harbor.runme_agents:RunmeClaudeCode"
 CURSOR_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCursorCli"
 OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
-MIN_HARBOR_VERSION = (0, 13, 1)
-MAX_HARBOR_VERSION = (0, 14, 0)
+MIN_HARBOR_VERSION = (0, 15, 0)
+MAX_HARBOR_VERSION = (0, 16, 0)
 SKIP_METADATA_SYNC_ENV = "RUNME_HARBOR_SKIP_METADATA_SYNC"
 BUNDLED_HARBOR_EXECUTABLE = "runme-harbor-harbor"
 AGENT_ARGUMENTS = {
@@ -227,7 +227,7 @@ def _preflight_harbor_package() -> None:
 
     version = _version_tuple(importlib.metadata.version("harbor"))
     if version < MIN_HARBOR_VERSION or version >= MAX_HARBOR_VERSION:
-        raise SystemExit("Runme Harbor requires harbor>=0.13.1,<0.14.")
+        raise SystemExit("Runme Harbor requires harbor>=0.15,<0.16.")
 
 
 def _skip_metadata_sync() -> bool:

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -332,6 +332,30 @@ def test_main_sync_metadata_command_reports_preflight_errors(
     assert capsys.readouterr().err == "Runme Harbor requires the `harbor` Python package.\n"
 
 
+@pytest.mark.parametrize(
+    ("version", "supported"),
+    [
+        ("0.14.0", False),
+        ("0.15.0", True),
+        ("0.15.9", True),
+        ("0.16.0", False),
+    ],
+)
+def test_preflight_harbor_version_range(
+    monkeypatch: pytest.MonkeyPatch,
+    version: str,
+    supported: bool,
+) -> None:
+    monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: version)
+
+    if supported:
+        cli._preflight_harbor_package()
+    else:
+        with pytest.raises(SystemExit, match="harbor>=0.15,<0.16"):
+            cli._preflight_harbor_package()
+
+
 def test_pyproject_exposes_runme_owned_scripts_only() -> None:
     pyproject = Path(__file__).parents[1] / "pyproject.toml"
     scripts = tomllib.loads(pyproject.read_text())["project"]["scripts"]
@@ -354,7 +378,7 @@ def test_preflight_uses_bundled_harbor_executable(
 
     monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
     monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
-    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.15.0")
     monkeypatch.setattr(cli.shutil, "which", lambda name: f"/usr/local/bin/{name}")
 
     assert cli._preflight("oracle") == bundled_harbor.resolve()
@@ -374,7 +398,7 @@ def test_preflight_rejects_global_harbor_without_bundled_sibling(
     monkeypatch.setenv("PATH", str(global_bin))
     monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
     monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
-    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.15.0")
 
     with pytest.raises(SystemExit, match="bundled `runme-harbor-harbor` executable"):
         cli._preflight("oracle")
@@ -403,7 +427,7 @@ def test_preflight_requires_runme_agent_cli(
 
     monkeypatch.setattr(sys, "argv", [str(runme_harbor), "run"])
     monkeypatch.setattr(cli.importlib, "import_module", lambda _name: object())
-    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.13.1")
+    monkeypatch.setattr(cli.importlib.metadata, "version", lambda _name: "0.15.0")
     monkeypatch.setattr(
         cli.shutil, "which", lambda name: None if name == missing else f"/bin/{name}"
     )

--- a/integrations/harbor/uv.lock
+++ b/integrations/harbor/uv.lock
@@ -663,7 +663,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.13.1"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -680,7 +680,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
-    { name = "ruff" },
     { name = "shortuuid" },
     { name = "supabase" },
     { name = "tenacity" },
@@ -688,9 +687,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/5a/89fe6831dba01c53cffed5afb0dd9cfa7dd1e62c0d6b531294742270e30c/harbor-0.13.1.tar.gz", hash = "sha256:4c9f8a345a3bda772dbba2053ee68bc735ca641d083b083f7e81a3c3fb6fb2cc", size = 1094654, upload-time = "2026-06-03T20:45:47.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/af/9927af345cd7d80e4346539e2340a1cd795861b12fb5d5ffc7b0788a7401/harbor-0.15.0.tar.gz", hash = "sha256:406b20ce520fc1ec12bc9b05396cc91756bb6379fb565a5bc2f2b6759e94cb12", size = 1287081, upload-time = "2026-06-19T22:48:17.474Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d9/640ae0d85f0c63bdda20341f3eee1dbdcd22448258d0ca4970a8523f7eb5/harbor-0.13.1-py3-none-any.whl", hash = "sha256:6116305f7d756ae919b50ce1c5363e14ea377ae924dfd68b10ed00dc20f6f432", size = 1247918, upload-time = "2026-06-03T20:45:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/6e860d3bdbb09c56296d4b57fcebc22f8eb014b06eb3810f9e0a8ab718f7/harbor-0.15.0-py3-none-any.whl", hash = "sha256:a6f7f703d9b008920f07751ae27f6c049afe908bee8199aa6bcc911f6c2aab1b", size = 1463875, upload-time = "2026-06-19T22:48:19.009Z" },
 ]
 
 [[package]]
@@ -2063,7 +2062,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "harbor", specifier = ">=0.13.1,<0.14" },
+    { name = "harbor", specifier = ">=0.15,<0.16" },
     { name = "protobuf", specifier = ">=7.35.1" },
 ]
 


### PR DESCRIPTION
## Summary
- upgrade `runme-harbor` from Harbor `0.13.x` to Harbor `0.15.x`
- move the runtime preflight guard to `harbor>=0.15,<0.16`
- add coverage for the accepted/rejected Harbor version window

## Verification
- `cd integrations/harbor && uv run pytest`
- `runme run build-harbor`
- `runme run test`
- `./runme eval examples/harbor/datasets/runme-integration --task-dir simple-agent --agent oracle --jobs-dir /tmp/runme-harbor-015-smoke/jobs --ask`
- `./runme eval examples/harbor/datasets/runme-integration --task-dir text-stats-reward --agent oracle --jobs-dir /tmp/runme-harbor-015-smoke/jobs --ask`
