### PR TITLE
[codex] Remove Homebrew formula bump action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           path: cover.out
           if-no-files-found: error
       - name: Debug Build
-        uses: stateful/vscode-server-action@v1
+        uses: stateful/vscode-server-action@v1.1.0
         if: failure()
 
   test-in-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,22 +91,3 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
-
-      - name: Calculate Homebrew source checksum
-        id: homebrew-source
-        # skip prereleases
-        if: ${{ !contains(github.ref, '-') }}
-        run: |
-          curl -sSL "https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz" \
-            | shasum -a 256 \
-            | awk '{print "sha256="$1}' >> "$GITHUB_OUTPUT"
-
-      - name: Bump Homebrew Formula
-        uses: mislav/bump-homebrew-formula-action@v4.1
-        # skip prereleases
-        if: ${{ !contains(github.ref, '-') }}
-        with:
-          formula-name: runme
-          download-sha256: ${{ steps.homebrew-source.outputs.sha256 }}
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
## What changed

- Removed the `mislav/bump-homebrew-formula-action@v4.1` step from the release workflow.
- Removed the checksum precomputation step that only existed to feed that action.

## Why

Homebrew now autobumps `runme` in `homebrew-core`. The latest manual Homebrew PR was closed as a duplicate of BrewTestBot's autobump PR, which was already merged with bottles. Continuing to open proactive formula bump PRs creates noise and can be closed by Homebrew automation or maintainers.

This resolves the remaining release workflow issue by deleting our manual Homebrew PR generation path instead of trying to keep its generated PR body compatible with Homebrew's evolving template checks.

Fixes #1185

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "workflow YAML parses"'`
- `runme run lint test`
