### PR TITLE
feat: add eval compare command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -89,6 +89,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 
 	cmd.AddCommand(evalViewCmd())
 	cmd.AddCommand(evalPromoteCmd())
+	cmd.AddCommand(evalCompareCmd())
 
 	return cmd
 }

--- a/cmd/eval_compare.go
+++ b/cmd/eval_compare.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type evalComparer interface {
+	Run(args []string) error
+}
+
+var newEvalComparer = func(opts harbor.EvalCompareOptions) evalComparer {
+	return harbor.NewEvalComparer(opts)
+}
+
+type evalCompareOptions struct {
+	jobsDir       string
+	job           string
+	base          string
+	format        string
+	includeOracle bool
+	allowErrors   bool
+	stdout        io.Writer
+	stderr        io.Writer
+}
+
+func evalCompareCmd() *cobra.Command {
+	opts := evalCompareOptions{
+		base:   "HEAD",
+		format: "text",
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "compare",
+		Short: "Compare the latest Git-tracked eval job with the latest local eval job",
+		Long: `Compare top-level eval result summaries between the last Git-tracked eval
+job and a local candidate eval job. By default, the candidate is the newest
+local job under --jobs-dir. The command is read-only and prints an advisory
+recommendation based on comparable top-level stats such as score rollups,
+pass counts, exceptions, and failures. It does not promote, commit, or enforce
+policy.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.stdout = cmd.OutOrStdout()
+			opts.stderr = cmd.ErrOrStderr()
+			return runEvalCompare(opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.jobsDir, "jobs-dir", "", "Eval jobs directory; defaults to .runme/evals/jobs under the project root")
+	flags.StringVar(&opts.job, "job", "", "Compare against a specific local eval job instead of the newest local job")
+	flags.StringVar(&opts.base, "base", "HEAD", "Git ref used to find the tracked baseline eval job")
+	flags.StringVar(&opts.format, "format", "text", "Output format: text or json")
+	flags.BoolVar(&opts.includeOracle, "include-oracle", false, "Allow comparing eval jobs that only used Harbor's oracle agent")
+	flags.BoolVar(&opts.allowErrors, "allow-errors", false, "Allow comparing eval jobs with errored trials")
+
+	return cmd
+}
+
+func runEvalCompare(opts evalCompareOptions, args []string) error {
+	err := newEvalComparer(harbor.EvalCompareOptions{
+		JobsDir:       opts.jobsDir,
+		Job:           opts.job,
+		Base:          opts.base,
+		Format:        opts.format,
+		IncludeOracle: opts.includeOracle,
+		AllowErrors:   opts.allowErrors,
+		Stdout:        opts.stdout,
+		Stderr:        opts.stderr,
+	}).Run(args)
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
+	}
+	var codeErr interface{ ExitCode() int }
+	if errors.As(err, &codeErr) {
+		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
+	}
+	return err
+}

--- a/cmd/eval_compare_test.go
+++ b/cmd/eval_compare_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type fakeEvalComparer struct {
+	err error
+}
+
+func (c fakeEvalComparer) Run([]string) error {
+	return c.err
+}
+
+func TestEvalCompareCmdPassesOptionsToHarborComparer(t *testing.T) {
+	var gotOpts harbor.EvalCompareOptions
+	var gotArgs []string
+	cmd := evalCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"compare",
+		"--jobs-dir", "jobs",
+		"--job", "jobs/job-1",
+		"--base", "HEAD~1",
+		"--format", "json",
+		"--include-oracle",
+		"--allow-errors",
+	})
+	restoreEvalComparer(t, func(opts harbor.EvalCompareOptions) evalComparer {
+		gotOpts = opts
+		return evalComparerFunc(func(args []string) error {
+			gotArgs = append([]string(nil), args...)
+			return nil
+		})
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotArgs, []string(nil)) {
+		t.Fatalf("args = %#v", gotArgs)
+	}
+	if gotOpts.JobsDir != "jobs" ||
+		gotOpts.Job != "jobs/job-1" ||
+		gotOpts.Base != "HEAD~1" ||
+		gotOpts.Format != "json" ||
+		!gotOpts.IncludeOracle ||
+		!gotOpts.AllowErrors ||
+		gotOpts.Stdout != &stdout ||
+		gotOpts.Stderr != &stderr {
+		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalCompareCmdDefaultsBaseAndFormat(t *testing.T) {
+	var gotOpts harbor.EvalCompareOptions
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"compare"})
+	restoreEvalComparer(t, func(opts harbor.EvalCompareOptions) evalComparer {
+		gotOpts = opts
+		return fakeEvalComparer{}
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotOpts.Base != "HEAD" {
+		t.Fatalf("Base = %q, want HEAD", gotOpts.Base)
+	}
+	if gotOpts.Format != "text" {
+		t.Fatalf("Format = %q, want text", gotOpts.Format)
+	}
+}
+
+func TestRunEvalComparePropagatesDelegateExitCode(t *testing.T) {
+	restoreEvalComparer(t, func(harbor.EvalCompareOptions) evalComparer {
+		return fakeEvalComparer{err: fakeExitError{code: 42}}
+	})
+
+	err := runEvalCompare(evalCompareOptions{}, nil)
+	var exitErr ExitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("error = %T %v, want ExitCodeError", err, err)
+	}
+	if exitErr.Code != 42 {
+		t.Fatalf("exit code = %d, want 42", exitErr.Code)
+	}
+}
+
+type evalComparerFunc func([]string) error
+
+func (f evalComparerFunc) Run(args []string) error {
+	return f(args)
+}
+
+func restoreEvalComparer(t *testing.T, fn func(harbor.EvalCompareOptions) evalComparer) {
+	t.Helper()
+	previous := newEvalComparer
+	newEvalComparer = fn
+	t.Cleanup(func() {
+		newEvalComparer = previous
+	})
+}

--- a/internal/harbor/eval_compare.go
+++ b/internal/harbor/eval_compare.go
@@ -1,0 +1,87 @@
+package harbor
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type EvalCompareOptions struct {
+	JobsDir       string
+	Job           string
+	Base          string
+	Format        string
+	IncludeOracle bool
+	AllowErrors   bool
+	Stdout        io.Writer
+	Stderr        io.Writer
+	Git           compareGit
+}
+
+type EvalComparer struct {
+	opts EvalCompareOptions
+}
+
+func NewEvalComparer(opts EvalCompareOptions) *EvalComparer {
+	if opts.Base == "" {
+		opts.Base = "HEAD"
+	}
+	if opts.Format == "" {
+		opts.Format = "text"
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	return &EvalComparer{opts: opts}
+}
+
+func (c *EvalComparer) Run(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("accepts no arguments")
+	}
+	if c.opts.Format != "text" && c.opts.Format != "json" {
+		return fmt.Errorf("unsupported format %q; expected text or json", c.opts.Format)
+	}
+
+	paths, err := resolveEvalViewPaths(c.opts.JobsDir)
+	if err != nil {
+		return err
+	}
+
+	gitClient := c.opts.Git
+	if gitClient == nil {
+		gitClient, err = newGoGitCompareClient()
+		if err != nil {
+			return err
+		}
+	}
+
+	base, err := resolveCompareBase(compareBaseOptions{
+		git:      gitClient,
+		baseRef:  c.opts.Base,
+		jobsRoot: paths.jobsDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	candidate, err := resolveCompareCandidate(compareCandidateOptions{
+		jobsDir:       paths.jobsDir,
+		job:           c.opts.Job,
+		includeOracle: c.opts.IncludeOracle,
+		allowErrors:   c.opts.AllowErrors,
+		git:           gitClient,
+	})
+	if err != nil {
+		return err
+	}
+
+	comparison := buildEvalComparison(base, candidate, c.opts.Base)
+	if c.opts.Format == "json" {
+		return renderEvalComparisonJSON(c.opts.Stdout, comparison)
+	}
+	return renderEvalComparisonText(c.opts.Stdout, comparison)
+}

--- a/internal/harbor/eval_compare_git.go
+++ b/internal/harbor/eval_compare_git.go
@@ -1,0 +1,137 @@
+package harbor
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+type compareGit interface {
+	Rel(string) (string, error)
+	TrackedEvalJobs(string, string) ([]compareJob, error)
+}
+
+type goGitCompareClient struct {
+	repo *git.Repository
+	root string
+}
+
+func newGoGitCompareClient() (*goGitCompareClient, error) {
+	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return nil, err
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	return &goGitCompareClient{
+		repo: repo,
+		root: cleanExistingPath(wt.Filesystem.Root()),
+	}, nil
+}
+
+func (c *goGitCompareClient) Rel(path string) (string, error) {
+	path = cleanExistingPath(path)
+	rel, err := filepath.Rel(c.root, path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %s is outside git root %s", path, c.root)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]compareJob, error) {
+	jobsRootRel, err := c.Rel(jobsRoot)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := c.tree(baseRef)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := strings.TrimSuffix(jobsRootRel, "/") + "/"
+	files := tree.Files()
+	defer files.Close()
+
+	var jobs []compareJob
+	err = files.ForEach(func(file *object.File) error {
+		if !strings.HasPrefix(file.Name, prefix) {
+			return nil
+		}
+		rest := strings.TrimPrefix(file.Name, prefix)
+		parts := strings.Split(rest, "/")
+		if len(parts) != 2 || parts[1] != "result.json" {
+			return nil
+		}
+
+		resultData, err := file.Contents()
+		if err != nil {
+			return err
+		}
+		result, err := parsePromoteJobResult(file.Name, []byte(resultData))
+		if err != nil {
+			return nil
+		}
+
+		jobRel := prefix + parts[0]
+		config := promoteJobConfig{}
+		if configFile, err := tree.File(jobRel + "/config.json"); err == nil {
+			configData, err := configFile.Contents()
+			if err != nil {
+				return err
+			}
+			parsed, err := parsePromoteJobConfig([]byte(configData))
+			if err == nil {
+				config = parsed
+			}
+		}
+
+		jobs = append(jobs, compareJob{
+			RelPath:   jobRel,
+			ResultRel: file.Name,
+			Result:    result,
+			Config:    config,
+			Selection: "latest tracked job under --base",
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sortCompareJobs(jobs)
+	return jobs, nil
+}
+
+func (c *goGitCompareClient) tree(ref string) (*object.Tree, error) {
+	hash, err := c.repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return nil, err
+	}
+	commit, err := c.repo.CommitObject(*hash)
+	if err != nil {
+		return nil, err
+	}
+	return commit.Tree()
+}
+
+func sortCompareJobs(jobs []compareJob) {
+	sort.Slice(jobs, func(i, j int) bool {
+		left, right := jobs[i], jobs[j]
+		leftTime, rightTime := resultTimestamp(left.Result), resultTimestamp(right.Result)
+		if !leftTime.IsZero() || !rightTime.IsZero() {
+			if !leftTime.Equal(rightTime) {
+				return leftTime.After(rightTime)
+			}
+		}
+		return left.RelPath > right.RelPath
+	})
+}

--- a/internal/harbor/eval_compare_job.go
+++ b/internal/harbor/eval_compare_job.go
@@ -1,0 +1,98 @@
+package harbor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type compareJob struct {
+	RelPath   string
+	ResultRel string
+	Result    promoteJobResult
+	Config    promoteJobConfig
+	Selection string
+}
+
+type compareBaseOptions struct {
+	git      compareGit
+	baseRef  string
+	jobsRoot string
+}
+
+type compareCandidateOptions struct {
+	jobsDir       string
+	job           string
+	includeOracle bool
+	allowErrors   bool
+	git           compareGit
+}
+
+func resolveCompareBase(opts compareBaseOptions) (compareJob, error) {
+	jobs, err := opts.git.TrackedEvalJobs(opts.baseRef, opts.jobsRoot)
+	if err != nil {
+		return compareJob{}, err
+	}
+	for _, job := range jobs {
+		if incompletePromoteJobReason(job.Result) == "" {
+			return job, nil
+		}
+	}
+	return compareJob{}, fmt.Errorf("no complete Git-tracked eval job found under %s at %s", opts.jobsRoot, opts.baseRef)
+}
+
+func resolveCompareCandidate(opts compareCandidateOptions) (compareJob, error) {
+	var jobDir, selection string
+	var err error
+	policy := promoteJobPolicy{
+		includeOracle: opts.includeOracle,
+		allowErrors:   opts.allowErrors,
+	}
+	if opts.job == "" {
+		jobDir, selection, err = latestPromoteJob(opts.jobsDir, policy)
+		if err != nil {
+			return compareJob{}, err
+		}
+	} else {
+		invocationCwd, err := os.Getwd()
+		if err != nil {
+			return compareJob{}, err
+		}
+		jobDir = opts.job
+		if !filepath.IsAbs(jobDir) {
+			jobDir = filepath.Join(invocationCwd, jobDir)
+		}
+		jobDir = cleanExistingPath(jobDir)
+		if err := validatePromoteJobDir(opts.jobsDir, jobDir); err != nil {
+			return compareJob{}, err
+		}
+		selection = "explicit --job"
+	}
+
+	result, err := readPromoteJobResult(jobDir)
+	if err != nil {
+		return compareJob{}, err
+	}
+	config, err := readPromoteJobConfig(jobDir)
+	if err != nil {
+		return compareJob{}, err
+	}
+	if err := validatePromoteJobPolicy(result, config, policy); err != nil {
+		return compareJob{}, err
+	}
+	jobRel, err := opts.git.Rel(jobDir)
+	if err != nil {
+		return compareJob{}, err
+	}
+	resultRel, err := opts.git.Rel(result.Path)
+	if err != nil {
+		return compareJob{}, err
+	}
+	return compareJob{
+		RelPath:   jobRel,
+		ResultRel: resultRel,
+		Result:    result,
+		Config:    config,
+		Selection: selection,
+	}, nil
+}

--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -1,0 +1,244 @@
+package harbor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type evalComparison struct {
+	Base           evalComparisonJob    `json:"base"`
+	Candidate      evalComparisonJob    `json:"candidate"`
+	Metadata       evalComparisonMeta   `json:"metadata"`
+	MetadataDiffs  []evalComparisonDiff `json:"metadata_mismatches,omitempty"`
+	Stats          evalComparisonStats  `json:"stats"`
+	Recommendation string               `json:"recommendation"`
+}
+
+type evalComparisonJob struct {
+	Path      string `json:"path"`
+	Result    string `json:"result"`
+	Ref       string `json:"ref,omitempty"`
+	Selection string `json:"selection"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type evalComparisonMeta struct {
+	Dataset     evalComparisonDiff `json:"dataset"`
+	Tasks       evalComparisonDiff `json:"tasks"`
+	Agent       evalComparisonDiff `json:"agent"`
+	Model       evalComparisonDiff `json:"model"`
+	Environment evalComparisonDiff `json:"environment"`
+}
+
+type evalComparisonStats struct {
+	Completed evalComparisonDiff `json:"completed"`
+	Errors    evalComparisonDiff `json:"errors"`
+	Mean      evalComparisonDiff `json:"mean,omitempty"`
+	Evals     evalComparisonDiff `json:"evals"`
+	CostUSD   evalComparisonDiff `json:"cost_usd,omitempty"`
+}
+
+type evalComparisonDiff struct {
+	Base      interface{} `json:"base"`
+	Candidate interface{} `json:"candidate"`
+	Delta     interface{} `json:"delta,omitempty"`
+}
+
+func buildEvalComparison(base, candidate compareJob, baseRef string) evalComparison {
+	baseSummary := promoteMessageData{config: base.Config, result: base.Result}
+	candidateSummary := promoteMessageData{config: candidate.Config, result: candidate.Result}
+
+	metadata := evalComparisonMeta{
+		Dataset:     stringDiff(baseSummary.datasetSummary(), candidateSummary.datasetSummary()),
+		Tasks:       stringDiff(baseSummary.taskSummary(), candidateSummary.taskSummary()),
+		Agent:       stringDiff(baseSummary.agentSummary(), candidateSummary.agentSummary()),
+		Model:       stringDiff(baseSummary.modelSummary(), candidateSummary.modelSummary()),
+		Environment: stringDiff(baseSummary.environmentSummary(), candidateSummary.environmentSummary()),
+	}
+	stats := compareStats(base.Result, candidate.Result)
+	mismatches := metadataMismatches(metadata)
+
+	comparison := evalComparison{
+		Base: evalComparisonJob{
+			Path:      base.RelPath,
+			Result:    base.ResultRel,
+			Ref:       baseRef,
+			Selection: base.Selection,
+			Timestamp: formatCompareTimestamp(resultTimestamp(base.Result)),
+		},
+		Candidate: evalComparisonJob{
+			Path:      candidate.RelPath,
+			Result:    candidate.ResultRel,
+			Selection: candidate.Selection,
+			Timestamp: formatCompareTimestamp(resultTimestamp(candidate.Result)),
+		},
+		Metadata:      metadata,
+		MetadataDiffs: mismatches,
+		Stats:         stats,
+	}
+	comparison.Recommendation = compareRecommendation(comparison)
+	return comparison
+}
+
+func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
+	_, _ = fmt.Fprintf(w, "Base:   %s  tracked in %s\n", comparison.Base.Path, comparison.Base.Ref)
+	_, _ = fmt.Fprintf(w, "Latest: %s  local\n\n", comparison.Candidate.Path)
+
+	_, _ = fmt.Fprintf(w, "Dataset: %s\n", comparison.Metadata.Dataset.Candidate)
+	if tasks := strings.TrimSpace(fmt.Sprint(comparison.Metadata.Tasks.Candidate)); tasks != "" {
+		_, _ = fmt.Fprintf(w, "Tasks: %s\n", tasks)
+	}
+	_, _ = fmt.Fprintf(w, "Agent: %s\n", comparison.Metadata.Agent.Candidate)
+	_, _ = fmt.Fprintf(w, "Model: %s\n", comparison.Metadata.Model.Candidate)
+	_, _ = fmt.Fprintf(w, "Environment: %s\n\n", comparison.Metadata.Environment.Candidate)
+
+	if len(comparison.MetadataDiffs) > 0 {
+		_, _ = fmt.Fprintln(w, "Metadata mismatches:")
+		for _, diff := range comparison.MetadataDiffs {
+			_, _ = fmt.Fprintf(w, "  %s: %v -> %v\n", diff.Delta, diff.Base, diff.Candidate)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	_, _ = fmt.Fprintln(w, "Score:")
+	_, _ = fmt.Fprintf(w, "  completed: %v -> %v  %s\n", comparison.Stats.Completed.Base, comparison.Stats.Completed.Candidate, signedDelta(comparison.Stats.Completed.Delta))
+	_, _ = fmt.Fprintf(w, "  errors:    %v -> %v  %s\n", comparison.Stats.Errors.Base, comparison.Stats.Errors.Candidate, signedDelta(comparison.Stats.Errors.Delta))
+	if comparison.Stats.Mean.Base != nil || comparison.Stats.Mean.Candidate != nil {
+		_, _ = fmt.Fprintf(w, "  mean:      %s -> %s  %s\n", displayValue(comparison.Stats.Mean.Base), displayValue(comparison.Stats.Mean.Candidate), signedDelta(comparison.Stats.Mean.Delta))
+	}
+	_, _ = fmt.Fprintf(w, "  evals:     %v -> %v  %s\n\n", comparison.Stats.Evals.Base, comparison.Stats.Evals.Candidate, signedDelta(comparison.Stats.Evals.Delta))
+	_, _ = fmt.Fprintf(w, "Recommendation: %s\n", comparison.Recommendation)
+	return nil
+}
+
+func renderEvalComparisonJSON(w io.Writer, comparison evalComparison) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(comparison)
+}
+
+func stringDiff(base, candidate string) evalComparisonDiff {
+	return evalComparisonDiff{Base: base, Candidate: candidate}
+}
+
+func intDiff(base, candidate int) evalComparisonDiff {
+	return evalComparisonDiff{Base: base, Candidate: candidate, Delta: candidate - base}
+}
+
+func floatDiff(base, candidate *float64) evalComparisonDiff {
+	diff := evalComparisonDiff{Base: base, Candidate: candidate}
+	if base != nil && candidate != nil {
+		diff.Delta = *candidate - *base
+	}
+	return diff
+}
+
+func compareStats(base, candidate promoteJobResult) evalComparisonStats {
+	baseMean, baseHasMean := singlePromoteMean(base.Stats)
+	candidateMean, candidateHasMean := singlePromoteMean(candidate.Stats)
+	var baseMeanPtr, candidateMeanPtr *float64
+	if baseHasMean {
+		baseMeanPtr = &baseMean
+	}
+	if candidateHasMean {
+		candidateMeanPtr = &candidateMean
+	}
+	return evalComparisonStats{
+		Completed: intDiff(base.Stats.CompletedTrials, candidate.Stats.CompletedTrials),
+		Errors:    intDiff(base.Stats.ErroredTrials, candidate.Stats.ErroredTrials),
+		Mean:      floatDiff(baseMeanPtr, candidateMeanPtr),
+		Evals:     intDiff(len(base.Stats.Evals), len(candidate.Stats.Evals)),
+		CostUSD:   floatDiff(base.Stats.CostUSD, candidate.Stats.CostUSD),
+	}
+}
+
+func metadataMismatches(meta evalComparisonMeta) []evalComparisonDiff {
+	checks := []struct {
+		name string
+		diff evalComparisonDiff
+	}{
+		{"dataset", meta.Dataset},
+		{"tasks", meta.Tasks},
+		{"agent", meta.Agent},
+		{"model", meta.Model},
+		{"environment", meta.Environment},
+	}
+	var mismatches []evalComparisonDiff
+	for _, check := range checks {
+		if check.diff.Base != check.diff.Candidate {
+			check.diff.Delta = check.name
+			mismatches = append(mismatches, check.diff)
+		}
+	}
+	return mismatches
+}
+
+func compareRecommendation(comparison evalComparison) string {
+	if sameComparisonJob(comparison.Base, comparison.Candidate) {
+		return "base and latest are the same eval job; nothing to compare."
+	}
+	if len(comparison.MetadataDiffs) > 0 {
+		return "metadata differs; review mismatches before promotion."
+	}
+	stats := comparison.Stats
+	if intDelta(stats.Errors) > 0 || intDelta(stats.Completed) < 0 || floatDelta(stats.Mean) < 0 {
+		return "candidate regressed; rerun or inspect job/task details before promotion."
+	}
+	if stats.Mean.Base == nil || stats.Mean.Candidate == nil {
+		return "summary changed; inspect job/task details before promotion."
+	}
+	return "candidate improved or held steady; promotion looks reasonable after normal review."
+}
+
+func sameComparisonJob(base, candidate evalComparisonJob) bool {
+	if base.Result != "" && base.Result == candidate.Result {
+		return true
+	}
+	return base.Path != "" && base.Path == candidate.Path
+}
+
+func intDelta(diff evalComparisonDiff) int {
+	value, _ := diff.Delta.(int)
+	return value
+}
+
+func floatDelta(diff evalComparisonDiff) float64 {
+	value, _ := diff.Delta.(float64)
+	return value
+}
+
+func signedDelta(value interface{}) string {
+	switch typed := value.(type) {
+	case int:
+		return fmt.Sprintf("%+d", typed)
+	case float64:
+		return fmt.Sprintf("%+.3f", typed)
+	default:
+		return ""
+	}
+}
+
+func displayValue(value interface{}) string {
+	if value == nil {
+		return "n/a"
+	}
+	switch typed := value.(type) {
+	case *float64:
+		if typed == nil {
+			return "n/a"
+		}
+		return fmt.Sprintf("%.3f", *typed)
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", typed))
+	}
+}
+
+func formatCompareTimestamp(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.Format(time.RFC3339)
+}

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -1,0 +1,401 @@
+package harbor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestEvalComparerComparesTrackedBaseWithLatestLocalCandidate(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	t.Chdir(tmp)
+
+	baseJob := localCompareJob(t, tmp, baseDir, "tracked in test")
+	var stdout bytes.Buffer
+	err := NewEvalComparer(EvalCompareOptions{
+		JobsDir: jobsRoot,
+		Stdout:  &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{baseJob},
+		},
+	}).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Base:   jobs/2026-06-25__09-00-00  tracked in HEAD",
+		"Latest: jobs/2026-06-25__10-00-00  local",
+		"mean:      0.500 -> 0.750  +0.250",
+		"Recommendation: candidate improved or held steady; promotion looks reasonable after normal review.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "old")
+	candidateDir := filepath.Join(jobsRoot, "new")
+	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	err := NewEvalComparer(EvalCompareOptions{
+		JobsDir: jobsRoot,
+		Format:  "json",
+		Stdout:  &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{localCompareJob(t, tmp, baseDir, "tracked in test")},
+		},
+	}).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid json: %v\n%s", err, stdout.String())
+	}
+	if _, ok := parsed["base"]; !ok {
+		t.Fatalf("json missing base: %#v", parsed)
+	}
+	if _, ok := parsed["candidate"]; !ok {
+		t.Fatalf("json missing candidate: %#v", parsed)
+	}
+	if _, ok := parsed["stats"]; !ok {
+		t.Fatalf("json missing stats: %#v", parsed)
+	}
+	if _, ok := parsed["recommendation"]; !ok {
+		t.Fatalf("json missing recommendation: %#v", parsed)
+	}
+}
+
+func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
+	base := compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"oracle__dataset": {Metrics: []map[string]interface{}{{"mean": 1.0}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "dataset-a", TaskNames: []string{"one"}}},
+			Agents:   []promoteAgentConfig{{Name: "oracle", ModelName: "model-a"}},
+		},
+		Selection: "tracked",
+	}
+	candidate := base
+	candidate.RelPath = ".runme/evals/jobs/candidate"
+	candidate.ResultRel = ".runme/evals/jobs/candidate/result.json"
+	candidate.Config.Datasets = []promoteDatasetConfig{{Path: "dataset-b", TaskNames: []string{"one"}}}
+
+	comparison := buildEvalComparison(base, candidate, "HEAD")
+	if len(comparison.MetadataDiffs) != 1 {
+		t.Fatalf("metadata diffs = %#v, want one diff", comparison.MetadataDiffs)
+	}
+	if !strings.Contains(comparison.Recommendation, "metadata differs") {
+		t.Fatalf("recommendation = %q", comparison.Recommendation)
+	}
+}
+
+func TestBuildEvalComparisonRecommendsNoopForSameJob(t *testing.T) {
+	job := compareJob{
+		RelPath:   ".runme/evals/jobs/job",
+		ResultRel: ".runme/evals/jobs/job/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__dataset": {Metrics: []map[string]interface{}{{"mean": 1.0}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "dataset", TaskNames: []string{"one"}}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex", ModelName: "model"}},
+		},
+		Selection: "tracked",
+	}
+
+	comparison := buildEvalComparison(job, job, "HEAD")
+	if comparison.Recommendation != "base and latest are the same eval job; nothing to compare." {
+		t.Fatalf("recommendation = %q", comparison.Recommendation)
+	}
+}
+
+func TestRenderEvalComparisonTextOmitsEmptyTasks(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats:       promoteJobStats{CompletedTrials: 1},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats:       promoteJobStats{CompletedTrials: 1},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	var stdout bytes.Buffer
+	if err := renderEvalComparisonText(&stdout, comparison); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stdout.String(), "Tasks:") {
+		t.Fatalf("output should not contain Tasks without explicit task names:\n%s", stdout.String())
+	}
+}
+
+func TestEvalComparerReadsTrackedBaseFromGit(t *testing.T) {
+	tmp := t.TempDir()
+	repo, err := git.PlainInit(tmp, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jobsRoot := filepath.Join(tmp, ".runme", "evals", "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	if _, err := wt.Add(".runme/evals/jobs/2026-06-25__09-00-00/result.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(".runme/evals/jobs/2026-06-25__09-00-00/config.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("baseline", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Runme Test",
+			Email: "runme@example.com",
+			When:  time.Date(2026, 6, 25, 9, 0, 0, 0, time.UTC),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	if err := NewEvalComparer(EvalCompareOptions{
+		Stdout: &stdout,
+	}).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Base:   .runme/evals/jobs/2026-06-25__09-00-00  tracked in HEAD") {
+		t.Fatalf("output missing tracked base:\n%s", output)
+	}
+	if !strings.Contains(output, "Latest: .runme/evals/jobs/2026-06-25__10-00-00  local") {
+		t.Fatalf("output missing local candidate:\n%s", output)
+	}
+}
+
+func TestEvalComparerLatestSkipsOracleOnlyJobsByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__08-00-00")
+	agentDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	oracleDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithMean(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithMean(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithMeanAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	if err := NewEvalComparer(EvalCompareOptions{
+		JobsDir: jobsRoot,
+		Stdout:  &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{localCompareJob(t, tmp, baseDir, "tracked in test")},
+		},
+	}).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "Latest: jobs/2026-06-25__09-00-00  local") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestEvalComparerLatestCanIncludeOracleOnlyJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__08-00-00")
+	agentDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	oracleDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithMean(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithMean(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithMeanAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	if err := NewEvalComparer(EvalCompareOptions{
+		JobsDir:       jobsRoot,
+		IncludeOracle: true,
+		Stdout:        &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{localCompareJob(t, tmp, baseDir, "tracked in test")},
+		},
+	}).Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "Latest: jobs/2026-06-25__10-00-00  local") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestResolveCompareBaseSkipsIncompleteTrackedJobs(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	completeDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	incompleteDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithMean(t, completeDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithMean(t, incompleteDir, "2026-06-25T10:00:00Z", 1, 0, 0, 0.75)
+
+	job, err := resolveCompareBase(compareBaseOptions{
+		git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{
+				localCompareJob(t, tmp, incompleteDir, "latest tracked job under --base"),
+				localCompareJob(t, tmp, completeDir, "latest tracked job under --base"),
+			},
+		},
+		baseRef:  "HEAD",
+		jobsRoot: jobsRoot,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.RelPath != "jobs/2026-06-25__09-00-00" {
+		t.Fatalf("base job = %q, want complete tracked job", job.RelPath)
+	}
+}
+
+type fakeCompareGit struct {
+	root string
+	jobs []compareJob
+}
+
+func (g fakeCompareGit) Rel(path string) (string, error) {
+	rel, err := filepath.Rel(cleanExistingPath(g.root), cleanExistingPath(path))
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func (g fakeCompareGit) TrackedEvalJobs(string, string) ([]compareJob, error) {
+	return append([]compareJob(nil), g.jobs...), nil
+}
+
+func localCompareJob(t *testing.T, root, jobDir, selection string) compareJob {
+	t.Helper()
+	root = cleanExistingPath(root)
+	jobDir = cleanExistingPath(jobDir)
+	result, err := readPromoteJobResult(jobDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := readPromoteJobConfig(jobDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobRel, err := filepath.Rel(root, jobDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return compareJob{
+		RelPath:   filepath.ToSlash(jobRel),
+		ResultRel: filepath.ToSlash(filepath.Join(jobRel, "result.json")),
+		Result:    result,
+		Config:    config,
+		Selection: selection,
+	}
+}
+
+func writePromoteJobWithMean(t *testing.T, jobDir, finishedAt string, total, completed, errors int, mean float64) {
+	t.Helper()
+	writePromoteJobWithMeanAgent(t, jobDir, finishedAt, "runme-codex", total, completed, errors, mean)
+}
+
+func writePromoteJobWithMeanAgent(t *testing.T, jobDir, finishedAt, agent string, total, completed, errors int, mean float64) {
+	t.Helper()
+	writePromoteJob(t, jobDir, finishedAt)
+	result := fmt.Sprintf(`{
+		"started_at": %q,
+		"updated_at": %q,
+		"finished_at": %q,
+		"n_total_trials": %d,
+		"stats": {
+			"n_completed_trials": %d,
+			"n_errored_trials": %d,
+			"evals": {
+				"%s__dataset": {
+					"n_trials": %d,
+					"n_errors": %d,
+					"metrics": [{"mean": %.3f}]
+				}
+			}
+		}
+	}`, finishedAt, finishedAt, finishedAt, total, completed, errors, agent, total, errors, mean)
+	writeFile(t, filepath.Join(jobDir, "result.json"), result)
+	config := `{
+		"datasets": [{"path": "dataset", "task_names": ["task"]}],
+		"agents": [{"name": "` + agent + `", "model_name": "model"}],
+		"environment": {"type": "runme"}
+	}`
+	writeFile(t, filepath.Join(jobDir, "config.json"), config)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/harbor/eval_promote_job.go
+++ b/internal/harbor/eval_promote_job.go
@@ -318,6 +318,10 @@ func readPromoteJobResult(jobDir string) (promoteJobResult, error) {
 	if err != nil {
 		return promoteJobResult{}, err
 	}
+	return parsePromoteJobResult(resultPath, data)
+}
+
+func parsePromoteJobResult(resultPath string, data []byte) (promoteJobResult, error) {
 	var raw struct {
 		StartedAt   string          `json:"started_at"`
 		UpdatedAt   string          `json:"updated_at"`
@@ -347,6 +351,10 @@ func readPromoteJobConfig(jobDir string) (promoteJobConfig, error) {
 		}
 		return promoteJobConfig{}, err
 	}
+	return parsePromoteJobConfig(data)
+}
+
+func parsePromoteJobConfig(data []byte) (promoteJobConfig, error) {
 	var config promoteJobConfig
 	if err := json.Unmarshal(data, &config); err != nil {
 		return promoteJobConfig{}, err


### PR DESCRIPTION
## Summary

- add `runme eval compare` as a read-only precursor to eval promotion
- compare the latest Git-tracked eval job at `--base` with the latest local job or explicit `--job`
- render compact text and JSON summaries with metadata mismatches, top-level stats deltas, and advisory recommendations
- reuse promote job parsing/selection boundaries and keep compare logic under `internal/harbor`

## Validation

- `go test ./cmd ./internal/harbor`
- `go test ./...` currently fails in existing document/editor packages with the same frontmatter version and local timezone expectation failures noted in PR #1199
