### PR TITLE
fix: drain harbor pty stdout before closing

### DIFF
--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -485,12 +485,11 @@ func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, std
 	}()
 
 	waitErr := cmd.Wait()
-	_ = ptmx.Close()
 	copyErr := <-copyDone
 	if waitErr != nil {
 		return waitErr
 	}
-	if copyErr != nil && !errors.Is(copyErr, os.ErrClosed) {
+	if copyErr != nil {
 		if errors.Is(copyErr, syscall.EIO) {
 			return nil
 		}


### PR DESCRIPTION
## Summary

- drain Harbor PTY stdout before closing the PTY master
- stop treating `os.ErrClosed` as a benign PTY copy result
- keep Linux `syscall.EIO` handling as expected PTY EOF behavior

## Why

The Docker CI job flaked in `TestRunExternalCommandUsesPtyWhenStdoutIsTerminal` with an empty stdout buffer. The PTY copy goroutine could lose the race against closing `ptmx`, especially for tiny no-newline writes like `printf tty`.

Waiting for the copy goroutine before cleanup lets the PTY output drain normally. If `os.ErrClosed` still appears after this ordering fix, that should be investigated rather than masked.

## Tests

- `go test -run '^TestRunExternalCommandUsesPtyWhenStdoutIsTerminal$|^TestRunExternalCommandWithPtyStdoutReturnsExitError$' -count=100 -v ./internal/harbor`
- `docker run --rm -e GOTOOLCHAIN=auto -e RUNME_TEST_ENV=docker -v "$PWD":/workspace -w /workspace ghcr.io/runmedev/runme-build-env:latest go test -run '^TestRunExternalCommandUsesPtyWhenStdoutIsTerminal$|^TestRunExternalCommandWithPtyStdoutReturnsExitError$' -count=100 -v ./internal/harbor`
- `docker run --rm -e RUNME_TEST_ENV=docker -e GOTOOLCHAIN=auto -v "$PWD":/workspace -v dev.runme.test-env-gocache:/root/.cache/go-build -w /workspace ghcr.io/runmedev/runme-build-env:latest make test/execute PKGS='./internal/harbor' RUN='.*' RACE=false TAGS=''`
- `runme run test`
