### PR TITLE
feat: add eval agent env flag

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -20,6 +20,7 @@ type evalOptions struct {
 	jobsDir         string
 	ask             bool
 	agentKwargs     []string
+	agentEnv        []string
 	model           string
 	env             string
 	runmeBin        string
@@ -65,8 +66,11 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags := cmd.Flags()
 	previousNormalize := flags.GetNormalizeFunc()
 	flags.SetNormalizeFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
-		if name == "ak" {
+		switch name {
+		case "ak":
 			name = "agent-kwarg"
+		case "ae":
+			name = "agent-env"
 		}
 		return previousNormalize(f, name)
 	})
@@ -75,6 +79,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags.StringVar(&opts.jobsDir, "jobs-dir", harbor.DefaultEvalJobsDir, "Eval jobs directory")
 	flags.BoolVar(&opts.ask, "ask", false, "Do not auto-accept Harbor confirmation prompts")
 	flags.StringArrayVar(&opts.agentKwargs, "agent-kwarg", nil, "Harbor agent kwarg; can be repeated; alias: --ak")
+	flags.StringArrayVar(&opts.agentEnv, "agent-env", nil, "Environment variable to pass to the agent in KEY=VALUE format; can be repeated; alias: --ae")
 	flags.StringVar(&opts.model, "model", "", "Harbor agent model")
 	flags.StringVarP(&opts.env, "env", "e", "", `Harbor environment to use. Defaults to "runme"`)
 	flags.StringVar(&opts.runmeBin, "runme-bin", "", "Runme binary used by the Harbor environment")
@@ -92,6 +97,7 @@ func runEval(opts evalOptions, args []string) error {
 		JobsDir:         opts.jobsDir,
 		Ask:             opts.ask,
 		AgentKwargs:     opts.agentKwargs,
+		AgentEnv:        opts.agentEnv,
 		Model:           opts.model,
 		Env:             opts.env,
 		RunmeBin:        opts.runmeBin,

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -46,6 +46,8 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		"--ask",
 		"--agent-kwarg", "reasoning_effort=xhigh",
 		"--ak", "sandbox_mode=workspace-write",
+		"--agent-env", "AWS_REGION=us-east-1",
+		"--ae", "FOO=bar",
 		"--model", "haiku",
 		"--env", "docker",
 		"--runme-bin", "/bin/runme",
@@ -76,6 +78,7 @@ func TestEvalCmdPassesOptionsToHarborRunner(t *testing.T) {
 		!gotOpts.JobsDirExplicit ||
 		!gotOpts.Ask ||
 		!reflect.DeepEqual(gotOpts.AgentKwargs, []string{"reasoning_effort=xhigh", "sandbox_mode=workspace-write"}) ||
+		!reflect.DeepEqual(gotOpts.AgentEnv, []string{"AWS_REGION=us-east-1", "FOO=bar"}) ||
 		gotOpts.Model != "haiku" ||
 		gotOpts.Env != "docker" ||
 		gotOpts.RunmeBin != "/bin/runme" ||
@@ -166,6 +169,9 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 	if !strings.Contains(stdout.String(), `alias: --ak`) {
+		t.Fatalf("help output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `alias: --ae`) {
 		t.Fatalf("help output = %q", stdout.String())
 	}
 }

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -101,10 +101,10 @@ func (r *EvalRunner) Run(args []string) error {
 	if opts.Model != "" && containsModelFlag(paths.passthrough) {
 		return fmt.Errorf("--model cannot be used together with passthrough --model; use only runme eval --model")
 	}
-	if len(opts.AgentKwargs) > 0 && containsAgentKwargFlag(paths.passthrough) {
+	if len(opts.AgentKwargs) > 0 && containsFlagAlias(paths.passthrough, "--agent-kwarg", "--ak") {
 		return fmt.Errorf("--agent-kwarg cannot be used together with passthrough --agent-kwarg/--ak; use only runme eval --agent-kwarg")
 	}
-	if len(opts.AgentEnv) > 0 && containsAgentEnvFlag(paths.passthrough) {
+	if len(opts.AgentEnv) > 0 && containsFlagAlias(paths.passthrough, "--agent-env", "--ae") {
 		return fmt.Errorf("--agent-env cannot be used together with passthrough --agent-env/--ae; use only runme eval --agent-env")
 	}
 	if containsEnvironmentFlag(paths.passthrough) {
@@ -416,24 +416,12 @@ func containsModelFlag(args []string) bool {
 	return false
 }
 
-func containsAgentKwargFlag(args []string) bool {
+func containsFlagAlias(args []string, long, alias string) bool {
 	for _, arg := range args {
-		if arg == "--agent-kwarg" || arg == "--ak" {
+		if arg == long || arg == alias {
 			return true
 		}
-		if strings.HasPrefix(arg, "--agent-kwarg=") || strings.HasPrefix(arg, "--ak=") {
-			return true
-		}
-	}
-	return false
-}
-
-func containsAgentEnvFlag(args []string) bool {
-	for _, arg := range args {
-		if arg == "--agent-env" || arg == "--ae" {
-			return true
-		}
-		if strings.HasPrefix(arg, "--agent-env=") || strings.HasPrefix(arg, "--ae=") {
+		if strings.HasPrefix(arg, long+"=") || strings.HasPrefix(arg, alias+"=") {
 			return true
 		}
 	}

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -30,6 +30,7 @@ type EvalOptions struct {
 	JobsDir         string
 	Ask             bool
 	AgentKwargs     []string
+	AgentEnv        []string
 	Model           string
 	Env             string
 	RunmeBin        string
@@ -102,6 +103,9 @@ func (r *EvalRunner) Run(args []string) error {
 	}
 	if len(opts.AgentKwargs) > 0 && containsAgentKwargFlag(paths.passthrough) {
 		return fmt.Errorf("--agent-kwarg cannot be used together with passthrough --agent-kwarg/--ak; use only runme eval --agent-kwarg")
+	}
+	if len(opts.AgentEnv) > 0 && containsAgentEnvFlag(paths.passthrough) {
+		return fmt.Errorf("--agent-env cannot be used together with passthrough --agent-env/--ae; use only runme eval --agent-env")
 	}
 	if containsEnvironmentFlag(paths.passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
@@ -390,6 +394,9 @@ func buildRunmeHarborArgs(datasetPath string, opts EvalOptions, jobsDir string, 
 	for _, kwarg := range opts.AgentKwargs {
 		delegatedPassthrough = append(delegatedPassthrough, "--agent-kwarg", kwarg)
 	}
+	for _, env := range opts.AgentEnv {
+		delegatedPassthrough = append(delegatedPassthrough, "--agent-env", env)
+	}
 	if opts.Model != "" {
 		delegatedPassthrough = append(delegatedPassthrough, "--model", opts.Model)
 	}
@@ -415,6 +422,18 @@ func containsAgentKwargFlag(args []string) bool {
 			return true
 		}
 		if strings.HasPrefix(arg, "--agent-kwarg=") || strings.HasPrefix(arg, "--ak=") {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAgentEnvFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--agent-env" || arg == "--ae" {
+			return true
+		}
+		if strings.HasPrefix(arg, "--agent-env=") || strings.HasPrefix(arg, "--ae=") {
 			return true
 		}
 	}

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -496,6 +496,32 @@ func TestRunEvalDelegatesAgentKwargs(t *testing.T) {
 	}
 }
 
+func TestRunEvalDelegatesAgentEnv(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.AgentEnv = []string{"AWS_REGION=us-east-1", "FOO=bar"}
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"-y",
+		"--",
+		"--agent-env", "AWS_REGION=us-east-1",
+		"--agent-env", "FOO=bar",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
 func TestRunEvalPreservesPassthroughModel(t *testing.T) {
 	path := t.TempDir()
 	var calls []recordedCommand
@@ -539,6 +565,31 @@ func TestRunEvalPreservesPassthroughAgentKwargs(t *testing.T) {
 		"--",
 		"--ak", "reasoning_effort=xhigh",
 		"--agent-kwarg=sandbox_mode=workspace-write",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
+func TestRunEvalPreservesPassthroughAgentEnv(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+
+	err := NewEvalRunner(opts).Run([]string{path, "--ae", "AWS_REGION=us-east-1", "--agent-env=FOO=bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		mustAbs(t, path),
+		"--agent", "oracle",
+		"--jobs-dir", defaultJobsDir(t),
+		"-y",
+		"--",
+		"--ae", "AWS_REGION=us-east-1",
+		"--agent-env=FOO=bar",
 	}
 	if !reflect.DeepEqual(calls[1].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
@@ -594,6 +645,36 @@ func TestRunEvalRejectsDuplicateAgentKwargs(t *testing.T) {
 				t.Fatal("expected error")
 			}
 			if !strings.Contains(err.Error(), "--agent-kwarg cannot be used together with passthrough") {
+				t.Fatalf("error = %q", err.Error())
+			}
+			if len(calls) != 0 {
+				t.Fatalf("calls = %#v, want none", calls)
+			}
+		})
+	}
+}
+
+func TestRunEvalRejectsDuplicateAgentEnv(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		passthrough []string
+	}{
+		{name: "long separate arg", passthrough: []string{"--agent-env", "AWS_REGION=us-east-1"}},
+		{name: "long equals arg", passthrough: []string{"--agent-env=AWS_REGION=us-east-1"}},
+		{name: "alias separate arg", passthrough: []string{"--ae", "AWS_REGION=us-east-1"}},
+		{name: "alias equals arg", passthrough: []string{"--ae=AWS_REGION=us-east-1"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.AgentEnv = []string{"FOO=bar"}
+
+			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), "--agent-env cannot be used together with passthrough") {
 				t.Fatalf("error = %q", err.Error())
 			}
 			if len(calls) != 0 {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -624,61 +624,59 @@ func TestRunEvalRejectsDuplicateModel(t *testing.T) {
 	}
 }
 
-func TestRunEvalRejectsDuplicateAgentKwargs(t *testing.T) {
+func TestRunEvalRejectsDuplicateAgentFlags(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		passthrough []string
+		name         string
+		configure    func(*EvalOptions)
+		errorMessage string
+		variants     [][]string
 	}{
-		{name: "long separate arg", passthrough: []string{"--agent-kwarg", "sandbox_mode=workspace-write"}},
-		{name: "long equals arg", passthrough: []string{"--agent-kwarg=sandbox_mode=workspace-write"}},
-		{name: "alias separate arg", passthrough: []string{"--ak", "sandbox_mode=workspace-write"}},
-		{name: "alias equals arg", passthrough: []string{"--ak=sandbox_mode=workspace-write"}},
+		{
+			name: "agent kwargs",
+			configure: func(opts *EvalOptions) {
+				opts.AgentKwargs = []string{"reasoning_effort=xhigh"}
+			},
+			errorMessage: "--agent-kwarg cannot be used together with passthrough",
+			variants: [][]string{
+				{"--agent-kwarg", "sandbox_mode=workspace-write"},
+				{"--agent-kwarg=sandbox_mode=workspace-write"},
+				{"--ak", "sandbox_mode=workspace-write"},
+				{"--ak=sandbox_mode=workspace-write"},
+			},
+		},
+		{
+			name: "agent env",
+			configure: func(opts *EvalOptions) {
+				opts.AgentEnv = []string{"FOO=bar"}
+			},
+			errorMessage: "--agent-env cannot be used together with passthrough",
+			variants: [][]string{
+				{"--agent-env", "AWS_REGION=us-east-1"},
+				{"--agent-env=AWS_REGION=us-east-1"},
+				{"--ae", "AWS_REGION=us-east-1"},
+				{"--ae=AWS_REGION=us-east-1"},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
-			var calls []recordedCommand
-			opts := testEvalOptions(t, &calls, io.Discard)
-			opts.AgentKwargs = []string{"reasoning_effort=xhigh"}
+			for _, passthrough := range tt.variants {
+				t.Run(strings.Join(passthrough, " "), func(t *testing.T) {
+					path := t.TempDir()
+					var calls []recordedCommand
+					opts := testEvalOptions(t, &calls, io.Discard)
+					tt.configure(&opts)
 
-			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), "--agent-kwarg cannot be used together with passthrough") {
-				t.Fatalf("error = %q", err.Error())
-			}
-			if len(calls) != 0 {
-				t.Fatalf("calls = %#v, want none", calls)
-			}
-		})
-	}
-}
-
-func TestRunEvalRejectsDuplicateAgentEnv(t *testing.T) {
-	for _, tt := range []struct {
-		name        string
-		passthrough []string
-	}{
-		{name: "long separate arg", passthrough: []string{"--agent-env", "AWS_REGION=us-east-1"}},
-		{name: "long equals arg", passthrough: []string{"--agent-env=AWS_REGION=us-east-1"}},
-		{name: "alias separate arg", passthrough: []string{"--ae", "AWS_REGION=us-east-1"}},
-		{name: "alias equals arg", passthrough: []string{"--ae=AWS_REGION=us-east-1"}},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			path := t.TempDir()
-			var calls []recordedCommand
-			opts := testEvalOptions(t, &calls, io.Discard)
-			opts.AgentEnv = []string{"FOO=bar"}
-
-			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
-			if err == nil {
-				t.Fatal("expected error")
-			}
-			if !strings.Contains(err.Error(), "--agent-env cannot be used together with passthrough") {
-				t.Fatalf("error = %q", err.Error())
-			}
-			if len(calls) != 0 {
-				t.Fatalf("calls = %#v, want none", calls)
+					err := NewEvalRunner(opts).Run(append([]string{path}, passthrough...))
+					if err == nil {
+						t.Fatal("expected error")
+					}
+					if !strings.Contains(err.Error(), tt.errorMessage) {
+						t.Fatalf("error = %q", err.Error())
+					}
+					if len(calls) != 0 {
+						t.Fatalf("calls = %#v, want none", calls)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add first-class `runme eval --agent-env` with `--ae` alias normalization
- pass parsed agent env vars through to Harbor as canonical `--agent-env` arguments
- reject mixed first-class and passthrough agent env flag usage, matching `--agent-kwarg`
- cover CLI parsing, help text, delegation, passthrough preservation, and duplicate-source rejection

## Tests

- `go test ./cmd -run 'TestEvalCmd'`
- `go test ./internal/harbor -run 'TestRunEval.*AgentEnv|TestRunEval.*AgentKwargs|TestRunEval.*Model'`
- `runme run test`
