### PR TITLE
feat: add eval view command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -87,6 +87,8 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags.StringVar(&opts.runmeHarbor, "runme-harbor-bin", "", "runme-harbor executable")
 	flags.BoolVar(&opts.debug, "debug", false, "Print delegated commands")
 
+	cmd.AddCommand(evalViewCmd())
+
 	return cmd
 }
 

--- a/cmd/eval_view.go
+++ b/cmd/eval_view.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type evalViewer interface {
+	Run(args []string) error
+}
+
+var newEvalViewer = func(opts harbor.EvalViewOptions) evalViewer {
+	return harbor.NewEvalViewer(opts)
+}
+
+type evalViewOptions struct {
+	jobsDir     string
+	port        int
+	noOpen      bool
+	runmeHarbor string
+	debug       bool
+	stdout      io.Writer
+	stderr      io.Writer
+}
+
+func evalViewCmd() *cobra.Command {
+	opts := evalViewOptions{
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "view [jobs-dir]",
+		Short: "View Harbor eval jobs",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.stdout = cmd.OutOrStdout()
+			opts.stderr = cmd.ErrOrStderr()
+			if len(args) > 0 {
+				opts.jobsDir = args[0]
+			}
+			return runEvalView(opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.IntVar(&opts.port, "port", 0, "Dashboard port; defaults to the first open port from 8080")
+	flags.BoolVar(&opts.noOpen, "no-open", false, "Do not open the dashboard in the default browser")
+	flags.StringVar(&opts.runmeHarbor, "runme-harbor-bin", "", "runme-harbor executable")
+	flags.BoolVar(&opts.debug, "debug", false, "Print delegated commands")
+
+	return cmd
+}
+
+func runEvalView(opts evalViewOptions, args []string) error {
+	err := newEvalViewer(harbor.EvalViewOptions{
+		JobsDir:        opts.jobsDir,
+		Port:           opts.port,
+		Open:           !opts.noOpen,
+		RunmeHarborBin: opts.runmeHarbor,
+		Debug:          opts.debug,
+		Stdout:         opts.stdout,
+		Stderr:         opts.stderr,
+	}).Run(args)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, harbor.ErrRunmeHarborMissing) {
+		return fmt.Errorf("`runme eval view` requires the optional Python package `runme-harbor`.\n\nInstall it with:\n  uv tool install runme-harbor\n\nThen retry:\n  runme eval view")
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
+	}
+	var codeErr interface{ ExitCode() int }
+	if errors.As(err, &codeErr) {
+		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
+	}
+	return err
+}

--- a/cmd/eval_view_test.go
+++ b/cmd/eval_view_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type fakeEvalViewer struct {
+	err error
+}
+
+func (v fakeEvalViewer) Run([]string) error {
+	return v.err
+}
+
+func TestEvalViewCmdPassesOptionsToHarborRunner(t *testing.T) {
+	var gotOpts harbor.EvalViewOptions
+	var gotArgs []string
+	cmd := evalCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"view",
+		"custom/jobs",
+		"--port", "9090",
+		"--no-open",
+		"--runme-harbor-bin", "/bin/runme-harbor",
+		"--debug",
+	})
+	restoreEvalViewer(t, func(opts harbor.EvalViewOptions) evalViewer {
+		gotOpts = opts
+		return evalViewerFunc(func(args []string) error {
+			gotArgs = append([]string(nil), args...)
+			return nil
+		})
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotArgs, []string{"custom/jobs"}) {
+		t.Fatalf("args = %#v", gotArgs)
+	}
+	if gotOpts.JobsDir != "custom/jobs" ||
+		gotOpts.Port != 9090 ||
+		gotOpts.Open ||
+		gotOpts.RunmeHarborBin != "/bin/runme-harbor" ||
+		!gotOpts.Debug ||
+		gotOpts.Stdout != &stdout ||
+		gotOpts.Stderr != &stderr {
+		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalViewCmdDefaultsOpen(t *testing.T) {
+	var gotOpts harbor.EvalViewOptions
+	cmd := evalCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"view"})
+	restoreEvalViewer(t, func(opts harbor.EvalViewOptions) evalViewer {
+		gotOpts = opts
+		return fakeEvalViewer{}
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotOpts.JobsDir != "" {
+		t.Fatalf("jobsDir = %q, want default", gotOpts.JobsDir)
+	}
+	if !gotOpts.Open {
+		t.Fatal("Open = false, want true")
+	}
+}
+
+func TestRunEvalViewPropagatesDelegateExitCode(t *testing.T) {
+	restoreEvalViewer(t, func(harbor.EvalViewOptions) evalViewer {
+		return fakeEvalViewer{err: fakeExitError{code: 42}}
+	})
+
+	err := runEvalView(evalViewOptions{}, nil)
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+	if exitErr.Code != 42 {
+		t.Fatalf("exit code = %d, want 42", exitErr.Code)
+	}
+}
+
+func TestRunEvalViewMissingRunmeHarborMessage(t *testing.T) {
+	restoreEvalViewer(t, func(harbor.EvalViewOptions) evalViewer {
+		return fakeEvalViewer{err: harbor.ErrRunmeHarborMissing}
+	})
+
+	err := runEvalView(evalViewOptions{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "uv tool install runme-harbor") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "runme eval view") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+type evalViewerFunc func([]string) error
+
+func (f evalViewerFunc) Run(args []string) error {
+	return f(args)
+}
+
+func restoreEvalViewer(t *testing.T, fn func(harbor.EvalViewOptions) evalViewer) {
+	t.Helper()
+	previous := newEvalViewer
+	newEvalViewer = fn
+	t.Cleanup(func() {
+		newEvalViewer = previous
+	})
+}

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -50,7 +50,11 @@ def run(args: argparse.Namespace) -> int:
     command = build_harbor_command(args, harbor_bin=harbor_bin)
     if args.debug:
         print(_command_string(command), file=sys.stderr)
-    exit_code = subprocess.call(command)
+    process = subprocess.Popen(command)
+    try:
+        exit_code = process.wait()
+    except KeyboardInterrupt:
+        exit_code = process.wait()
     if not _skip_metadata_sync():
         from runme_harbor.metadata_sync import sync_jobs_metadata
 

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -21,6 +21,8 @@ MIN_HARBOR_VERSION = (0, 15, 0)
 MAX_HARBOR_VERSION = (0, 16, 0)
 SKIP_METADATA_SYNC_ENV = "RUNME_HARBOR_SKIP_METADATA_SYNC"
 BUNDLED_HARBOR_EXECUTABLE = "runme-harbor-harbor"
+INTERRUPTED_EXIT_CODE = 130
+INTERRUPT_WAIT_TIMEOUT_SECONDS = 1
 AGENT_ARGUMENTS = {
     "oracle": ("--agent", "oracle"),
     "codex": ("--agent-import-path", CODEX_IMPORT_PATH),
@@ -54,7 +56,8 @@ def run(args: argparse.Namespace) -> int:
     try:
         exit_code = process.wait()
     except KeyboardInterrupt:
-        exit_code = process.wait()
+        _stop_interrupted_process(process)
+        return INTERRUPTED_EXIT_CODE
     if not _skip_metadata_sync():
         from runme_harbor.metadata_sync import sync_jobs_metadata
 
@@ -63,6 +66,20 @@ def run(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(f"warning: failed to sync Harbor job metadata: {exc}", file=sys.stderr)
     return exit_code
+
+
+def _stop_interrupted_process(process: subprocess.Popen) -> None:
+    try:
+        process.wait(timeout=INTERRUPT_WAIT_TIMEOUT_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        process.terminate()
+
+    try:
+        process.wait(timeout=INTERRUPT_WAIT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait()
 
 
 def sync_metadata(args: argparse.Namespace) -> int:

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -21,16 +21,32 @@ def make_executable(path: Path) -> Path:
 
 
 class FakeProcess:
-    def __init__(self, exit_code: int = 0, interrupt_once: bool = False) -> None:
+    def __init__(
+        self,
+        exit_code: int = 0,
+        interrupt_once: bool = False,
+        timeout_after_interrupt: bool = False,
+    ) -> None:
         self.exit_code = exit_code
         self.interrupt_once = interrupt_once
+        self.timeout_after_interrupt = timeout_after_interrupt
         self.waits = 0
+        self.terminates = 0
+        self.kills = 0
 
-    def wait(self) -> int:
+    def wait(self, timeout: float | None = None) -> int:
         self.waits += 1
         if self.interrupt_once and self.waits == 1:
             raise KeyboardInterrupt
+        if self.timeout_after_interrupt and self.waits == 2:
+            raise cli.subprocess.TimeoutExpired("fake", timeout)
         return self.exit_code
+
+    def terminate(self) -> None:
+        self.terminates += 1
+
+    def kill(self) -> None:
+        self.kills += 1
 
 
 def test_build_harbor_command_oracle_defaults(tmp_path: Path) -> None:
@@ -294,18 +310,39 @@ def test_main_skips_metadata_sync_when_disabled(
     assert synced == []
 
 
-def test_main_waits_for_child_after_keyboard_interrupt(
+def test_main_returns_130_after_keyboard_interrupt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    synced: list[str] = []
     process = FakeProcess(130, interrupt_once=True)
-    monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda _command: process)
+    monkeypatch.setattr(
+        metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
+    )
+
+    assert cli.main(["run", str(tmp_path)]) == 130
+
+    assert process.waits == 2
+    assert process.terminates == 0
+    assert process.kills == 0
+    assert synced == []
+
+
+def test_main_terminates_child_after_keyboard_interrupt_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(130, interrupt_once=True, timeout_after_interrupt=True)
     monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
     monkeypatch.setattr(cli.subprocess, "Popen", lambda _command: process)
 
     assert cli.main(["run", str(tmp_path)]) == 130
 
-    assert process.waits == 2
+    assert process.waits == 3
+    assert process.terminates == 1
+    assert process.kills == 0
 
 
 def test_main_sync_metadata_command_uses_default_jobs_dir(

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -20,6 +20,19 @@ def make_executable(path: Path) -> Path:
     return path
 
 
+class FakeProcess:
+    def __init__(self, exit_code: int = 0, interrupt_once: bool = False) -> None:
+        self.exit_code = exit_code
+        self.interrupt_once = interrupt_once
+        self.waits = 0
+
+    def wait(self) -> int:
+        self.waits += 1
+        if self.interrupt_once and self.waits == 1:
+            raise KeyboardInterrupt
+        return self.exit_code
+
+
 def test_build_harbor_command_oracle_defaults(tmp_path: Path) -> None:
     args = parse(["run", str(tmp_path)])
 
@@ -240,7 +253,7 @@ def test_main_runs_bundled_harbor_and_prints_debug(
     calls: list[list[str]] = []
     harbor_bin = tmp_path / "bin" / "runme-harbor-harbor"
     monkeypatch.setattr(cli, "_preflight", lambda _agent: harbor_bin)
-    monkeypatch.setattr(cli.subprocess, "call", lambda command: calls.append(command) or 7)
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda command: calls.append(command) or FakeProcess(7))
 
     assert cli.main(["run", str(tmp_path), "--debug"]) == 7
 
@@ -254,7 +267,7 @@ def test_main_syncs_metadata_after_harbor_run(
 ) -> None:
     synced: list[str] = []
     monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
-    monkeypatch.setattr(cli.subprocess, "call", lambda _command: 7)
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda _command: FakeProcess(7))
     monkeypatch.setattr(
         metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
     )
@@ -271,7 +284,7 @@ def test_main_skips_metadata_sync_when_disabled(
     synced: list[str] = []
     monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
     monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
-    monkeypatch.setattr(cli.subprocess, "call", lambda _command: 0)
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda _command: FakeProcess(0))
     monkeypatch.setattr(
         metadata_sync, "sync_jobs_metadata", lambda jobs_dir: synced.append(jobs_dir) or 1
     )
@@ -279,6 +292,20 @@ def test_main_skips_metadata_sync_when_disabled(
     assert cli.main(["run", str(tmp_path), "--jobs-dir", "jobs"]) == 0
 
     assert synced == []
+
+
+def test_main_waits_for_child_after_keyboard_interrupt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess(130, interrupt_once=True)
+    monkeypatch.setenv(cli.SKIP_METADATA_SYNC_ENV, "1")
+    monkeypatch.setattr(cli, "_preflight", lambda _agent: tmp_path / "runme-harbor-harbor")
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda _command: process)
+
+    assert cli.main(["run", str(tmp_path)]) == 130
+
+    assert process.waits == 2
 
 
 def test_main_sync_metadata_command_uses_default_jobs_dir(

--- a/internal/harbor/eval.go
+++ b/internal/harbor/eval.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -88,6 +89,12 @@ func (r *EvalRunner) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	runmeHarbor, err := resolveRunmeHarbor(opts)
+	if err != nil {
+		return err
+	}
+
 	if _, err := os.Stat(paths.datasetPath); err != nil {
 		if os.IsNotExist(err) {
 			if paths.defaultDataset {
@@ -109,11 +116,6 @@ func (r *EvalRunner) Run(args []string) error {
 	}
 	if containsEnvironmentFlag(paths.passthrough) {
 		return fmt.Errorf("use runme eval --env instead of passing Harbor environment flags after --")
-	}
-
-	runmeHarbor, err := resolveRunmeHarbor(opts)
-	if err != nil {
-		return err
 	}
 
 	runmeBin, err := resolveRunmeBin(opts)
@@ -463,7 +465,10 @@ func runExternalCommand(name string, args []string, workingDir string, env []str
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = stdin
-	return cmd.Run()
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return waitExternalCommand(cmd)
 }
 
 func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer, stdoutFile *os.File) error {
@@ -491,7 +496,7 @@ func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, std
 		copyDone <- err
 	}()
 
-	waitErr := cmd.Wait()
+	waitErr := waitExternalCommand(cmd)
 	copyErr := <-copyDone
 	if waitErr != nil {
 		return waitErr
@@ -503,6 +508,31 @@ func runExternalCommandWithPtyStdout(cmd *exec.Cmd, stdin io.Reader, stdout, std
 		return copyErr
 	}
 	return nil
+}
+
+func waitExternalCommand(cmd *exec.Cmd) error {
+	signals := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(signals)
+		close(done)
+	}()
+
+	go func() {
+		for {
+			select {
+			case sig := <-signals:
+				if sig != os.Interrupt && cmd.Process != nil {
+					_ = cmd.Process.Signal(sig)
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	return cmd.Wait()
 }
 
 func isTerminal(fd uintptr) bool {

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -1135,6 +1136,9 @@ func TestWaitExternalCommandIgnoresInterruptForwardingAndWaits(t *testing.T) {
 func TestWaitExternalCommandForwardsTerminateAndWaits(t *testing.T) {
 	if testing.Short() {
 		t.Skip("signal test is too slow for short mode")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("SIGTERM forwarding to shell traps is POSIX-specific")
 	}
 
 	cmd := exec.Command(

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/creack/pty"
 	"github.com/go-git/go-git/v5"
@@ -1093,6 +1095,78 @@ func TestRunExternalCommandWithPtyStdoutReturnsExitError(t *testing.T) {
 	}
 	if got := stdout.String(); got != "before-exit" {
 		t.Fatalf("stdout = %q, want before-exit", got)
+	}
+}
+
+func TestWaitExternalCommandIgnoresInterruptForwardingAndWaits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("signal test is too slow for short mode")
+	}
+
+	cmd := exec.Command(
+		testShell(t),
+		"-c",
+		"trap 'printf interrupted; exit 130' INT; sleep 0.3; printf completed",
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		process, err := os.FindProcess(os.Getpid())
+		if err == nil {
+			_ = process.Signal(os.Interrupt)
+		}
+	}()
+
+	err := waitExternalCommand(cmd)
+	if err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+	if got := stdout.String(); got != "completed" {
+		t.Fatalf("stdout = %q, want completed", got)
+	}
+}
+
+func TestWaitExternalCommandForwardsTerminateAndWaits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("signal test is too slow for short mode")
+	}
+
+	cmd := exec.Command(
+		testShell(t),
+		"-c",
+		"trap 'printf terminated; exit 143' TERM; while :; do sleep 1; done",
+	)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		process, err := os.FindProcess(os.Getpid())
+		if err == nil {
+			_ = process.Signal(syscall.SIGTERM)
+		}
+	}()
+
+	err := waitExternalCommand(cmd)
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %[1]v, want *exec.ExitError", err)
+	}
+	if exitErr.ExitCode() != 143 {
+		t.Fatalf("exit code = %d, want 143", exitErr.ExitCode())
+	}
+	if got := stdout.String(); got != "terminated" {
+		t.Fatalf("stdout = %q, want terminated", got)
 	}
 }
 

--- a/internal/harbor/eval_view.go
+++ b/internal/harbor/eval_view.go
@@ -1,0 +1,265 @@
+package harbor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pkg/browser"
+)
+
+const (
+	defaultEvalViewPort      = 8080
+	defaultEvalViewPortLimit = 8180
+)
+
+type EvalViewOptions struct {
+	JobsDir        string
+	Port           int
+	Open           bool
+	RunmeHarborBin string
+	Debug          bool
+	CommandStart   CommandStartFunc
+	BrowserOpen    BrowserOpenFunc
+	DashboardReady DashboardReadyFunc
+	LookPath       func(string) (string, error)
+	Stdin          io.Reader
+	Stdout         io.Writer
+	Stderr         io.Writer
+	ExtraEnv       []string
+}
+
+type CommandStartFunc func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) (StartedCommand, error)
+
+type StartedCommand interface {
+	Wait() error
+}
+
+type BrowserOpenFunc func(url string) error
+
+type DashboardReadyFunc func(urls []string) (string, error)
+
+type EvalViewer struct {
+	opts EvalViewOptions
+}
+
+type evalViewPaths struct {
+	jobsDir         string
+	delegateJobsDir string
+	workingDir      string
+}
+
+func NewEvalViewer(opts EvalViewOptions) *EvalViewer {
+	if opts.CommandStart == nil {
+		opts.CommandStart = startExternalCommand
+	}
+	if opts.BrowserOpen == nil {
+		opts.BrowserOpen = browser.OpenURL
+	}
+	if opts.DashboardReady == nil {
+		opts.DashboardReady = waitForDashboard
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	if opts.Stdin == nil {
+		opts.Stdin = os.Stdin
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	return &EvalViewer{opts: opts}
+}
+
+func (r *EvalViewer) Run(args []string) error {
+	opts := r.opts
+	if len(args) > 0 && opts.JobsDir == "" {
+		opts.JobsDir = args[0]
+	}
+
+	runmeHarbor, err := resolveRunmeHarbor(EvalOptions{
+		RunmeHarborBin: opts.RunmeHarborBin,
+		LookPath:       opts.LookPath,
+	})
+	if err != nil {
+		return err
+	}
+
+	bundledHarbor, err := resolveBundledHarbor(runmeHarbor)
+	if err != nil {
+		return err
+	}
+
+	paths, err := resolveEvalViewPaths(opts.JobsDir)
+	if err != nil {
+		return err
+	}
+	if info, err := os.Stat(paths.jobsDir); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("eval jobs directory does not exist: %s", paths.jobsDir)
+		}
+		return err
+	} else if !info.IsDir() {
+		return fmt.Errorf("eval jobs path is not a directory: %s", paths.jobsDir)
+	}
+
+	portArg := fmt.Sprintf("%d", opts.Port)
+	candidatePorts := []int{opts.Port}
+	if opts.Port == 0 {
+		portArg = fmt.Sprintf("%d-%d", defaultEvalViewPort, defaultEvalViewPortLimit)
+		candidatePorts = nil
+		if opts.Open {
+			candidatePorts, err = openLocalPorts(defaultEvalViewPort, defaultEvalViewPortLimit)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	delegatedArgs := []string{
+		"view",
+		paths.delegateJobsDir,
+		"--jobs",
+		"--port",
+		portArg,
+	}
+	if opts.Debug {
+		_, _ = fmt.Fprintf(opts.Stderr, "%s\n", shellCommandString(append([]string{bundledHarbor}, delegatedArgs...)))
+	}
+
+	env := append(os.Environ(), opts.ExtraEnv...)
+	started, err := opts.CommandStart(bundledHarbor, delegatedArgs, paths.workingDir, env, opts.Stdin, opts.Stdout, opts.Stderr)
+	if err != nil {
+		return err
+	}
+
+	if opts.Open {
+		urls := dashboardURLs(candidatePorts)
+		url, err := opts.DashboardReady(urls)
+		if err != nil {
+			_, _ = fmt.Fprintf(opts.Stderr, "warning: dashboard did not become ready at %s: %v\n", strings.Join(urls, ", "), err)
+		} else if err := opts.BrowserOpen(url); err != nil {
+			_, _ = fmt.Fprintf(opts.Stderr, "warning: failed to open dashboard at %s: %v\n", url, err)
+		}
+	}
+
+	return started.Wait()
+}
+
+func resolveEvalViewPaths(jobsDir string) (evalViewPaths, error) {
+	invocationCwd, err := os.Getwd()
+	if err != nil {
+		return evalViewPaths{}, err
+	}
+	invocationCwd = cleanExistingPath(invocationCwd)
+	baseDir := defaultEvalBaseDir(invocationCwd)
+
+	if jobsDir == "" {
+		return evalViewPaths{
+			jobsDir:         filepath.Join(baseDir, DefaultEvalJobsDir),
+			delegateJobsDir: DefaultEvalJobsDir,
+			workingDir:      baseDir,
+		}, nil
+	}
+
+	resolver := evalPathResolver{invocationCwd: invocationCwd, baseDir: baseDir}
+	resolved := resolver.inputPath(jobsDir)
+	delegate := resolver.delegatePath(resolved, invocationCwd)
+	return evalViewPaths{
+		jobsDir:         resolved,
+		delegateJobsDir: delegate,
+		workingDir:      invocationCwd,
+	}, nil
+}
+
+func resolveBundledHarbor(runmeHarbor string) (string, error) {
+	name := "runme-harbor-harbor"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	candidate := filepath.Join(filepath.Dir(runmeHarbor), name)
+	if _, err := resolveExecutable(candidate, exec.LookPath); err != nil {
+		return "", fmt.Errorf("Runme Harbor expected a bundled `runme-harbor-harbor` executable next to `runme-harbor`.\n\nReinstall with:\n  uv tool install runme-harbor --force")
+	}
+	return candidate, nil
+}
+
+func openLocalPorts(start, limit int) ([]int, error) {
+	ports := []int{}
+	for port := start; port <= limit; port++ {
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err == nil {
+			_ = listener.Close()
+			ports = append(ports, port)
+		}
+	}
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("no open local port found in range %d-%d", start, limit)
+	}
+	return ports, nil
+}
+
+func dashboardURLs(ports []int) []string {
+	urls := make([]string, 0, len(ports))
+	for _, port := range ports {
+		urls = append(urls, fmt.Sprintf("http://127.0.0.1:%d", port))
+	}
+	return urls
+}
+
+func waitForDashboard(urls []string) (string, error) {
+	client := http.Client{Timeout: 250 * time.Millisecond}
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		for _, url := range urls {
+			resp, err := client.Get(url)
+			if err == nil {
+				_ = resp.Body.Close()
+				if resp.StatusCode < 500 {
+					return url, nil
+				}
+				lastErr = fmt.Errorf("%s returned status %s", url, resp.Status)
+			} else {
+				lastErr = err
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", errors.New("timed out waiting for dashboard")
+}
+
+type externalStartedCommand struct {
+	cmd *exec.Cmd
+}
+
+func (c externalStartedCommand) Wait() error {
+	return waitExternalCommand(c.cmd)
+}
+
+func startExternalCommand(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) (StartedCommand, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workingDir
+	cmd.Env = env
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return externalStartedCommand{cmd: cmd}, nil
+}

--- a/internal/harbor/eval_view.go
+++ b/internal/harbor/eval_view.go
@@ -184,15 +184,18 @@ func resolveEvalViewPaths(jobsDir string) (evalViewPaths, error) {
 }
 
 func resolveBundledHarbor(runmeHarbor string) (string, error) {
-	name := "runme-harbor-harbor"
-	if runtime.GOOS == "windows" {
-		name += ".exe"
-	}
-	candidate := filepath.Join(filepath.Dir(runmeHarbor), name)
+	candidate := filepath.Join(filepath.Dir(runmeHarbor), bundledHarborExecutableName())
 	if _, err := resolveExecutable(candidate, exec.LookPath); err != nil {
-		return "", fmt.Errorf("Runme Harbor expected a bundled `runme-harbor-harbor` executable next to `runme-harbor`.\n\nReinstall with:\n  uv tool install runme-harbor --force")
+		return "", fmt.Errorf("runme: Harbor installation is missing a required executable.\n\nReinstall with:\n  uv tool install runme-harbor --force")
 	}
 	return candidate, nil
+}
+
+func bundledHarborExecutableName() string {
+	if runtime.GOOS == "windows" {
+		return "runme-harbor-harbor.exe"
+	}
+	return "runme-harbor-harbor"
 }
 
 func openLocalPorts(start, limit int) ([]int, error) {

--- a/internal/harbor/eval_view_test.go
+++ b/internal/harbor/eval_view_test.go
@@ -1,0 +1,349 @@
+package harbor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+)
+
+type fakeStartedCommand struct {
+	err error
+}
+
+func (c fakeStartedCommand) Wait() error {
+	return c.err
+}
+
+func TestRunEvalViewDefaultsJobsDirFromGitRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := filepath.Join(repoRoot, DefaultEvalJobsDir)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+
+	var calls []recordedCommand
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	opts.Port = 9090
+	opts.Open = false
+
+	if err := NewEvalViewer(opts).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"view", defaultJobsArg(), "--jobs", "--port", "9090"}
+	if !reflect.DeepEqual(calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+	if calls[0].workingDir != repoRoot {
+		t.Fatalf("workingDir = %q, want %q", calls[0].workingDir, repoRoot)
+	}
+}
+
+func TestRunEvalViewExplicitJobsDirUsesInvocationCwd(t *testing.T) {
+	repoRoot := t.TempDir()
+	if _, err := git.PlainInit(repoRoot, false); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(repoRoot, "nested", "dir")
+	jobsDir := filepath.Join(nested, "custom", "jobs")
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(nested)
+
+	var calls []recordedCommand
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	opts.Port = 9090
+	opts.Open = false
+
+	if err := NewEvalViewer(opts).Run([]string{"custom/jobs"}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"view", filepath.Join("custom", "jobs"), "--jobs", "--port", "9090"}
+	if !reflect.DeepEqual(calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+	if calls[0].workingDir != cleanExistingPath(nested) {
+		t.Fatalf("workingDir = %q, want %q", calls[0].workingDir, cleanExistingPath(nested))
+	}
+}
+
+func TestRunEvalViewDelegatesBundledHarborAndOpensDashboard(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	var opened []string
+	var ready []string
+	var stderr bytes.Buffer
+	opts := testEvalViewOptions(t, &calls, &stderr)
+	opts.Port = 9090
+	opts.Debug = true
+	opts.DashboardReady = func(urls []string) (string, error) {
+		ready = append(ready, urls...)
+		return urls[0], nil
+	}
+	opts.BrowserOpen = func(url string) error {
+		opened = append(opened, url)
+		return nil
+	}
+
+	if err := NewEvalViewer(opts).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	bundledHarbor := filepath.Join(filepath.Dir(opts.RunmeHarborBin), "runme-harbor-harbor")
+	want := recordedCommand{
+		name:       bundledHarbor,
+		args:       []string{"view", defaultJobsArg(), "--jobs", "--port", "9090"},
+		workingDir: cleanExistingPath(tmp),
+	}
+	if !sameCommand(calls[0], want) || calls[0].workingDir != want.workingDir {
+		t.Fatalf("call = %#v, want %#v", calls[0], want)
+	}
+	wantURL := "http://127.0.0.1:9090"
+	if !reflect.DeepEqual(ready, []string{wantURL}) {
+		t.Fatalf("ready = %#v, want %q", ready, wantURL)
+	}
+	if !reflect.DeepEqual(opened, []string{wantURL}) {
+		t.Fatalf("opened = %#v, want %q", opened, wantURL)
+	}
+	wantDebug := shellCommandString(append([]string{bundledHarbor}, want.args...)) + "\n"
+	if stderr.String() != wantDebug {
+		t.Fatalf("debug = %q, want %q", stderr.String(), wantDebug)
+	}
+}
+
+func TestRunEvalViewNoOpenSkipsDashboardOpen(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	opts.Port = 9090
+	opts.Open = false
+	opts.DashboardReady = func([]string) (string, error) {
+		t.Fatal("DashboardReady called")
+		return "", nil
+	}
+	opts.BrowserOpen = func(string) error {
+		t.Fatal("BrowserOpen called")
+		return nil
+	}
+
+	if err := NewEvalViewer(opts).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %#v, want one delegate", calls)
+	}
+}
+
+func TestRunEvalViewAutoPortDelegatesRange(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	var ready []string
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	opts.Port = 0
+	opts.DashboardReady = func(urls []string) (string, error) {
+		ready = append(ready, urls...)
+		return "http://127.0.0.1:8081", nil
+	}
+
+	if err := NewEvalViewer(opts).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"view", defaultJobsArg(), "--jobs", "--port", "8080-8180"}
+	if !reflect.DeepEqual(calls[0].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+	if len(ready) == 0 {
+		t.Fatal("DashboardReady did not receive candidate URLs")
+	}
+}
+
+func TestRunEvalViewWarnsWhenDashboardOpenFails(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	var stderr bytes.Buffer
+	opts := testEvalViewOptions(t, &calls, &stderr)
+	opts.Port = 9090
+	opts.DashboardReady = func(urls []string) (string, error) { return urls[0], nil }
+	opts.BrowserOpen = func(string) error { return errors.New("no opener") }
+
+	if err := NewEvalViewer(opts).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stderr.String(), "warning: failed to open dashboard") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunEvalViewMissingRunmeHarbor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	opts.RunmeHarborBin = ""
+	opts.LookPath = func(string) (string, error) {
+		return "", os.ErrNotExist
+	}
+
+	err := NewEvalViewer(opts).Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrRunmeHarborMissing) {
+		t.Fatalf("error = %q, want ErrRunmeHarborMissing", err.Error())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls = %#v, want none", calls)
+	}
+}
+
+func TestRunEvalViewMissingBundledHarbor(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.MkdirAll(DefaultEvalJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []recordedCommand
+	opts := testEvalViewOptions(t, &calls, io.Discard)
+	if err := os.Remove(filepath.Join(filepath.Dir(opts.RunmeHarborBin), "runme-harbor-harbor")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := NewEvalViewer(opts).Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "uv tool install runme-harbor --force") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls = %#v, want none", calls)
+	}
+}
+
+func TestOpenLocalPortsSkipsOccupiedPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	occupied := listener.Addr().(*net.TCPAddr).Port
+	if occupied == 65535 {
+		t.Skip("occupied port has no next port")
+	}
+	next := occupied + 1
+	probe, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", next))
+	if err != nil {
+		t.Skipf("next port %d is unavailable: %v", next, err)
+	}
+	_ = probe.Close()
+
+	ports, err := openLocalPorts(occupied, occupied+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ports, []int{next}) {
+		t.Fatalf("ports = %#v, want [%d]", ports, next)
+	}
+}
+
+func TestRunEvalMissingHarborBeforeMissingDefaultDataset(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.LookPath = func(string) (string, error) {
+		return "", os.ErrNotExist
+	}
+
+	err := NewEvalRunner(opts).Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, ErrRunmeHarborMissing) {
+		t.Fatalf("error = %q, want ErrRunmeHarborMissing", err.Error())
+	}
+	if len(calls) != 0 {
+		t.Fatalf("calls = %#v, want none", calls)
+	}
+}
+
+func testEvalViewOptions(t *testing.T, calls *[]recordedCommand, stderr io.Writer) EvalViewOptions {
+	t.Helper()
+	binDir := t.TempDir()
+	runmeHarbor := filepath.Join(binDir, "runme-harbor")
+	bundledHarbor := filepath.Join(binDir, "runme-harbor-harbor")
+	for _, path := range []string{runmeHarbor, bundledHarbor} {
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return EvalViewOptions{
+		Port:           9090,
+		Open:           true,
+		RunmeHarborBin: runmeHarbor,
+		CommandStart:   recordStartedCommand(calls, nil),
+		BrowserOpen:    func(string) error { return nil },
+		DashboardReady: func(urls []string) (string, error) { return urls[0], nil },
+		Stdin:          nil,
+		Stdout:         io.Discard,
+		Stderr:         stderr,
+	}
+}
+
+func recordStartedCommand(calls *[]recordedCommand, err error) CommandStartFunc {
+	return func(name string, args []string, workingDir string, env []string, stdin io.Reader, stdout, stderr io.Writer) (StartedCommand, error) {
+		*calls = append(*calls, recordedCommand{
+			name:       name,
+			args:       append([]string(nil), args...),
+			workingDir: workingDir,
+			env:        append([]string(nil), env...),
+		})
+		return fakeStartedCommand{err: err}, nil
+	}
+}

--- a/internal/harbor/eval_view_test.go
+++ b/internal/harbor/eval_view_test.go
@@ -24,7 +24,7 @@ func (c fakeStartedCommand) Wait() error {
 }
 
 func TestRunEvalViewDefaultsJobsDirFromGitRoot(t *testing.T) {
-	repoRoot := t.TempDir()
+	repoRoot := cleanExistingPath(t.TempDir())
 	if _, err := git.PlainInit(repoRoot, false); err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestRunEvalViewDefaultsJobsDirFromGitRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"view", defaultJobsArg(), "--jobs", "--port", "9090"}
+	want := []string{"view", DefaultEvalJobsDir, "--jobs", "--port", "9090"}
 	if !reflect.DeepEqual(calls[0].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
 	}
@@ -113,10 +113,10 @@ func TestRunEvalViewDelegatesBundledHarborAndOpensDashboard(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bundledHarbor := filepath.Join(filepath.Dir(opts.RunmeHarborBin), "runme-harbor-harbor")
+	bundledHarbor := filepath.Join(filepath.Dir(opts.RunmeHarborBin), bundledHarborExecutableName())
 	want := recordedCommand{
 		name:       bundledHarbor,
-		args:       []string{"view", defaultJobsArg(), "--jobs", "--port", "9090"},
+		args:       []string{"view", DefaultEvalJobsDir, "--jobs", "--port", "9090"},
 		workingDir: cleanExistingPath(tmp),
 	}
 	if !sameCommand(calls[0], want) || calls[0].workingDir != want.workingDir {
@@ -183,7 +183,7 @@ func TestRunEvalViewAutoPortDelegatesRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := []string{"view", defaultJobsArg(), "--jobs", "--port", "8080-8180"}
+	want := []string{"view", DefaultEvalJobsDir, "--jobs", "--port", "8080-8180"}
 	if !reflect.DeepEqual(calls[0].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
 	}
@@ -249,7 +249,7 @@ func TestRunEvalViewMissingBundledHarbor(t *testing.T) {
 
 	var calls []recordedCommand
 	opts := testEvalViewOptions(t, &calls, io.Discard)
-	if err := os.Remove(filepath.Join(filepath.Dir(opts.RunmeHarborBin), "runme-harbor-harbor")); err != nil {
+	if err := os.Remove(filepath.Join(filepath.Dir(opts.RunmeHarborBin), bundledHarborExecutableName())); err != nil {
 		t.Fatal(err)
 	}
 
@@ -317,7 +317,7 @@ func testEvalViewOptions(t *testing.T, calls *[]recordedCommand, stderr io.Write
 	t.Helper()
 	binDir := t.TempDir()
 	runmeHarbor := filepath.Join(binDir, "runme-harbor")
-	bundledHarbor := filepath.Join(binDir, "runme-harbor-harbor")
+	bundledHarbor := filepath.Join(binDir, bundledHarborExecutableName())
 	for _, path := range []string{runmeHarbor, bundledHarbor} {
 		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

- add `runme eval view [jobs-dir]` for launching Harbor eval job dashboards
- delegate directly to bundled `runme-harbor-harbor view --jobs` with Harbor's `8080-8180` port range
- open the local dashboard by default, with `--no-open` and `--port` escape hatches
- preflight `runme-harbor` before eval dataset validation so missing optional dependency errors are consistent

## Tests

- `go test ./cmd -run 'TestEval'`
- `go test ./internal/harbor -run 'TestRunEvalView|TestFirstOpenLocalPort|TestRunEvalMissingHarborBeforeMissingDefaultDataset|TestRunEvalMissing|TestRunEvalDelegates'`
- `go test ./cmd`
- `go test ./internal/harbor`
- `runme run test`
