### PR TITLE
[codex] Upgrade Homebrew bump action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
 
       - name: Bump Homebrew Formula
-        uses: mislav/bump-homebrew-formula-action@v3
+        uses: mislav/bump-homebrew-formula-action@v4.1
         # skip prereleases
         if: ${{ !contains(github.ref, '-') }}
         with:


### PR DESCRIPTION
## What changed

- Upgrade `mislav/bump-homebrew-formula-action` from `v3` to `v4.1` in the release workflow.

## Why

The `v3` action failed during the `v3.16.13` release at the Homebrew formula bump step with `unexpected HTTP 303 response`. `v4.1` is the current Marketplace release for the action.

## Validation

- `runme run lint test`