### PR TITLE
[codex] Add eval promote artifacts flag

### DIFF
--- a/cmd/eval_promote.go
+++ b/cmd/eval_promote.go
@@ -25,6 +25,7 @@ type evalPromoteOptions struct {
 	latest        bool
 	dryRun        bool
 	evidenceOnly  bool
+	artifacts     bool
 	includeOracle bool
 	allowErrors   bool
 	message       string
@@ -55,6 +56,7 @@ func evalPromoteCmd() *cobra.Command {
 	flags.BoolVar(&opts.latest, "latest", false, "Promote the latest eval job under --jobs-dir")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Print what would be committed without staging or committing")
 	flags.BoolVar(&opts.evidenceOnly, "evidence-only", false, "Commit only the selected eval job evidence when no source changes are staged")
+	flags.BoolVar(&opts.artifacts, "artifacts", false, "Include full eval artifacts such as logs and trial outputs; may contain sensitive information")
 	flags.BoolVar(&opts.includeOracle, "include-oracle", false, "Allow promoting eval jobs that only used Harbor's oracle agent")
 	flags.BoolVar(&opts.allowErrors, "allow-errors", false, "Allow promoting eval jobs with errored trials")
 	flags.StringVar(&opts.message, "message", "", "Commit message subject")
@@ -69,6 +71,7 @@ func runEvalPromote(opts evalPromoteOptions, args []string) error {
 		Latest:        opts.latest,
 		DryRun:        opts.dryRun,
 		EvidenceOnly:  opts.evidenceOnly,
+		Artifacts:     opts.artifacts,
 		IncludeOracle: opts.includeOracle,
 		AllowErrors:   opts.allowErrors,
 		Message:       opts.message,

--- a/cmd/eval_promote_test.go
+++ b/cmd/eval_promote_test.go
@@ -30,6 +30,7 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		"--job", "jobs/job-1",
 		"--dry-run",
 		"--evidence-only",
+		"--artifacts",
 		"--include-oracle",
 		"--allow-errors",
 		"--message", "Custom subject",
@@ -53,6 +54,7 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		gotOpts.Job != "jobs/job-1" ||
 		!gotOpts.DryRun ||
 		!gotOpts.EvidenceOnly ||
+		!gotOpts.Artifacts ||
 		!gotOpts.IncludeOracle ||
 		!gotOpts.AllowErrors ||
 		gotOpts.Latest ||

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -14,6 +14,7 @@ type EvalPromoteOptions struct {
 	Latest        bool
 	DryRun        bool
 	EvidenceOnly  bool
+	Artifacts     bool
 	IncludeOracle bool
 	AllowErrors   bool
 	Message       string
@@ -115,8 +116,25 @@ func (p *EvalPromoter) Run(args []string) error {
 	})
 
 	if p.opts.DryRun {
+		files, err := gitClient.JobFiles(jobDir, p.opts.Artifacts)
+		if err != nil {
+			return err
+		}
 		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selected eval job:"), jobRel)
-		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n\n", evalOutputLabel(p.opts.Stdout, "Selection:"), selection)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selection:"), selection)
+		if p.opts.Artifacts {
+			_, _ = fmt.Fprintf(p.opts.Stdout, "%s artifacts\n", evalOutputLabel(p.opts.Stdout, "Evidence mode:"))
+		} else {
+			_, _ = fmt.Fprintf(p.opts.Stdout, "%s compact\n", evalOutputLabel(p.opts.Stdout, "Evidence mode:"))
+		}
+		_, _ = fmt.Fprintln(p.opts.Stdout, evalOutputLabel(p.opts.Stdout, "Files to add:"))
+		for _, file := range files {
+			_, _ = fmt.Fprintf(p.opts.Stdout, "  %s\n", file)
+		}
+		if p.opts.Artifacts {
+			_, _ = fmt.Fprintf(p.opts.Stdout, "%s */workdir/*\n", evalOutputLabel(p.opts.Stdout, "Excluded:"))
+		}
+		_, _ = fmt.Fprintln(p.opts.Stdout)
 		_, _ = fmt.Fprint(p.opts.Stdout, renderPromoteCommitMessageForWriter(p.opts.Stdout, promoteMessageData{
 			subject:      p.opts.Message,
 			jobPath:      jobRel,
@@ -156,7 +174,7 @@ func (p *EvalPromoter) Run(args []string) error {
 			_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s\n", warning)
 		}
 	}
-	if err := gitClient.AddJobDir(jobDir); err != nil {
+	if err := gitClient.AddJobDir(jobDir, p.opts.Artifacts); err != nil {
 		return err
 	}
 	hash, err := gitClient.Commit(message)

--- a/internal/harbor/eval_promote_git.go
+++ b/internal/harbor/eval_promote_git.go
@@ -15,7 +15,8 @@ type promoteGit interface {
 	StagedFiles() ([]string, error)
 	UnstagedFilesTouching([]string) ([]string, error)
 	LatestModTime([]string) (time.Time, error)
-	AddJobDir(string) error
+	AddJobDir(string, bool) error
+	JobFiles(string, bool) ([]string, error)
 	Commit(string) (string, error)
 	Rel(string) (string, error)
 }
@@ -97,23 +98,76 @@ func (c *goGitPromoteClient) LatestModTime(paths []string) (time.Time, error) {
 	return latest, nil
 }
 
-func (c *goGitPromoteClient) AddJobDir(jobDir string) error {
-	return filepath.WalkDir(jobDir, func(path string, d os.DirEntry, err error) error {
+func (c *goGitPromoteClient) AddJobDir(jobDir string, includeArtifacts bool) error {
+	files, err := c.JobFiles(jobDir, includeArtifacts)
+	if err != nil {
+		return err
+	}
+	for _, rel := range files {
+		if err := c.wt.AddWithOptions(&git.AddOptions{
+			Path:       filepath.FromSlash(rel),
+			SkipStatus: true,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *goGitPromoteClient) JobFiles(jobDir string, includeArtifacts bool) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(jobDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		if shouldSkipPromoteDir(jobDir, path, d) {
+			return filepath.SkipDir
+		}
+		if d.IsDir() || !shouldAddPromoteFile(jobDir, path, includeArtifacts) {
 			return nil
 		}
 		rel, err := c.Rel(path)
 		if err != nil {
 			return err
 		}
-		return c.wt.AddWithOptions(&git.AddOptions{
-			Path:       filepath.FromSlash(rel),
-			SkipStatus: true,
-		})
+		files = append(files, rel)
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func shouldSkipPromoteDir(jobDir, path string, d os.DirEntry) bool {
+	if !d.IsDir() || cleanExistingPath(path) == cleanExistingPath(jobDir) {
+		return false
+	}
+	return d.Name() == "workdir"
+}
+
+func shouldAddPromoteFile(jobDir, path string, includeArtifacts bool) bool {
+	if includeArtifacts {
+		return true
+	}
+	rel, err := filepath.Rel(jobDir, path)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return false
+	}
+	if !strings.Contains(rel, string(os.PathSeparator)) {
+		return true
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	for _, part := range parts[:len(parts)-1] {
+		if part == "verifier" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *goGitPromoteClient) Commit(message string) (string, error) {

--- a/internal/harbor/eval_promote_git_test.go
+++ b/internal/harbor/eval_promote_git_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
-func TestGoGitPromoteClientAddJobDirForceAddsIgnoredFiles(t *testing.T) {
+func TestGoGitPromoteClientAddJobDirAddsCompactEvidence(t *testing.T) {
 	repoRoot := t.TempDir()
 	repo, err := git.PlainInit(repoRoot, false)
 	if err != nil {
@@ -36,8 +36,33 @@ func TestGoGitPromoteClientAddJobDirForceAddsIgnoredFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(jobDir, "job.log"), []byte("log"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+	trialDir := filepath.Join(jobDir, "text-stats-reward__abc123")
+	for _, dir := range []string{
+		filepath.Join(trialDir, "artifacts"),
+		filepath.Join(trialDir, "agent"),
+		filepath.Join(trialDir, "verifier"),
+		filepath.Join(trialDir, "workdir"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(trialDir, "trial.log"):                "trial",
+		filepath.Join(trialDir, "artifacts", "result.txt"):  "artifact",
+		filepath.Join(trialDir, "agent", "trajectory.json"): "{}",
+		filepath.Join(trialDir, "verifier", "reward.json"):  "{}",
+		filepath.Join(trialDir, "workdir", "sample.txt"):    "sample",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	t.Chdir(repoRoot)
 
@@ -45,7 +70,30 @@ func TestGoGitPromoteClientAddJobDirForceAddsIgnoredFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := client.AddJobDir(jobDir); err != nil {
+	files, err := client.JobFiles(jobDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFiles := []string{
+		".runme/evals/jobs/job/config.json",
+		".runme/evals/jobs/job/job.log",
+		".runme/evals/jobs/job/result.json",
+		".runme/evals/jobs/job/text-stats-reward__abc123/verifier/reward.json",
+	}
+	if len(files) != len(wantFiles) {
+		t.Fatalf("files = %#v, want %#v", files, wantFiles)
+	}
+	for i := range wantFiles {
+		if files[i] != wantFiles[i] {
+			t.Fatalf("files = %#v, want %#v", files, wantFiles)
+		}
+		if wtStatus, err := wt.Status(); err != nil {
+			t.Fatal(err)
+		} else if wtStatus.File(files[i]).Staging != git.Untracked {
+			t.Fatalf("%s staging = %q, want untracked before add; status=%s", files[i], wtStatus.File(files[i]).Staging, wtStatus.String())
+		}
+	}
+	if err := client.AddJobDir(jobDir, false); err != nil {
 		t.Fatal(err)
 	}
 	status, err := wt.Status()
@@ -54,11 +102,96 @@ func TestGoGitPromoteClientAddJobDirForceAddsIgnoredFiles(t *testing.T) {
 	}
 	for _, path := range []string{
 		".runme/evals/jobs/job/result.json",
+		".runme/evals/jobs/job/config.json",
 		".runme/evals/jobs/job/job.log",
+		".runme/evals/jobs/job/text-stats-reward__abc123/verifier/reward.json",
 	} {
 		if status.File(path).Staging != git.Added {
 			t.Fatalf("%s staging = %q, want added; status=%s", path, status.File(path).Staging, status.String())
 		}
+	}
+	for _, path := range []string{
+		".runme/evals/jobs/job/text-stats-reward__abc123/trial.log",
+		".runme/evals/jobs/job/text-stats-reward__abc123/artifacts/result.txt",
+		".runme/evals/jobs/job/text-stats-reward__abc123/agent/trajectory.json",
+		".runme/evals/jobs/job/text-stats-reward__abc123/workdir/sample.txt",
+	} {
+		if status.File(path).Staging != git.Untracked {
+			t.Fatalf("%s staging = %q, want untracked; status=%s", path, status.File(path).Staging, status.String())
+		}
+	}
+}
+
+func TestGoGitPromoteClientAddJobDirAddsArtifactsExceptWorkdir(t *testing.T) {
+	repoRoot := t.TempDir()
+	repo, err := git.PlainInit(repoRoot, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoRoot, ".gitignore"), []byte(".runme/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(".gitignore"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("initial", &git.CommitOptions{Author: testPromoteSignature()}); err != nil {
+		t.Fatal(err)
+	}
+
+	jobDir := filepath.Join(repoRoot, ".runme", "evals", "jobs", "job")
+	trialDir := filepath.Join(jobDir, "text-stats-reward__abc123")
+	for _, dir := range []string{
+		filepath.Join(trialDir, "artifacts"),
+		filepath.Join(trialDir, "agent"),
+		filepath.Join(trialDir, "verifier"),
+		filepath.Join(trialDir, "workdir"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for path, content := range map[string]string{
+		filepath.Join(jobDir, "result.json"):                "{}",
+		filepath.Join(trialDir, "trial.log"):                "trial",
+		filepath.Join(trialDir, "artifacts", "result.txt"):  "artifact",
+		filepath.Join(trialDir, "agent", "trajectory.json"): "{}",
+		filepath.Join(trialDir, "verifier", "reward.json"):  "{}",
+		filepath.Join(trialDir, "workdir", "sample.txt"):    "sample",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Chdir(repoRoot)
+
+	client, err := newGoGitPromoteClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.AddJobDir(jobDir, true); err != nil {
+		t.Fatal(err)
+	}
+	status, err := wt.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		".runme/evals/jobs/job/result.json",
+		".runme/evals/jobs/job/text-stats-reward__abc123/trial.log",
+		".runme/evals/jobs/job/text-stats-reward__abc123/artifacts/result.txt",
+		".runme/evals/jobs/job/text-stats-reward__abc123/agent/trajectory.json",
+		".runme/evals/jobs/job/text-stats-reward__abc123/verifier/reward.json",
+	} {
+		if status.File(path).Staging != git.Added {
+			t.Fatalf("%s staging = %q, want added; status=%s", path, status.File(path).Staging, status.String())
+		}
+	}
+	if path := ".runme/evals/jobs/job/text-stats-reward__abc123/workdir/sample.txt"; status.File(path).Staging != git.Untracked {
+		t.Fatalf("%s staging = %q, want untracked; status=%s", path, status.File(path).Staging, status.String())
 	}
 }
 

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -16,7 +16,13 @@ func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
 	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
 
 	var stdout bytes.Buffer
-	gitClient := &recordingPromoteGit{root: tmp}
+	gitClient := &recordingPromoteGit{
+		root: tmp,
+		jobFiles: []string{
+			"jobs/2026-06-25__10-00-00/result.json",
+			"jobs/2026-06-25__10-00-00/trial/verifier/reward.json",
+		},
+	}
 	promoter := NewEvalPromoter(EvalPromoteOptions{
 		JobsDir: jobsRoot,
 		Latest:  true,
@@ -31,6 +37,12 @@ func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
 	if gitClient.stagedCalled {
 		t.Fatal("StagedFiles was called during dry-run")
 	}
+	if !gitClient.jobFilesCalled {
+		t.Fatal("JobFiles was not called during dry-run")
+	}
+	if gitClient.addCalled {
+		t.Fatal("AddJobDir was called during dry-run")
+	}
 	if got := stdout.String(); !strings.Contains(got, "Selected eval job: jobs/2026-06-25__10-00-00") {
 		t.Fatalf("stdout = %q", got)
 	}
@@ -39,6 +51,40 @@ func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
 	}
 	if got := stdout.String(); strings.HasSuffix(got, "\n\n") {
 		t.Fatalf("stdout has trailing blank line: %q", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Evidence mode: compact\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\n  jobs/2026-06-25__10-00-00/trial/verifier/reward.json\n\nPromote changes verified by task eval") {
+		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestEvalPromoterDryRunShowsArtifactsModeAndWorkdirExclusion(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	var stdout bytes.Buffer
+	gitClient := &recordingPromoteGit{
+		root:     tmp,
+		jobFiles: []string{"jobs/2026-06-25__10-00-00/result.json"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:   jobsRoot,
+		Latest:    true,
+		DryRun:    true,
+		Artifacts: true,
+		Stdout:    &stdout,
+		Git:       gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !gitClient.includeArtifacts {
+		t.Fatal("includeArtifacts = false, want true")
+	}
+	if got := stdout.String(); !strings.Contains(got, "Evidence mode: artifacts\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\nExcluded: */workdir/*\n\nPromote changes verified by task eval") {
+		t.Fatalf("stdout = %q", got)
 	}
 }
 
@@ -142,8 +188,39 @@ func TestEvalPromoterEvidenceOnlyCommitsJobWithoutStagedChanges(t *testing.T) {
 	if !gitClient.addCalled || !gitClient.commitCalled {
 		t.Fatal("expected add and commit")
 	}
+	if gitClient.includeArtifacts {
+		t.Fatal("includeArtifacts = true, want false")
+	}
 	if !strings.Contains(gitClient.message, "Promotion-Mode: eval-evidence-only") {
 		t.Fatalf("commit message missing evidence-only mode:\n%s", gitClient.message)
+	}
+}
+
+func TestEvalPromoterArtifactsCommitsFullJobEvidence(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, jobDir, "2026-06-25T10:00:00Z")
+
+	gitClient := &recordingPromoteGit{
+		root:   tmp,
+		staged: []string{"main.go"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:   jobsRoot,
+		Latest:    true,
+		Artifacts: true,
+		Git:       gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !gitClient.addCalled || !gitClient.commitCalled {
+		t.Fatal("expected add and commit")
+	}
+	if !gitClient.includeArtifacts {
+		t.Fatal("includeArtifacts = false, want true")
 	}
 }
 
@@ -250,12 +327,15 @@ func TestEvalPromoterExplicitJobRejectsIncompleteJob(t *testing.T) {
 }
 
 type recordingPromoteGit struct {
-	root         string
-	staged       []string
-	stagedCalled bool
-	addCalled    bool
-	commitCalled bool
-	message      string
+	root             string
+	staged           []string
+	stagedCalled     bool
+	addCalled        bool
+	jobFilesCalled   bool
+	commitCalled     bool
+	includeArtifacts bool
+	jobFiles         []string
+	message          string
 }
 
 func (g *recordingPromoteGit) StagedFiles() ([]string, error) {
@@ -271,9 +351,16 @@ func (g *recordingPromoteGit) LatestModTime([]string) (time.Time, error) {
 	return time.Time{}, nil
 }
 
-func (g *recordingPromoteGit) AddJobDir(string) error {
+func (g *recordingPromoteGit) AddJobDir(_ string, includeArtifacts bool) error {
 	g.addCalled = true
+	g.includeArtifacts = includeArtifacts
 	return nil
+}
+
+func (g *recordingPromoteGit) JobFiles(_ string, includeArtifacts bool) ([]string, error) {
+	g.jobFilesCalled = true
+	g.includeArtifacts = includeArtifacts
+	return append([]string(nil), g.jobFiles...), nil
 }
 
 func (g *recordingPromoteGit) Commit(message string) (string, error) {


### PR DESCRIPTION
## Summary

- add `runme eval promote --artifacts` for opting into full eval artifacts
- make default promotion commit compact evidence: top-level job files plus nested verifier outputs
- always exclude nested `workdir` contents, including when artifacts are requested

## Validation

- `go test ./internal/harbor ./cmd`
- `runme run lint test`

Signed-off-by: Sebastian (Tiedtke) Huckleberry <sebastiantiedtke@gmail.com>
