### PR TITLE
feat: add eval promote command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -88,6 +88,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags.BoolVar(&opts.debug, "debug", false, "Print delegated commands")
 
 	cmd.AddCommand(evalViewCmd())
+	cmd.AddCommand(evalPromoteCmd())
 
 	return cmd
 }

--- a/cmd/eval_promote.go
+++ b/cmd/eval_promote.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type evalPromoter interface {
+	Run(args []string) error
+}
+
+var newEvalPromoter = func(opts harbor.EvalPromoteOptions) evalPromoter {
+	return harbor.NewEvalPromoter(opts)
+}
+
+type evalPromoteOptions struct {
+	jobsDir       string
+	job           string
+	latest        bool
+	dryRun        bool
+	evidenceOnly  bool
+	includeOracle bool
+	allowErrors   bool
+	message       string
+	stdout        io.Writer
+	stderr        io.Writer
+}
+
+func evalPromoteCmd() *cobra.Command {
+	opts := evalPromoteOptions{
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "promote",
+		Short: "Commit staged changes with eval job evidence",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.stdout = cmd.OutOrStdout()
+			opts.stderr = cmd.ErrOrStderr()
+			return runEvalPromote(opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.jobsDir, "jobs-dir", "", "Eval jobs directory; defaults to .runme/evals/jobs under the project root")
+	flags.StringVar(&opts.job, "job", "", "Eval job directory to promote")
+	flags.BoolVar(&opts.latest, "latest", false, "Promote the latest eval job under --jobs-dir")
+	flags.BoolVar(&opts.dryRun, "dry-run", false, "Print what would be committed without staging or committing")
+	flags.BoolVar(&opts.evidenceOnly, "evidence-only", false, "Commit only the selected eval job evidence when no source changes are staged")
+	flags.BoolVar(&opts.includeOracle, "include-oracle", false, "Allow promoting eval jobs that only used Harbor's oracle agent")
+	flags.BoolVar(&opts.allowErrors, "allow-errors", false, "Allow promoting eval jobs with errored trials")
+	flags.StringVar(&opts.message, "message", "", "Commit message subject")
+
+	return cmd
+}
+
+func runEvalPromote(opts evalPromoteOptions, args []string) error {
+	err := newEvalPromoter(harbor.EvalPromoteOptions{
+		JobsDir:       opts.jobsDir,
+		Job:           opts.job,
+		Latest:        opts.latest,
+		DryRun:        opts.dryRun,
+		EvidenceOnly:  opts.evidenceOnly,
+		IncludeOracle: opts.includeOracle,
+		AllowErrors:   opts.allowErrors,
+		Message:       opts.message,
+		Stdout:        opts.stdout,
+		Stderr:        opts.stderr,
+	}).Run(args)
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
+	}
+	var codeErr interface{ ExitCode() int }
+	if errors.As(err, &codeErr) {
+		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
+	}
+	return err
+}

--- a/cmd/eval_promote_test.go
+++ b/cmd/eval_promote_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type fakeEvalPromoter struct {
+	err error
+}
+
+func (p fakeEvalPromoter) Run([]string) error {
+	return p.err
+}
+
+func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
+	var gotOpts harbor.EvalPromoteOptions
+	var gotArgs []string
+	cmd := evalCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"promote",
+		"--jobs-dir", "jobs",
+		"--job", "jobs/job-1",
+		"--dry-run",
+		"--evidence-only",
+		"--include-oracle",
+		"--allow-errors",
+		"--message", "Custom subject",
+	})
+	restoreEvalPromoter(t, func(opts harbor.EvalPromoteOptions) evalPromoter {
+		gotOpts = opts
+		return evalPromoterFunc(func(args []string) error {
+			gotArgs = append([]string(nil), args...)
+			return nil
+		})
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotArgs, []string(nil)) {
+		t.Fatalf("args = %#v", gotArgs)
+	}
+	if gotOpts.JobsDir != "jobs" ||
+		gotOpts.Job != "jobs/job-1" ||
+		!gotOpts.DryRun ||
+		!gotOpts.EvidenceOnly ||
+		!gotOpts.IncludeOracle ||
+		!gotOpts.AllowErrors ||
+		gotOpts.Latest ||
+		gotOpts.Message != "Custom subject" ||
+		gotOpts.Stdout != &stdout ||
+		gotOpts.Stderr != &stderr {
+		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalPromoteCmdPassesLatest(t *testing.T) {
+	var gotOpts harbor.EvalPromoteOptions
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"promote", "--latest"})
+	restoreEvalPromoter(t, func(opts harbor.EvalPromoteOptions) evalPromoter {
+		gotOpts = opts
+		return fakeEvalPromoter{}
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !gotOpts.Latest {
+		t.Fatal("Latest = false, want true")
+	}
+}
+
+func TestRunEvalPromotePropagatesDelegateExitCode(t *testing.T) {
+	restoreEvalPromoter(t, func(harbor.EvalPromoteOptions) evalPromoter {
+		return fakeEvalPromoter{err: fakeExitError{code: 42}}
+	})
+
+	err := runEvalPromote(evalPromoteOptions{}, nil)
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+	if exitErr.Code != 42 {
+		t.Fatalf("exit code = %d, want 42", exitErr.Code)
+	}
+}
+
+type evalPromoterFunc func([]string) error
+
+func (f evalPromoterFunc) Run(args []string) error {
+	return f(args)
+}
+
+func restoreEvalPromoter(t *testing.T, fn func(harbor.EvalPromoteOptions) evalPromoter) {
+	t.Helper()
+	previous := newEvalPromoter
+	newEvalPromoter = fn
+	t.Cleanup(func() {
+		newEvalPromoter = previous
+	})
+}

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -1,0 +1,161 @@
+package harbor
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const defaultPromoteSubject = "Promote changes verified by task eval"
+
+type EvalPromoteOptions struct {
+	JobsDir       string
+	Job           string
+	Latest        bool
+	DryRun        bool
+	EvidenceOnly  bool
+	IncludeOracle bool
+	AllowErrors   bool
+	Message       string
+	Stdout        io.Writer
+	Stderr        io.Writer
+	Git           promoteGit
+}
+
+type EvalPromoter struct {
+	opts EvalPromoteOptions
+}
+
+func NewEvalPromoter(opts EvalPromoteOptions) *EvalPromoter {
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	if opts.Message == "" {
+		opts.Message = defaultPromoteSubject
+	}
+	return &EvalPromoter{opts: opts}
+}
+
+func (p *EvalPromoter) Run(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("accepts no arguments")
+	}
+	if p.opts.Job == "" && !p.opts.Latest {
+		return fmt.Errorf("one of --job or --latest is required")
+	}
+	if p.opts.Job != "" && p.opts.Latest {
+		return fmt.Errorf("--job cannot be used together with --latest")
+	}
+
+	jobsRoot, jobDir, selection, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir:       p.opts.JobsDir,
+		job:           p.opts.Job,
+		latest:        p.opts.Latest,
+		includeOracle: p.opts.IncludeOracle,
+		allowErrors:   p.opts.AllowErrors,
+	})
+	if err != nil {
+		return err
+	}
+
+	result, err := readPromoteJobResult(jobDir)
+	if err != nil {
+		return err
+	}
+	config, err := readPromoteJobConfig(jobDir)
+	if err != nil {
+		return err
+	}
+	if err := validatePromoteJobPolicy(result, config, promoteJobPolicy{
+		includeOracle: p.opts.IncludeOracle,
+		allowErrors:   p.opts.AllowErrors,
+	}); err != nil {
+		return err
+	}
+
+	gitClient := p.opts.Git
+	if gitClient == nil {
+		gitClient, err = newGoGitPromoteClient()
+		if err != nil {
+			return err
+		}
+	}
+
+	jobRel, err := gitClient.Rel(jobDir)
+	if err != nil {
+		return err
+	}
+	jobsRel, err := gitClient.Rel(jobsRoot)
+	if err != nil {
+		return err
+	}
+	if p.opts.Latest {
+		selection = fmt.Sprintf("latest job under %s", jobsRel)
+	}
+	if warning := newerPromotableJobWarning(jobsRoot, jobDir, result, promoteJobPolicy{
+		includeOracle: p.opts.IncludeOracle,
+		allowErrors:   p.opts.AllowErrors,
+	}); warning != "" {
+		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s\n", warning, jobsRel)
+	}
+	resultRel, err := gitClient.Rel(result.Path)
+	if err != nil {
+		return err
+	}
+	message := renderPromoteCommitMessage(promoteMessageData{
+		subject:      p.opts.Message,
+		jobPath:      jobRel,
+		resultPath:   resultRel,
+		evidenceOnly: p.opts.EvidenceOnly,
+		config:       config,
+		result:       result,
+	})
+
+	if p.opts.DryRun {
+		_, _ = fmt.Fprintf(p.opts.Stdout, "Selected eval job: %s\n", jobRel)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "Selection: %s\n\n", selection)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s\n", message)
+		return nil
+	}
+
+	staged, err := gitClient.StagedFiles()
+	if err != nil {
+		return err
+	}
+	if len(staged) == 0 {
+		if !p.opts.EvidenceOnly {
+			return fmt.Errorf("no staged changes to promote; use --evidence-only to commit only the selected eval job evidence")
+		}
+	} else if p.opts.EvidenceOnly {
+		return fmt.Errorf("--evidence-only cannot be used with staged changes")
+	}
+	if len(staged) > 0 {
+		if conflicts, err := gitClient.UnstagedFilesTouching(staged); err != nil {
+			return err
+		} else if len(conflicts) > 0 {
+			return fmt.Errorf("unstaged changes touch staged files: %s", joinDisplay(conflicts))
+		}
+	}
+
+	if len(staged) > 0 {
+		latestStagedMod, err := gitClient.LatestModTime(staged)
+		if err != nil {
+			return err
+		}
+		if warning := stalePromoteWarning(result, latestStagedMod); warning != "" {
+			_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s\n", warning)
+		}
+	}
+	if err := gitClient.AddJobDir(jobDir); err != nil {
+		return err
+	}
+	hash, err := gitClient.Commit(message)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(p.opts.Stdout, "Promoted eval job %s in commit %s\n", jobRel, hash)
+	return nil
+}

--- a/internal/harbor/eval_promote_git.go
+++ b/internal/harbor/eval_promote_git.go
@@ -1,0 +1,141 @@
+package harbor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+)
+
+type promoteGit interface {
+	StagedFiles() ([]string, error)
+	UnstagedFilesTouching([]string) ([]string, error)
+	LatestModTime([]string) (time.Time, error)
+	AddJobDir(string) error
+	Commit(string) (string, error)
+	Rel(string) (string, error)
+}
+
+type goGitPromoteClient struct {
+	repo *git.Repository
+	wt   *git.Worktree
+	root string
+}
+
+func newGoGitPromoteClient() (*goGitPromoteClient, error) {
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return nil, err
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	return &goGitPromoteClient{
+		repo: repo,
+		wt:   wt,
+		root: cleanExistingPath(wt.Filesystem.Root()),
+	}, nil
+}
+
+func (c *goGitPromoteClient) StagedFiles() ([]string, error) {
+	status, err := c.wt.Status()
+	if err != nil {
+		return nil, err
+	}
+	var staged []string
+	for path, file := range status {
+		if file.Staging != git.Unmodified && file.Staging != git.Untracked {
+			staged = append(staged, filepath.ToSlash(path))
+		}
+	}
+	sort.Strings(staged)
+	return staged, nil
+}
+
+func (c *goGitPromoteClient) UnstagedFilesTouching(staged []string) ([]string, error) {
+	status, err := c.wt.Status()
+	if err != nil {
+		return nil, err
+	}
+	stagedSet := map[string]struct{}{}
+	for _, path := range staged {
+		stagedSet[filepath.ToSlash(path)] = struct{}{}
+	}
+	var conflicts []string
+	for path, file := range status {
+		if file.Worktree == git.Unmodified {
+			continue
+		}
+		path = filepath.ToSlash(path)
+		if _, ok := stagedSet[path]; ok {
+			conflicts = append(conflicts, path)
+		}
+	}
+	sort.Strings(conflicts)
+	return conflicts, nil
+}
+
+func (c *goGitPromoteClient) LatestModTime(paths []string) (time.Time, error) {
+	var latest time.Time
+	for _, path := range paths {
+		info, err := os.Stat(filepath.Join(c.root, filepath.FromSlash(path)))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return time.Time{}, err
+		}
+		if info.ModTime().After(latest) {
+			latest = info.ModTime()
+		}
+	}
+	return latest, nil
+}
+
+func (c *goGitPromoteClient) AddJobDir(jobDir string) error {
+	return filepath.WalkDir(jobDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := c.Rel(path)
+		if err != nil {
+			return err
+		}
+		return c.wt.AddWithOptions(&git.AddOptions{
+			Path:       filepath.FromSlash(rel),
+			SkipStatus: true,
+		})
+	})
+}
+
+func (c *goGitPromoteClient) Commit(message string) (string, error) {
+	hash, err := c.wt.Commit(message, &git.CommitOptions{})
+	if err != nil {
+		return "", err
+	}
+	return hash.String(), nil
+}
+
+func (c *goGitPromoteClient) Rel(path string) (string, error) {
+	path = cleanExistingPath(path)
+	rel, err := filepath.Rel(c.root, path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %s is outside git root %s", path, c.root)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func joinDisplay(values []string) string {
+	return strings.Join(values, ", ")
+}

--- a/internal/harbor/eval_promote_git_test.go
+++ b/internal/harbor/eval_promote_git_test.go
@@ -1,0 +1,140 @@
+package harbor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestGoGitPromoteClientAddJobDirForceAddsIgnoredFiles(t *testing.T) {
+	repoRoot := t.TempDir()
+	repo, err := git.PlainInit(repoRoot, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".gitignore"), []byte(".runme/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(".gitignore"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("initial", &git.CommitOptions{Author: testPromoteSignature()}); err != nil {
+		t.Fatal(err)
+	}
+
+	jobDir := filepath.Join(repoRoot, ".runme", "evals", "jobs", "job")
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "job.log"), []byte("log"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(repoRoot)
+
+	client, err := newGoGitPromoteClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.AddJobDir(jobDir); err != nil {
+		t.Fatal(err)
+	}
+	status, err := wt.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		".runme/evals/jobs/job/result.json",
+		".runme/evals/jobs/job/job.log",
+	} {
+		if status.File(path).Staging != git.Added {
+			t.Fatalf("%s staging = %q, want added; status=%s", path, status.File(path).Staging, status.String())
+		}
+	}
+}
+
+func TestGoGitPromoteClientStagedFilesIgnoresUntrackedEvalJobs(t *testing.T) {
+	repoRoot := t.TempDir()
+	repo, err := git.PlainInit(repoRoot, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".gitignore"), []byte(".runme/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(".gitignore"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("main.go"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("initial", &git.CommitOptions{Author: testPromoteSignature()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("main.go"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, job := range []string{
+		"2026-06-11__15-16-47",
+		"2026-06-24__16-22-06",
+		"2026-06-25__09-02-34",
+	} {
+		workdir := filepath.Join(repoRoot, ".runme", "evals", "jobs", job, "text-stats-reward__abc123", "workdir")
+		if err := os.MkdirAll(workdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(workdir, ".gitignore"), []byte("*\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(workdir, ".gitkeep"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(workdir, "sample.txt"), []byte("sample"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(repoRoot)
+
+	client, err := newGoGitPromoteClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staged, err := client.StagedFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(staged) != 1 || staged[0] != "main.go" {
+		t.Fatalf("staged = %#v, want only main.go", staged)
+	}
+	conflicts, err := client.UnstagedFilesTouching(staged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("conflicts = %#v, want none", conflicts)
+	}
+}
+
+func testPromoteSignature() *object.Signature {
+	return &object.Signature{Name: "Runme Test", Email: "test@example.com"}
+}

--- a/internal/harbor/eval_promote_job.go
+++ b/internal/harbor/eval_promote_job.go
@@ -1,0 +1,401 @@
+package harbor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type promoteJobOptions struct {
+	jobsDir       string
+	job           string
+	latest        bool
+	includeOracle bool
+	allowErrors   bool
+}
+
+type promoteJobResult struct {
+	Path         string
+	StartedAt    time.Time
+	UpdatedAt    time.Time
+	FinishedAt   time.Time
+	TotalTrials  int
+	Stats        promoteJobStats
+	RawTimestamp string
+}
+
+type promoteJobStats struct {
+	CompletedTrials int                         `json:"n_completed_trials"`
+	ErroredTrials   int                         `json:"n_errored_trials"`
+	RunningTrials   int                         `json:"n_running_trials"`
+	PendingTrials   int                         `json:"n_pending_trials"`
+	CancelledTrials int                         `json:"n_cancelled_trials"`
+	Retries         int                         `json:"n_retries"`
+	Evals           map[string]promoteEvalStats `json:"evals"`
+	InputTokens     *int                        `json:"n_input_tokens"`
+	CacheTokens     *int                        `json:"n_cache_tokens"`
+	OutputTokens    *int                        `json:"n_output_tokens"`
+	CostUSD         *float64                    `json:"cost_usd"`
+}
+
+type promoteEvalStats struct {
+	Trials  int                      `json:"n_trials"`
+	Errors  int                      `json:"n_errors"`
+	Metrics []map[string]interface{} `json:"metrics"`
+}
+
+type promoteJobConfig struct {
+	Datasets    []promoteDatasetConfig `json:"datasets"`
+	Agents      []promoteAgentConfig   `json:"agents"`
+	Environment promoteEnvConfig       `json:"environment"`
+}
+
+type promoteDatasetConfig struct {
+	Path      string   `json:"path"`
+	Name      string   `json:"name"`
+	TaskNames []string `json:"task_names"`
+}
+
+type promoteAgentConfig struct {
+	Name       string `json:"name"`
+	ImportPath string `json:"import_path"`
+	ModelName  string `json:"model_name"`
+}
+
+type promoteEnvConfig struct {
+	Type       string `json:"type"`
+	ImportPath string `json:"import_path"`
+}
+
+func resolvePromoteJob(opts promoteJobOptions) (jobsRoot, jobDir, selection string, err error) {
+	paths, err := resolveEvalViewPaths(opts.jobsDir)
+	if err != nil {
+		return "", "", "", err
+	}
+	jobsRoot = paths.jobsDir
+
+	if opts.latest {
+		jobDir, selection, err = latestPromoteJob(jobsRoot, promoteJobPolicy{
+			includeOracle: opts.includeOracle,
+			allowErrors:   opts.allowErrors,
+		})
+		if err != nil {
+			return "", "", "", err
+		}
+		return jobsRoot, jobDir, selection, nil
+	}
+
+	invocationCwd, err := os.Getwd()
+	if err != nil {
+		return "", "", "", err
+	}
+	jobDir = opts.job
+	if !filepath.IsAbs(jobDir) {
+		jobDir = filepath.Join(invocationCwd, jobDir)
+	}
+	jobDir = cleanExistingPath(jobDir)
+	if err := validatePromoteJobDir(jobsRoot, jobDir); err != nil {
+		return "", "", "", err
+	}
+	return jobsRoot, jobDir, "explicit --job", nil
+}
+
+type promoteJobPolicy struct {
+	includeOracle bool
+	allowErrors   bool
+}
+
+func latestPromoteJob(jobsRoot string, policy promoteJobPolicy) (string, string, error) {
+	entries, err := os.ReadDir(jobsRoot)
+	if err != nil {
+		return "", "", err
+	}
+	var candidates []promoteJobCandidate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(jobsRoot, entry.Name())
+		result, err := readPromoteJobResult(dir)
+		if err != nil {
+			continue
+		}
+		config, err := readPromoteJobConfig(dir)
+		if err != nil {
+			continue
+		}
+		if err := validatePromoteJobPolicy(result, config, policy); err != nil {
+			continue
+		}
+		timestamp := resultTimestamp(result)
+		info, _ := entry.Info()
+		candidates = append(candidates, promoteJobCandidate{
+			dir:       dir,
+			name:      entry.Name(),
+			timestamp: timestamp,
+			modTime:   info.ModTime(),
+		})
+	}
+	if len(candidates) == 0 {
+		return "", "", fmt.Errorf("no promotable eval jobs found under %s; use --include-oracle for oracle-only jobs or --allow-errors for errored jobs", jobsRoot)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		left, right := candidates[i], candidates[j]
+		if !left.timestamp.IsZero() || !right.timestamp.IsZero() {
+			if !left.timestamp.Equal(right.timestamp) {
+				return left.timestamp.After(right.timestamp)
+			}
+		}
+		if left.name != right.name {
+			return left.name > right.name
+		}
+		return left.modTime.After(right.modTime)
+	})
+	return candidates[0].dir, "latest job under --jobs-dir", nil
+}
+
+func validatePromoteJobPolicy(result promoteJobResult, config promoteJobConfig, policy promoteJobPolicy) error {
+	if reason := incompletePromoteJobReason(result); reason != "" {
+		return fmt.Errorf("eval job is incomplete: %s", reason)
+	}
+	if result.Stats.ErroredTrials > 0 && !policy.allowErrors {
+		return fmt.Errorf("eval job has %d errored trial(s); use --allow-errors to promote it anyway", result.Stats.ErroredTrials)
+	}
+	if isOracleOnlyPromoteJob(config, result) && !policy.includeOracle {
+		return fmt.Errorf("eval job only used Harbor's oracle agent; use --include-oracle to promote it anyway")
+	}
+	return nil
+}
+
+func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult promoteJobResult, policy promoteJobPolicy) string {
+	entries, err := os.ReadDir(jobsRoot)
+	if err != nil {
+		return ""
+	}
+	selectedJobDir = cleanExistingPath(selectedJobDir)
+	selectedName := filepath.Base(selectedJobDir)
+	selectedTimestamp := resultTimestamp(selectedResult)
+	var foundNewer bool
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := cleanExistingPath(filepath.Join(jobsRoot, entry.Name()))
+		if dir == selectedJobDir {
+			continue
+		}
+		result, err := readPromoteJobResult(dir)
+		if err != nil {
+			continue
+		}
+		if !isPromoteJobNewer(result, entry.Name(), selectedTimestamp, selectedName) {
+			continue
+		}
+		foundNewer = true
+		config, err := readPromoteJobConfig(dir)
+		if err != nil {
+			continue
+		}
+		if validatePromoteJobPolicy(result, config, policy) == nil {
+			return ""
+		}
+	}
+	if !foundNewer {
+		return ""
+	}
+	return "no newer complete promotable eval job found"
+}
+
+func isPromoteJobNewer(result promoteJobResult, name string, selectedTimestamp time.Time, selectedName string) bool {
+	timestamp := resultTimestamp(result)
+	if !timestamp.IsZero() || !selectedTimestamp.IsZero() {
+		if !timestamp.Equal(selectedTimestamp) {
+			return timestamp.After(selectedTimestamp)
+		}
+	}
+	return name > selectedName
+}
+
+func incompletePromoteJobReason(result promoteJobResult) string {
+	var reasons []string
+	if strings.TrimSpace(result.RawTimestamp) == "" {
+		reasons = append(reasons, "finished_at is missing")
+	} else if result.FinishedAt.IsZero() {
+		reasons = append(reasons, "finished_at is invalid")
+	}
+	if result.TotalTrials <= 0 {
+		reasons = append(reasons, fmt.Sprintf("total trials is %d", result.TotalTrials))
+	}
+	stats := result.Stats
+	if stats.RunningTrials != 0 {
+		reasons = append(reasons, fmt.Sprintf("%d running", stats.RunningTrials))
+	}
+	if stats.PendingTrials != 0 {
+		reasons = append(reasons, fmt.Sprintf("%d pending", stats.PendingTrials))
+	}
+	if stats.CancelledTrials != 0 {
+		reasons = append(reasons, fmt.Sprintf("%d cancelled", stats.CancelledTrials))
+	}
+	if stats.CompletedTrials+stats.ErroredTrials != result.TotalTrials {
+		reasons = append(reasons, fmt.Sprintf(
+			"%d/%d completed, %d errored",
+			stats.CompletedTrials,
+			result.TotalTrials,
+			stats.ErroredTrials,
+		))
+	}
+	return strings.Join(reasons, ", ")
+}
+
+func isOracleOnlyPromoteJob(config promoteJobConfig, result promoteJobResult) bool {
+	var agents []string
+	for _, agent := range config.Agents {
+		if agent.Name != "" {
+			agents = append(agents, agent.Name)
+			continue
+		}
+		if agent.ImportPath != "" {
+			agents = append(agents, agent.ImportPath)
+		}
+	}
+	if len(agents) == 0 {
+		for key := range result.Stats.Evals {
+			agent, _, _ := strings.Cut(key, "__")
+			if agent != "" {
+				agents = append(agents, agent)
+			}
+		}
+	}
+	if len(agents) == 0 {
+		return false
+	}
+	for _, agent := range agents {
+		if strings.TrimSpace(agent) != "oracle" {
+			return false
+		}
+	}
+	return true
+}
+
+type promoteJobCandidate struct {
+	dir       string
+	name      string
+	timestamp time.Time
+	modTime   time.Time
+}
+
+func validatePromoteJobDir(jobsRoot, jobDir string) error {
+	if relativePathUnder(jobsRoot, jobDir) == "" {
+		return fmt.Errorf("eval job directory %s is outside jobs directory %s", jobDir, jobsRoot)
+	}
+	info, err := os.Stat(jobDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("eval job directory does not exist: %s", jobDir)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("eval job path is not a directory: %s", jobDir)
+	}
+	resultPath := filepath.Join(jobDir, "result.json")
+	if _, err := os.Stat(resultPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("eval job result does not exist: %s", resultPath)
+		}
+		return err
+	}
+	return nil
+}
+
+func readPromoteJobResult(jobDir string) (promoteJobResult, error) {
+	resultPath := filepath.Join(jobDir, "result.json")
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		return promoteJobResult{}, err
+	}
+	var raw struct {
+		StartedAt   string          `json:"started_at"`
+		UpdatedAt   string          `json:"updated_at"`
+		FinishedAt  string          `json:"finished_at"`
+		TotalTrials int             `json:"n_total_trials"`
+		Stats       promoteJobStats `json:"stats"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return promoteJobResult{}, err
+	}
+	return promoteJobResult{
+		Path:         resultPath,
+		StartedAt:    parsePromoteTime(raw.StartedAt),
+		UpdatedAt:    parsePromoteTime(raw.UpdatedAt),
+		FinishedAt:   parsePromoteTime(raw.FinishedAt),
+		TotalTrials:  raw.TotalTrials,
+		Stats:        raw.Stats,
+		RawTimestamp: raw.FinishedAt,
+	}, nil
+}
+
+func readPromoteJobConfig(jobDir string) (promoteJobConfig, error) {
+	data, err := os.ReadFile(filepath.Join(jobDir, "config.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return promoteJobConfig{}, nil
+		}
+		return promoteJobConfig{}, err
+	}
+	var config promoteJobConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return promoteJobConfig{}, err
+	}
+	return config, nil
+}
+
+func resultTimestamp(result promoteJobResult) time.Time {
+	if !result.FinishedAt.IsZero() {
+		return result.FinishedAt
+	}
+	if !result.UpdatedAt.IsZero() {
+		return result.UpdatedAt
+	}
+	return result.StartedAt
+}
+
+func parsePromoteTime(value string) time.Time {
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02T15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func stalePromoteWarning(result promoteJobResult, latestStagedMod time.Time) string {
+	timestamp := resultTimestamp(result)
+	if timestamp.IsZero() {
+		return "eval job timestamp could not be determined"
+	}
+	if !latestStagedMod.IsZero() && timestamp.Before(latestStagedMod) {
+		return fmt.Sprintf("eval job finished at %s before staged changes modified at %s", timestamp.Format(time.RFC3339), latestStagedMod.Format(time.RFC3339))
+	}
+	return ""
+}
+
+func displayList(values []string) string {
+	filtered := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			filtered = append(filtered, value)
+		}
+	}
+	if len(filtered) == 0 {
+		return "unknown"
+	}
+	return strings.Join(filtered, ", ")
+}

--- a/internal/harbor/eval_promote_job_test.go
+++ b/internal/harbor/eval_promote_job_test.go
@@ -1,0 +1,323 @@
+package harbor
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestResolvePromoteJobExplicitPathUnderJobsRoot(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	gotJobsRoot, gotJobDir, selection, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		job:     filepath.Join("jobs", "2026-06-25__09-00-00"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobsRoot != cleanExistingPath(jobsRoot) {
+		t.Fatalf("jobsRoot = %q, want %q", gotJobsRoot, cleanExistingPath(jobsRoot))
+	}
+	if gotJobDir != cleanExistingPath(jobDir) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(jobDir))
+	}
+	if selection != "explicit --job" {
+		t.Fatalf("selection = %q", selection)
+	}
+}
+
+func TestResolvePromoteJobRejectsOutsideJobsRoot(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(tmp, "outside")
+	writePromoteJob(t, jobDir, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, _, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: jobsRoot,
+		job:     jobDir,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "outside jobs directory") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestResolvePromoteJobLatestUsesHarborTimestamps(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	oldJob := filepath.Join(jobsRoot, "z-name-but-older")
+	newJob := filepath.Join(jobsRoot, "a-name-but-newer")
+	writePromoteJob(t, oldJob, "2026-06-25T09:00:00Z")
+	writePromoteJob(t, newJob, "2026-06-25T10:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, selection, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		latest:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(newJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(newJob))
+	}
+	if selection != "latest job under --jobs-dir" {
+		t.Fatalf("selection = %q", selection)
+	}
+}
+
+func TestResolvePromoteJobLatestFallsBackToNameSort(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	writePromoteJob(t, filepath.Join(jobsRoot, "2026-06-25__09-00-00"), "2026-06-25T10:00:00Z")
+	writePromoteJob(t, filepath.Join(jobsRoot, "2026-06-25__10-00-00"), "2026-06-25T10:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		latest:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := cleanExistingPath(filepath.Join(jobsRoot, "2026-06-25__10-00-00"))
+	if gotJobDir != want {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, want)
+	}
+}
+
+func TestResolvePromoteJobLatestSkipsIncompleteJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	incompleteJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	completeJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writeIncompletePromoteJob(t, incompleteJob, "2026-06-25T10:00:00Z", 0, 1, 0)
+	writePromoteJob(t, completeJob, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		latest:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(completeJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(completeJob))
+	}
+}
+
+func TestValidatePromoteJobPolicyRejectsIncompleteJob(t *testing.T) {
+	result := promoteJobResult{
+		RawTimestamp: "2026-06-25T10:00:00Z",
+		FinishedAt:   parsePromoteTime("2026-06-25T10:00:00Z"),
+		TotalTrials:  1,
+		Stats: promoteJobStats{
+			PendingTrials: 1,
+		},
+	}
+
+	err := validatePromoteJobPolicy(result, promoteJobConfig{}, promoteJobPolicy{
+		allowErrors:   true,
+		includeOracle: true,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "eval job is incomplete:") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "0/1 completed, 0 errored") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "1 pending") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestValidatePromoteJobPolicyRejectsMissingFinishedAt(t *testing.T) {
+	result := promoteJobResult{
+		TotalTrials: 1,
+		Stats: promoteJobStats{
+			CompletedTrials: 1,
+		},
+	}
+
+	err := validatePromoteJobPolicy(result, promoteJobConfig{}, promoteJobPolicy{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "finished_at is missing") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestResolvePromoteJobLatestSkipsOracleOnlyJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	oracleJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	agentJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writeOraclePromoteJob(t, oracleJob, "2026-06-25T10:00:00Z")
+	writePromoteJob(t, agentJob, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		latest:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(agentJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(agentJob))
+	}
+}
+
+func TestResolvePromoteJobLatestCanIncludeOracleOnlyJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	oracleJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	agentJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writeOraclePromoteJob(t, oracleJob, "2026-06-25T10:00:00Z")
+	writePromoteJob(t, agentJob, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir:       "jobs",
+		latest:        true,
+		includeOracle: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(oracleJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(oracleJob))
+	}
+}
+
+func TestResolvePromoteJobLatestSkipsErroredJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	erroredJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	passingJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writeErroredPromoteJob(t, erroredJob, "2026-06-25T10:00:00Z")
+	writePromoteJob(t, passingJob, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir: "jobs",
+		latest:  true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(passingJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(passingJob))
+	}
+}
+
+func TestResolvePromoteJobLatestCanAllowErroredJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	erroredJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	passingJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	writeErroredPromoteJob(t, erroredJob, "2026-06-25T10:00:00Z")
+	writePromoteJob(t, passingJob, "2026-06-25T09:00:00Z")
+	t.Chdir(tmp)
+
+	_, gotJobDir, _, err := resolvePromoteJob(promoteJobOptions{
+		jobsDir:     "jobs",
+		latest:      true,
+		allowErrors: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotJobDir != cleanExistingPath(erroredJob) {
+		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(erroredJob))
+	}
+}
+
+func writePromoteJob(t *testing.T, jobDir, finishedAt string) {
+	writePromoteJobWithAgent(t, jobDir, finishedAt, "codex", 0)
+}
+
+func writeOraclePromoteJob(t *testing.T, jobDir, finishedAt string) {
+	writePromoteJobWithAgent(t, jobDir, finishedAt, "oracle", 0)
+}
+
+func writeErroredPromoteJob(t *testing.T, jobDir, finishedAt string) {
+	writePromoteJobWithAgent(t, jobDir, finishedAt, "codex", 1)
+}
+
+func writePromoteJobWithAgent(t *testing.T, jobDir, finishedAt, agent string, errors int) {
+	t.Helper()
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	completed := 1
+	if errors > 0 {
+		completed = 0
+	}
+	result := `{
+		"started_at": "` + finishedAt + `",
+		"updated_at": "` + finishedAt + `",
+		"finished_at": "` + finishedAt + `",
+		"n_total_trials": 1,
+		"stats": {
+			"n_completed_trials": ` + strconv.Itoa(completed) + `,
+			"n_errored_trials": ` + strconv.Itoa(errors) + `,
+			"evals": {
+				"` + agent + `__dataset": {
+					"n_trials": 1,
+					"n_errors": ` + strconv.Itoa(errors) + `,
+					"metrics": [{"mean": 1.0}]
+				}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte(result), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := `{"agents":[{"name":"` + agent + `"}]}`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeIncompletePromoteJob(t *testing.T, jobDir, finishedAt string, running, pending, cancelled int) {
+	t.Helper()
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	result := `{
+		"started_at": "` + finishedAt + `",
+		"updated_at": "` + finishedAt + `",
+		"finished_at": "` + finishedAt + `",
+		"n_total_trials": 1,
+		"stats": {
+			"n_completed_trials": 0,
+			"n_errored_trials": 0,
+			"n_running_trials": ` + strconv.Itoa(running) + `,
+			"n_pending_trials": ` + strconv.Itoa(pending) + `,
+			"n_cancelled_trials": ` + strconv.Itoa(cancelled) + `,
+			"evals": {}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte(result), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte(`{"agents":[{"name":"codex"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/harbor/eval_promote_message.go
+++ b/internal/harbor/eval_promote_message.go
@@ -1,0 +1,146 @@
+package harbor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type promoteMessageData struct {
+	subject      string
+	jobPath      string
+	resultPath   string
+	evidenceOnly bool
+	config       promoteJobConfig
+	result       promoteJobResult
+}
+
+func renderPromoteCommitMessage(data promoteMessageData) string {
+	var b strings.Builder
+	subject := strings.TrimSpace(data.subject)
+	if subject == "" {
+		subject = defaultPromoteSubject
+	}
+	_, _ = fmt.Fprintf(&b, "%s\n\n", subject)
+	_, _ = fmt.Fprintf(&b, "Eval-Job: %s\n", data.jobPath)
+	_, _ = fmt.Fprintf(&b, "Eval-Result: %s\n", data.resultPath)
+	if data.evidenceOnly {
+		_, _ = fmt.Fprintf(&b, "Promotion-Mode: eval-evidence-only\n")
+	}
+	_, _ = fmt.Fprintf(&b, "Dataset: %s\n", data.datasetSummary())
+	if tasks := data.taskSummary(); tasks != "" {
+		_, _ = fmt.Fprintf(&b, "Tasks: %s\n", tasks)
+	}
+	_, _ = fmt.Fprintln(&b)
+	_, _ = fmt.Fprintf(&b, "Agent: %s\n", data.agentSummary())
+	_, _ = fmt.Fprintf(&b, "Model: %s\n", data.modelSummary())
+	_, _ = fmt.Fprintf(&b, "Environment: %s\n\n", data.environmentSummary())
+	_, _ = fmt.Fprintf(&b, "Result: %s\n", data.resultSummary())
+	if score := data.scoreSummary(); score != "" {
+		_, _ = fmt.Fprintf(&b, "Score: %s\n", score)
+	}
+	return b.String()
+}
+
+func (d promoteMessageData) datasetSummary() string {
+	var values []string
+	for _, dataset := range d.config.Datasets {
+		if dataset.Name != "" {
+			values = append(values, dataset.Name)
+			continue
+		}
+		values = append(values, dataset.Path)
+	}
+	return displayList(values)
+}
+
+func (d promoteMessageData) taskSummary() string {
+	var values []string
+	for _, dataset := range d.config.Datasets {
+		values = append(values, dataset.TaskNames...)
+	}
+	if len(values) == 0 {
+		return ""
+	}
+	return displayList(values)
+}
+
+func (d promoteMessageData) agentSummary() string {
+	var values []string
+	for _, agent := range d.config.Agents {
+		if agent.Name != "" {
+			values = append(values, agent.Name)
+			continue
+		}
+		values = append(values, agent.ImportPath)
+	}
+	return displayList(values)
+}
+
+func (d promoteMessageData) modelSummary() string {
+	var values []string
+	for _, agent := range d.config.Agents {
+		values = append(values, agent.ModelName)
+	}
+	return displayList(values)
+}
+
+func (d promoteMessageData) environmentSummary() string {
+	if d.config.Environment.Type != "" {
+		return d.config.Environment.Type
+	}
+	if d.config.Environment.ImportPath != "" {
+		return d.config.Environment.ImportPath
+	}
+	return "unknown"
+}
+
+func (d promoteMessageData) resultSummary() string {
+	stats := d.result.Stats
+	parts := []string{
+		fmt.Sprintf("completed=%d/%d", stats.CompletedTrials, d.result.TotalTrials),
+		fmt.Sprintf("errors=%d", stats.ErroredTrials),
+	}
+	if len(stats.Evals) > 0 {
+		parts = append(parts, fmt.Sprintf("evals=%d", len(stats.Evals)))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (d promoteMessageData) scoreSummary() string {
+	if score, ok := singlePromoteMean(d.result.Stats); ok {
+		return fmt.Sprintf("mean=%.3f", score)
+	}
+	return ""
+}
+
+func singlePromoteMean(stats promoteJobStats) (float64, bool) {
+	var means []float64
+	keys := make([]string, 0, len(stats.Evals))
+	for key := range stats.Evals {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		for _, metric := range stats.Evals[key].Metrics {
+			if value, ok := promoteMetricNumber(metric["mean"]); ok {
+				means = append(means, value)
+			}
+		}
+	}
+	if len(means) != 1 {
+		return 0, false
+	}
+	return means[0], true
+}
+
+func promoteMetricNumber(value interface{}) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case int:
+		return float64(typed), true
+	default:
+		return 0, false
+	}
+}

--- a/internal/harbor/eval_promote_message_test.go
+++ b/internal/harbor/eval_promote_message_test.go
@@ -1,0 +1,150 @@
+package harbor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPromoteCommitMessageUsesJobRollup(t *testing.T) {
+	msg := renderPromoteCommitMessage(promoteMessageData{
+		subject:    defaultPromoteSubject,
+		jobPath:    ".runme/evals/jobs/job",
+		resultPath: ".runme/evals/jobs/job/result.json",
+		config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{
+				Path:      "evals/tasks",
+				TaskNames: []string{"one", "two"},
+			}},
+			Agents: []promoteAgentConfig{{
+				Name:      "codex",
+				ModelName: "gpt-5-codex",
+			}},
+			Environment: promoteEnvConfig{ImportPath: runmeEnvironmentImportPath},
+		},
+		result: promoteJobResult{
+			TotalTrials: 2,
+			Stats: promoteJobStats{
+				CompletedTrials: 2,
+				ErroredTrials:   0,
+				Evals: map[string]promoteEvalStats{
+					"codex__dataset": {
+						Metrics: []map[string]interface{}{{"mean": 0.75}},
+					},
+				},
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"Promote changes verified by task eval",
+		"Eval-Job: .runme/evals/jobs/job",
+		"Eval-Result: .runme/evals/jobs/job/result.json",
+		"Dataset: evals/tasks",
+		"Tasks: one, two",
+		"Agent: codex",
+		"Model: gpt-5-codex",
+		"Environment: " + runmeEnvironmentImportPath,
+		"Result: completed=2/2, errors=0, evals=1",
+		"Score: mean=0.750",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestRenderPromoteCommitMessageSeparatesResultFromScore(t *testing.T) {
+	msg := renderPromoteCommitMessage(promoteMessageData{
+		subject:    defaultPromoteSubject,
+		jobPath:    ".runme/evals/jobs/job",
+		resultPath: ".runme/evals/jobs/job/result.json",
+		config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents: []promoteAgentConfig{{
+				Name:      "runme-codex",
+				ModelName: "gpt-5.4-mini",
+			}},
+		},
+		result: promoteJobResult{
+			TotalTrials: 2,
+			Stats: promoteJobStats{
+				CompletedTrials: 2,
+				ErroredTrials:   0,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__dataset": {},
+				},
+			},
+		},
+	})
+
+	for _, want := range []string{
+		"Result: completed=2/2, errors=0, evals=1",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "Tasks:") {
+		t.Fatalf("message should not contain Tasks without explicit task names:\n%s", msg)
+	}
+	if strings.Contains(msg, "Score:") {
+		t.Fatalf("message should not contain Score without score metric:\n%s", msg)
+	}
+}
+
+func TestRenderPromoteCommitMessageIgnoresNamedMetricDimensions(t *testing.T) {
+	msg := renderPromoteCommitMessage(promoteMessageData{
+		subject:    defaultPromoteSubject,
+		jobPath:    ".runme/evals/jobs/job",
+		resultPath: ".runme/evals/jobs/job/result.json",
+		config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__dataset": {
+						Metrics: []map[string]interface{}{{
+							"structure":   1.0,
+							"correctness": 0.5,
+						}},
+					},
+				},
+			},
+		},
+	})
+
+	if strings.Contains(msg, "Score:") {
+		t.Fatalf("message should not contain Score for named metric dimensions:\n%s", msg)
+	}
+}
+
+func TestRenderPromoteCommitMessageIgnoresRewardWithoutMean(t *testing.T) {
+	msg := renderPromoteCommitMessage(promoteMessageData{
+		subject:    defaultPromoteSubject,
+		jobPath:    ".runme/evals/jobs/job",
+		resultPath: ".runme/evals/jobs/job/result.json",
+		config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__dataset": {
+						Metrics: []map[string]interface{}{{"reward": 0.5}},
+					},
+				},
+			},
+		},
+	})
+
+	if strings.Contains(msg, "Score:") {
+		t.Fatalf("message should not contain Score without mean:\n%s", msg)
+	}
+}

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -1,0 +1,290 @@
+package harbor
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	var stdout bytes.Buffer
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		DryRun:  true,
+		Stdout:  &stdout,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if gitClient.stagedCalled {
+		t.Fatal("StagedFiles was called during dry-run")
+	}
+	if got := stdout.String(); !strings.Contains(got, "Selected eval job: jobs/2026-06-25__10-00-00") {
+		t.Fatalf("stdout = %q", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Selection: latest job under jobs") {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestEvalPromoterWarnsWhenNewerJobsAreNotPromotable(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	selectedJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	incompleteJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, selectedJob, "2026-06-25T09:00:00Z")
+	writeIncompletePromoteJob(t, incompleteJob, "2026-06-25T10:00:00Z", 0, 1, 0)
+
+	var stderr bytes.Buffer
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		DryRun:  true,
+		Stderr:  &stderr,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := stderr.String(); !strings.Contains(got, "warning: no newer complete promotable eval job found under jobs") {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestEvalPromoterDoesNotWarnWhenNewerPromotableJobExists(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	selectedJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	newerJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, selectedJob, "2026-06-25T09:00:00Z")
+	writePromoteJob(t, newerJob, "2026-06-25T10:00:00Z")
+
+	var stderr bytes.Buffer
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Job:     selectedJob,
+		DryRun:  true,
+		Stderr:  &stderr,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := stderr.String(); strings.Contains(got, "no newer complete promotable eval job") {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestEvalPromoterSuggestsEvidenceOnlyWhenNothingIsStaged(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		Git:     gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "use --evidence-only") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if gitClient.addCalled || gitClient.commitCalled {
+		t.Fatal("expected no add or commit")
+	}
+}
+
+func TestEvalPromoterEvidenceOnlyCommitsJobWithoutStagedChanges(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:      jobsRoot,
+		Latest:       true,
+		EvidenceOnly: true,
+		Git:          gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !gitClient.addCalled || !gitClient.commitCalled {
+		t.Fatal("expected add and commit")
+	}
+	if !strings.Contains(gitClient.message, "Promotion-Mode: eval-evidence-only") {
+		t.Fatalf("commit message missing evidence-only mode:\n%s", gitClient.message)
+	}
+}
+
+func TestEvalPromoterEvidenceOnlyRejectsStagedChanges(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{
+		root:   tmp,
+		staged: []string{"main.go"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:      jobsRoot,
+		Latest:       true,
+		EvidenceOnly: true,
+		Git:          gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "--evidence-only cannot be used with staged changes") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestEvalPromoterExplicitJobRejectsOracleOnlyJob(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writeOraclePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Job:     jobDir,
+		DryRun:  true,
+		Git:     gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "use --include-oracle") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestEvalPromoterExplicitJobRejectsErroredJob(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writeErroredPromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Job:     jobDir,
+		DryRun:  true,
+		Git:     gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "use --allow-errors") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestEvalPromoterExplicitJobRejectsIncompleteJob(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writeIncompletePromoteJob(t, jobDir, "2026-06-25T10:00:00Z", 0, 1, 0)
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:     jobsRoot,
+		Job:         jobDir,
+		DryRun:      true,
+		AllowErrors: true,
+		Git:         gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "eval job is incomplete:") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "0/1 completed, 0 errored") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "1 pending") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+type recordingPromoteGit struct {
+	root         string
+	staged       []string
+	stagedCalled bool
+	addCalled    bool
+	commitCalled bool
+	message      string
+}
+
+func (g *recordingPromoteGit) StagedFiles() ([]string, error) {
+	g.stagedCalled = true
+	return append([]string(nil), g.staged...), nil
+}
+
+func (g *recordingPromoteGit) UnstagedFilesTouching([]string) ([]string, error) {
+	return nil, nil
+}
+
+func (g *recordingPromoteGit) LatestModTime([]string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (g *recordingPromoteGit) AddJobDir(string) error {
+	g.addCalled = true
+	return nil
+}
+
+func (g *recordingPromoteGit) Commit(message string) (string, error) {
+	g.commitCalled = true
+	g.message = message
+	return "commit", nil
+}
+
+func (g *recordingPromoteGit) Rel(path string) (string, error) {
+	root := cleanExistingPath(g.root)
+	path = cleanExistingPath(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path %s is outside git root %s", path, root)
+	}
+	return filepath.ToSlash(rel), nil
+}


### PR DESCRIPTION
## Summary

- add `runme eval promote` to commit promoted changes together with Harbor eval job evidence
- support `--job <job-dir>` and `--latest` selection under the resolved `--jobs-dir`
- print dry-run selection with the resolved jobs directory, e.g. `Selection: latest job under .runme/evals/jobs`
- force-add only the selected eval job directory, including ignored `.runme` files, while ignoring unrelated untracked jobs under `--jobs-dir`
- add explicit evidence-only mode via `--evidence-only` for provider/model/config evals with no staged source changes
- default `--latest` skips oracle-only and errored jobs; `--include-oracle` and `--allow-errors` opt back in
- render commit messages from the top-level job `result.json` and `config.json`, including dataset, agent, model, environment, result status, and `Score:` only for the documented Harbor default `mean` metric
- omit `Tasks:` unless Harbor records explicit task names in the job config

## Validation

- `go test ./internal/harbor ./cmd`
- `runme run test`

## Notes

- promotion policy stays user-controlled; `promote` reports eval evidence and only applies structural/default safety checks
- job evidence comes from the top-level selected job directory; trial-level files remain committed evidence, not commit-summary sources
