### PR TITLE
style: bold eval output labels

### DIFF
--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -84,33 +84,33 @@ func buildEvalComparison(base, candidate compareJob, baseRef string) evalCompari
 }
 
 func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
-	_, _ = fmt.Fprintf(w, "Base:   %s  tracked in %s\n", comparison.Base.Path, comparison.Base.Ref)
-	_, _ = fmt.Fprintf(w, "Latest: %s  local\n\n", comparison.Candidate.Path)
+	_, _ = fmt.Fprintf(w, "%s   %s  tracked in %s\n", evalOutputLabel(w, "Base:"), comparison.Base.Path, comparison.Base.Ref)
+	_, _ = fmt.Fprintf(w, "%s %s  local\n\n", evalOutputLabel(w, "Latest:"), comparison.Candidate.Path)
 
-	_, _ = fmt.Fprintf(w, "Dataset: %s\n", comparison.Metadata.Dataset.Candidate)
+	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Dataset:"), comparison.Metadata.Dataset.Candidate)
 	if tasks := strings.TrimSpace(fmt.Sprint(comparison.Metadata.Tasks.Candidate)); tasks != "" {
-		_, _ = fmt.Fprintf(w, "Tasks: %s\n", tasks)
+		_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Tasks:"), tasks)
 	}
-	_, _ = fmt.Fprintf(w, "Agent: %s\n", comparison.Metadata.Agent.Candidate)
-	_, _ = fmt.Fprintf(w, "Model: %s\n", comparison.Metadata.Model.Candidate)
-	_, _ = fmt.Fprintf(w, "Environment: %s\n\n", comparison.Metadata.Environment.Candidate)
+	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Agent:"), comparison.Metadata.Agent.Candidate)
+	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Model:"), comparison.Metadata.Model.Candidate)
+	_, _ = fmt.Fprintf(w, "%s %s\n\n", evalOutputLabel(w, "Environment:"), comparison.Metadata.Environment.Candidate)
 
 	if len(comparison.MetadataDiffs) > 0 {
-		_, _ = fmt.Fprintln(w, "Metadata mismatches:")
+		_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Metadata mismatches:"))
 		for _, diff := range comparison.MetadataDiffs {
-			_, _ = fmt.Fprintf(w, "  %s: %v -> %v\n", diff.Delta, diff.Base, diff.Candidate)
+			_, _ = fmt.Fprintf(w, "  %s %v -> %v\n", evalOutputLabel(w, fmt.Sprintf("%s:", diff.Delta)), diff.Base, diff.Candidate)
 		}
 		_, _ = fmt.Fprintln(w)
 	}
 
-	_, _ = fmt.Fprintln(w, "Score:")
-	_, _ = fmt.Fprintf(w, "  completed: %v -> %v  %s\n", comparison.Stats.Completed.Base, comparison.Stats.Completed.Candidate, signedDelta(comparison.Stats.Completed.Delta))
-	_, _ = fmt.Fprintf(w, "  errors:    %v -> %v  %s\n", comparison.Stats.Errors.Base, comparison.Stats.Errors.Candidate, signedDelta(comparison.Stats.Errors.Delta))
+	_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Score:"))
+	_, _ = fmt.Fprintf(w, "  %s %v -> %v  %s\n", evalOutputLabel(w, "completed:"), comparison.Stats.Completed.Base, comparison.Stats.Completed.Candidate, signedDelta(comparison.Stats.Completed.Delta))
+	_, _ = fmt.Fprintf(w, "  %s    %v -> %v  %s\n", evalOutputLabel(w, "errors:"), comparison.Stats.Errors.Base, comparison.Stats.Errors.Candidate, signedDelta(comparison.Stats.Errors.Delta))
 	if comparison.Stats.Mean.Base != nil || comparison.Stats.Mean.Candidate != nil {
-		_, _ = fmt.Fprintf(w, "  mean:      %s -> %s  %s\n", displayValue(comparison.Stats.Mean.Base), displayValue(comparison.Stats.Mean.Candidate), signedDelta(comparison.Stats.Mean.Delta))
+		_, _ = fmt.Fprintf(w, "  %s      %s -> %s  %s\n", evalOutputLabel(w, "mean:"), displayValue(comparison.Stats.Mean.Base), displayValue(comparison.Stats.Mean.Candidate), signedDelta(comparison.Stats.Mean.Delta))
 	}
-	_, _ = fmt.Fprintf(w, "  evals:     %v -> %v  %s\n\n", comparison.Stats.Evals.Base, comparison.Stats.Evals.Candidate, signedDelta(comparison.Stats.Evals.Delta))
-	_, _ = fmt.Fprintf(w, "Recommendation: %s\n", comparison.Recommendation)
+	_, _ = fmt.Fprintf(w, "  %s     %v -> %v  %s\n\n", evalOutputLabel(w, "evals:"), comparison.Stats.Evals.Base, comparison.Stats.Evals.Candidate, signedDelta(comparison.Stats.Evals.Delta))
+	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Recommendation:"), comparison.Recommendation)
 	return nil
 }
 

--- a/internal/harbor/eval_output.go
+++ b/internal/harbor/eval_output.go
@@ -1,0 +1,13 @@
+package harbor
+
+import (
+	"io"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
+)
+
+const evalOutputLabelStyle = "+b"
+
+func evalOutputLabel(w io.Writer, label string) string {
+	return ansi.ColorForWriter(w, label, evalOutputLabelStyle)
+}

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -99,7 +99,7 @@ func (p *EvalPromoter) Run(args []string) error {
 		includeOracle: p.opts.IncludeOracle,
 		allowErrors:   p.opts.AllowErrors,
 	}); warning != "" {
-		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s\n", warning, jobsRel)
+		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s\n\n", warning, jobsRel)
 	}
 	resultRel, err := gitClient.Rel(result.Path)
 	if err != nil {
@@ -115,9 +115,16 @@ func (p *EvalPromoter) Run(args []string) error {
 	})
 
 	if p.opts.DryRun {
-		_, _ = fmt.Fprintf(p.opts.Stdout, "Selected eval job: %s\n", jobRel)
-		_, _ = fmt.Fprintf(p.opts.Stdout, "Selection: %s\n\n", selection)
-		_, _ = fmt.Fprintf(p.opts.Stdout, "%s\n", message)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selected eval job:"), jobRel)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n\n", evalOutputLabel(p.opts.Stdout, "Selection:"), selection)
+		_, _ = fmt.Fprint(p.opts.Stdout, renderPromoteCommitMessageForWriter(p.opts.Stdout, promoteMessageData{
+			subject:      p.opts.Message,
+			jobPath:      jobRel,
+			resultPath:   resultRel,
+			evidenceOnly: p.opts.EvidenceOnly,
+			config:       config,
+			result:       result,
+		}))
 		return nil
 	}
 

--- a/internal/harbor/eval_promote_message.go
+++ b/internal/harbor/eval_promote_message.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 )
@@ -16,28 +17,40 @@ type promoteMessageData struct {
 }
 
 func renderPromoteCommitMessage(data promoteMessageData) string {
+	return renderPromoteCommitMessageWithLabel(data, func(label string) string {
+		return label
+	})
+}
+
+func renderPromoteCommitMessageForWriter(w io.Writer, data promoteMessageData) string {
+	return renderPromoteCommitMessageWithLabel(data, func(label string) string {
+		return evalOutputLabel(w, label)
+	})
+}
+
+func renderPromoteCommitMessageWithLabel(data promoteMessageData, label func(string) string) string {
 	var b strings.Builder
 	subject := strings.TrimSpace(data.subject)
 	if subject == "" {
 		subject = defaultPromoteSubject
 	}
 	_, _ = fmt.Fprintf(&b, "%s\n\n", subject)
-	_, _ = fmt.Fprintf(&b, "Eval-Job: %s\n", data.jobPath)
-	_, _ = fmt.Fprintf(&b, "Eval-Result: %s\n", data.resultPath)
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Eval-Job:"), data.jobPath)
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Eval-Result:"), data.resultPath)
 	if data.evidenceOnly {
-		_, _ = fmt.Fprintf(&b, "Promotion-Mode: eval-evidence-only\n")
+		_, _ = fmt.Fprintf(&b, "%s eval-evidence-only\n", label("Promotion-Mode:"))
 	}
-	_, _ = fmt.Fprintf(&b, "Dataset: %s\n", data.datasetSummary())
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Dataset:"), data.datasetSummary())
 	if tasks := data.taskSummary(); tasks != "" {
-		_, _ = fmt.Fprintf(&b, "Tasks: %s\n", tasks)
+		_, _ = fmt.Fprintf(&b, "%s %s\n", label("Tasks:"), tasks)
 	}
 	_, _ = fmt.Fprintln(&b)
-	_, _ = fmt.Fprintf(&b, "Agent: %s\n", data.agentSummary())
-	_, _ = fmt.Fprintf(&b, "Model: %s\n", data.modelSummary())
-	_, _ = fmt.Fprintf(&b, "Environment: %s\n\n", data.environmentSummary())
-	_, _ = fmt.Fprintf(&b, "Result: %s\n", data.resultSummary())
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Agent:"), data.agentSummary())
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Model:"), data.modelSummary())
+	_, _ = fmt.Fprintf(&b, "%s %s\n\n", label("Environment:"), data.environmentSummary())
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Result:"), data.resultSummary())
 	if score := data.scoreSummary(); score != "" {
-		_, _ = fmt.Fprintf(&b, "Score: %s\n", score)
+		_, _ = fmt.Fprintf(&b, "%s %s\n", label("Score:"), score)
 	}
 	return b.String()
 }

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -37,6 +37,9 @@ func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
 	if got := stdout.String(); !strings.Contains(got, "Selection: latest job under jobs") {
 		t.Fatalf("stdout = %q", got)
 	}
+	if got := stdout.String(); strings.HasSuffix(got, "\n\n") {
+		t.Fatalf("stdout has trailing blank line: %q", got)
+	}
 }
 
 func TestEvalPromoterWarnsWhenNewerJobsAreNotPromotable(t *testing.T) {
@@ -62,6 +65,9 @@ func TestEvalPromoterWarnsWhenNewerJobsAreNotPromotable(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "warning: no newer complete promotable eval job found under jobs") {
 		t.Fatalf("stderr = %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "warning: no newer complete promotable eval job found under jobs\n\n") {
+		t.Fatalf("stderr missing trailing blank line after warning: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a shared Harbor helper for writer-aware bold labels
- bold labels in `runme eval compare` text output
- bold labels in `runme eval promote --dry-run` output while keeping actual commit messages plain

## Tests
- `go test ./cmd ./internal/harbor`
- `runme run lint test`
