### PR TITLE
fix: compare eval results by overlap

### DIFF
--- a/cmd/eval_compare.go
+++ b/cmd/eval_compare.go
@@ -41,12 +41,11 @@ func evalCompareCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compare",
 		Short: "Compare the latest Git-tracked eval job with the latest local eval job",
-		Long: `Compare top-level eval result summaries between the last Git-tracked eval
-job and a local candidate eval job. By default, the candidate is the newest
-local job under --jobs-dir. The command is read-only and prints an advisory
-recommendation based on comparable top-level stats such as score rollups,
-pass counts, exceptions, and failures. It does not promote, commit, or enforce
-policy.`,
+		Long: `Compare eval job execution summaries and matching eval results between
+the last Git-tracked eval job and a local candidate eval job. By default, the
+candidate is the newest local job under --jobs-dir. The command is read-only
+and prints an advisory recommendation based on job counters and overlapping
+result rewards. It does not promote, commit, or enforce policy.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()

--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -4,17 +4,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 )
 
 type evalComparison struct {
-	Base           evalComparisonJob    `json:"base"`
-	Candidate      evalComparisonJob    `json:"candidate"`
-	Metadata       evalComparisonMeta   `json:"metadata"`
-	MetadataDiffs  []evalComparisonDiff `json:"metadata_mismatches,omitempty"`
-	Stats          evalComparisonStats  `json:"stats"`
-	Recommendation string               `json:"recommendation"`
+	Base           evalComparisonJob     `json:"base"`
+	Candidate      evalComparisonJob     `json:"candidate"`
+	Metadata       evalComparisonMeta    `json:"metadata"`
+	MetadataDiffs  []evalComparisonDiff  `json:"metadata_mismatches,omitempty"`
+	Job            evalComparisonStats   `json:"job"`
+	Results        evalComparisonResults `json:"results"`
+	Recommendation string                `json:"recommendation"`
 }
 
 type evalComparisonJob struct {
@@ -36,9 +38,24 @@ type evalComparisonMeta struct {
 type evalComparisonStats struct {
 	Completed evalComparisonDiff `json:"completed"`
 	Errors    evalComparisonDiff `json:"errors"`
-	Mean      evalComparisonDiff `json:"mean,omitempty"`
 	Evals     evalComparisonDiff `json:"evals"`
 	CostUSD   evalComparisonDiff `json:"cost_usd,omitempty"`
+}
+
+type evalComparisonResults struct {
+	BaseOnly      []string               `json:"base_only,omitempty"`
+	CandidateOnly []string               `json:"candidate_only,omitempty"`
+	Comparisons   []evalComparisonResult `json:"comparisons"`
+}
+
+type evalComparisonResult struct {
+	Key          string             `json:"key"`
+	BaseKey      string             `json:"base_key,omitempty"`
+	CandidateKey string             `json:"candidate_key,omitempty"`
+	Reward       evalComparisonDiff `json:"reward"`
+	RewardStatus string             `json:"reward_status,omitempty"`
+	Errors       evalComparisonDiff `json:"errors"`
+	Trials       evalComparisonDiff `json:"trials"`
 }
 
 type evalComparisonDiff struct {
@@ -58,7 +75,8 @@ func buildEvalComparison(base, candidate compareJob, baseRef string) evalCompari
 		Model:       stringDiff(baseSummary.modelSummary(), candidateSummary.modelSummary()),
 		Environment: stringDiff(baseSummary.environmentSummary(), candidateSummary.environmentSummary()),
 	}
-	stats := compareStats(base.Result, candidate.Result)
+	job := compareJobStats(base.Result, candidate.Result)
+	results := compareResults(base, candidate)
 	mismatches := metadataMismatches(metadata)
 
 	comparison := evalComparison{
@@ -77,7 +95,8 @@ func buildEvalComparison(base, candidate compareJob, baseRef string) evalCompari
 		},
 		Metadata:      metadata,
 		MetadataDiffs: mismatches,
-		Stats:         stats,
+		Job:           job,
+		Results:       results,
 	}
 	comparison.Recommendation = compareRecommendation(comparison)
 	return comparison
@@ -103,13 +122,25 @@ func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
 		_, _ = fmt.Fprintln(w)
 	}
 
-	_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Score:"))
-	_, _ = fmt.Fprintf(w, "  %s %v -> %v  %s\n", evalOutputLabel(w, "completed:"), comparison.Stats.Completed.Base, comparison.Stats.Completed.Candidate, signedDelta(comparison.Stats.Completed.Delta))
-	_, _ = fmt.Fprintf(w, "  %s    %v -> %v  %s\n", evalOutputLabel(w, "errors:"), comparison.Stats.Errors.Base, comparison.Stats.Errors.Candidate, signedDelta(comparison.Stats.Errors.Delta))
-	if comparison.Stats.Mean.Base != nil || comparison.Stats.Mean.Candidate != nil {
-		_, _ = fmt.Fprintf(w, "  %s      %s -> %s  %s\n", evalOutputLabel(w, "mean:"), displayValue(comparison.Stats.Mean.Base), displayValue(comparison.Stats.Mean.Candidate), signedDelta(comparison.Stats.Mean.Delta))
+	_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Job:"))
+	_, _ = fmt.Fprintf(w, "  %s %v -> %v  %s\n", evalOutputLabel(w, "completed:"), comparison.Job.Completed.Base, comparison.Job.Completed.Candidate, signedDelta(comparison.Job.Completed.Delta))
+	_, _ = fmt.Fprintf(w, "  %s    %v -> %v  %s\n", evalOutputLabel(w, "errors:"), comparison.Job.Errors.Base, comparison.Job.Errors.Candidate, signedDelta(comparison.Job.Errors.Delta))
+	_, _ = fmt.Fprintf(w, "  %s     %v -> %v  %s\n\n", evalOutputLabel(w, "evals:"), comparison.Job.Evals.Base, comparison.Job.Evals.Candidate, signedDelta(comparison.Job.Evals.Delta))
+
+	_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Results:"))
+	if len(comparison.Results.Comparisons) == 0 {
+		_, _ = fmt.Fprintln(w, "  no matching eval results")
 	}
-	_, _ = fmt.Fprintf(w, "  %s     %v -> %v  %s\n\n", evalOutputLabel(w, "evals:"), comparison.Stats.Evals.Base, comparison.Stats.Evals.Candidate, signedDelta(comparison.Stats.Evals.Delta))
+	for _, result := range comparison.Results.Comparisons {
+		_, _ = fmt.Fprintf(w, "  %s reward %s -> %s  %s\n", evalOutputLabel(w, result.Key+":"), displayValue(result.Reward.Base), displayValue(result.Reward.Candidate), signedDelta(result.Reward.Delta))
+	}
+	if len(comparison.Results.BaseOnly) > 0 {
+		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "base only:"), strings.Join(comparison.Results.BaseOnly, ", "))
+	}
+	if len(comparison.Results.CandidateOnly) > 0 {
+		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "latest only:"), strings.Join(comparison.Results.CandidateOnly, ", "))
+	}
+	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Recommendation:"), comparison.Recommendation)
 	return nil
 }
@@ -136,23 +167,71 @@ func floatDiff(base, candidate *float64) evalComparisonDiff {
 	return diff
 }
 
-func compareStats(base, candidate promoteJobResult) evalComparisonStats {
-	baseMean, baseHasMean := singlePromoteMean(base.Stats)
-	candidateMean, candidateHasMean := singlePromoteMean(candidate.Stats)
-	var baseMeanPtr, candidateMeanPtr *float64
-	if baseHasMean {
-		baseMeanPtr = &baseMean
-	}
-	if candidateHasMean {
-		candidateMeanPtr = &candidateMean
-	}
+func compareJobStats(base, candidate promoteJobResult) evalComparisonStats {
 	return evalComparisonStats{
 		Completed: intDiff(base.Stats.CompletedTrials, candidate.Stats.CompletedTrials),
 		Errors:    intDiff(base.Stats.ErroredTrials, candidate.Stats.ErroredTrials),
-		Mean:      floatDiff(baseMeanPtr, candidateMeanPtr),
 		Evals:     intDiff(len(base.Stats.Evals), len(candidate.Stats.Evals)),
 		CostUSD:   floatDiff(base.Stats.CostUSD, candidate.Stats.CostUSD),
 	}
+}
+
+func compareResults(base, candidate compareJob) evalComparisonResults {
+	baseEntries := evalResultSummaryMap(base.Result, base.Config)
+	candidateEntries := evalResultSummaryMap(candidate.Result, candidate.Config)
+	baseKeys := sortedEvalResultSummaryKeys(baseEntries)
+	candidateKeys := sortedEvalResultSummaryKeys(candidateEntries)
+	candidateSet := make(map[string]struct{}, len(candidateKeys))
+	for _, key := range candidateKeys {
+		candidateSet[key] = struct{}{}
+	}
+	baseSet := make(map[string]struct{}, len(baseKeys))
+	for _, key := range baseKeys {
+		baseSet[key] = struct{}{}
+	}
+
+	var results evalComparisonResults
+	for _, key := range baseKeys {
+		if _, ok := candidateSet[key]; !ok {
+			results.BaseOnly = append(results.BaseOnly, key)
+			continue
+		}
+		baseEntry := baseEntries[key]
+		candidateEntry := candidateEntries[key]
+		results.Comparisons = append(results.Comparisons, evalComparisonResult{
+			Key:          key,
+			BaseKey:      baseEntry.RawKey,
+			CandidateKey: candidateEntry.RawKey,
+			Reward:       floatDiff(baseEntry.Reward, candidateEntry.Reward),
+			RewardStatus: combinedRewardStatus(baseEntry.RewardStatus, candidateEntry.RewardStatus),
+			Errors:       intDiff(baseEntry.Stats.Errors, candidateEntry.Stats.Errors),
+			Trials:       intDiff(baseEntry.Stats.Trials, candidateEntry.Stats.Trials),
+		})
+	}
+	for _, key := range candidateKeys {
+		if _, ok := baseSet[key]; !ok {
+			results.CandidateOnly = append(results.CandidateOnly, key)
+		}
+	}
+	return results
+}
+
+func evalResultSummaryMap(result promoteJobResult, config promoteJobConfig) map[string]evalResultSummary {
+	summaries := summarizeEvalResults(result, config)
+	entries := make(map[string]evalResultSummary, len(summaries))
+	for _, summary := range summaries {
+		entries[summary.Key] = summary
+	}
+	return entries
+}
+
+func sortedEvalResultSummaryKeys(entries map[string]evalResultSummary) []string {
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func metadataMismatches(meta evalComparisonMeta) []evalComparisonDiff {
@@ -180,15 +259,25 @@ func compareRecommendation(comparison evalComparison) string {
 	if sameComparisonJob(comparison.Base, comparison.Candidate) {
 		return "base and latest are the same eval job; nothing to compare."
 	}
+	job := comparison.Job
+	if intDelta(job.Errors) > 0 || intDelta(job.Completed) < 0 {
+		return "candidate regressed; rerun or inspect job/task details before promotion."
+	}
+	if len(comparison.Results.Comparisons) == 0 {
+		return "no matching eval results; compare job selection before promotion."
+	}
 	if len(comparison.MetadataDiffs) > 0 {
 		return "metadata differs; review mismatches before promotion."
 	}
-	stats := comparison.Stats
-	if intDelta(stats.Errors) > 0 || intDelta(stats.Completed) < 0 || floatDelta(stats.Mean) < 0 {
-		return "candidate regressed; rerun or inspect job/task details before promotion."
+	for _, result := range comparison.Results.Comparisons {
+		if floatDelta(result.Reward) < 0 {
+			return "candidate regressed; rerun or inspect job/task details before promotion."
+		}
 	}
-	if stats.Mean.Base == nil || stats.Mean.Candidate == nil {
-		return "summary changed; inspect job/task details before promotion."
+	for _, result := range comparison.Results.Comparisons {
+		if result.RewardStatus != "" {
+			return "summary changed; inspect job/task details before promotion."
+		}
 	}
 	return "candidate improved or held steady; promotion looks reasonable after normal review."
 }

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -19,8 +19,8 @@ func TestEvalComparerComparesTrackedBaseWithLatestLocalCandidate(t *testing.T) {
 	jobsRoot := filepath.Join(tmp, "jobs")
 	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
 	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
-	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
-	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
 	t.Chdir(tmp)
 
 	baseJob := localCompareJob(t, tmp, baseDir, "tracked in test")
@@ -41,12 +41,17 @@ func TestEvalComparerComparesTrackedBaseWithLatestLocalCandidate(t *testing.T) {
 	for _, want := range []string{
 		"Base:   jobs/2026-06-25__09-00-00  tracked in HEAD",
 		"Latest: jobs/2026-06-25__10-00-00  local",
-		"mean:      0.500 -> 0.750  +0.250",
+		"Job:",
+		"Results:",
+		"dataset: reward 0.500 -> 0.750  +0.250",
 		"Recommendation: candidate improved or held steady; promotion looks reasonable after normal review.",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
+	}
+	if strings.Contains(output, "Score:") {
+		t.Fatalf("output should use Job/Results instead of Score:\n%s", output)
 	}
 }
 
@@ -55,8 +60,8 @@ func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	jobsRoot := filepath.Join(tmp, "jobs")
 	baseDir := filepath.Join(jobsRoot, "old")
 	candidateDir := filepath.Join(jobsRoot, "new")
-	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
-	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
 	t.Chdir(tmp)
 
 	var stdout bytes.Buffer
@@ -83,8 +88,14 @@ func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	if _, ok := parsed["candidate"]; !ok {
 		t.Fatalf("json missing candidate: %#v", parsed)
 	}
-	if _, ok := parsed["stats"]; !ok {
-		t.Fatalf("json missing stats: %#v", parsed)
+	if _, ok := parsed["job"]; !ok {
+		t.Fatalf("json missing job: %#v", parsed)
+	}
+	if _, ok := parsed["results"]; !ok {
+		t.Fatalf("json missing results: %#v", parsed)
+	}
+	if _, ok := parsed["stats"]; ok {
+		t.Fatalf("json should not keep legacy stats shape: %#v", parsed)
 	}
 	if _, ok := parsed["recommendation"]; !ok {
 		t.Fatalf("json missing recommendation: %#v", parsed)
@@ -100,7 +111,7 @@ func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
 			Stats: promoteJobStats{
 				CompletedTrials: 1,
 				Evals: map[string]promoteEvalStats{
-					"oracle__dataset": {Metrics: []map[string]interface{}{{"mean": 1.0}}},
+					"oracle__dataset": {Metrics: []map[string]interface{}{{"reward": 1.0}}},
 				},
 			},
 		},
@@ -124,6 +135,127 @@ func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
 	}
 }
 
+func TestBuildEvalComparisonMatchesResultsAcrossDifferentAgents(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__regression": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.5}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/regression"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex", ModelName: "gpt-5.5"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-claude-code__regression": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.75}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/regression"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-claude-code", ModelName: "claude-opus-4-8"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	if len(comparison.Results.Comparisons) != 1 {
+		t.Fatalf("comparisons = %#v, want one normalized match", comparison.Results.Comparisons)
+	}
+	result := comparison.Results.Comparisons[0]
+	if result.Key != "regression" {
+		t.Fatalf("result key = %q, want normalized regression", result.Key)
+	}
+	if result.BaseKey != "runme-codex__regression" || result.CandidateKey != "runme-claude-code__regression" {
+		t.Fatalf("raw result keys = %q/%q", result.BaseKey, result.CandidateKey)
+	}
+	if len(comparison.Results.BaseOnly) != 0 || len(comparison.Results.CandidateOnly) != 0 {
+		t.Fatalf("unexpected non-overlap rows: %#v", comparison.Results)
+	}
+
+	var stdout bytes.Buffer
+	if err := renderEvalComparisonText(&stdout, comparison); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "regression: reward 0.500 -> 0.750  +0.250") {
+		t.Fatalf("output missing normalized result row:\n%s", output)
+	}
+	if strings.Contains(output, "no matching eval results") ||
+		strings.Contains(output, "base only:") ||
+		strings.Contains(output, "latest only:") {
+		t.Fatalf("output should not report non-overlap for normalized agent keys:\n%s", output)
+	}
+	if comparison.Recommendation != "metadata differs; review mismatches before promotion." {
+		t.Fatalf("recommendation = %q", comparison.Recommendation)
+	}
+}
+
+func TestBuildEvalComparisonTreatsMissingRewardAsZero(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__regression": {Trials: 1, Metrics: []map[string]interface{}{{"source_quality": 1.0}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/regression"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex", ModelName: "gpt-5.5"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"runme-codex__regression": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.75}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/regression"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex", ModelName: "gpt-5.5"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	if len(comparison.Results.Comparisons) != 1 {
+		t.Fatalf("comparisons = %#v, want one match", comparison.Results.Comparisons)
+	}
+	result := comparison.Results.Comparisons[0]
+	if result.RewardStatus != "" {
+		t.Fatalf("reward status = %q, want empty status", result.RewardStatus)
+	}
+	if got := displayValue(result.Reward.Base); got != "0.000" {
+		t.Fatalf("base reward = %s, want 0.000", got)
+	}
+	if got := displayValue(result.Reward.Candidate); got != "0.750" {
+		t.Fatalf("candidate reward = %s, want 0.750", got)
+	}
+}
+
 func TestBuildEvalComparisonRecommendsNoopForSameJob(t *testing.T) {
 	job := compareJob{
 		RelPath:   ".runme/evals/jobs/job",
@@ -133,7 +265,7 @@ func TestBuildEvalComparisonRecommendsNoopForSameJob(t *testing.T) {
 			Stats: promoteJobStats{
 				CompletedTrials: 1,
 				Evals: map[string]promoteEvalStats{
-					"runme-codex__dataset": {Metrics: []map[string]interface{}{{"mean": 1.0}}},
+					"runme-codex__dataset": {Metrics: []map[string]interface{}{{"reward": 1.0}}},
 				},
 			},
 		},
@@ -186,6 +318,160 @@ func TestRenderEvalComparisonTextOmitsEmptyTasks(t *testing.T) {
 	}
 }
 
+func TestRenderEvalComparisonTextShowsOverlappingResultsFirst(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 2,
+			Stats: promoteJobStats{
+				CompletedTrials: 2,
+				Evals: map[string]promoteEvalStats{
+					"base-only": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.1}}},
+					"shared":    {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.5}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 2,
+			Stats: promoteJobStats{
+				CompletedTrials: 2,
+				Evals: map[string]promoteEvalStats{
+					"candidate-only": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.9}}},
+					"shared":         {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.75}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	var stdout bytes.Buffer
+	if err := renderEvalComparisonText(&stdout, comparison); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	sharedIndex := strings.Index(output, "shared: reward 0.500 -> 0.750  +0.250")
+	baseOnlyIndex := strings.Index(output, "base only: base-only")
+	latestOnlyIndex := strings.Index(output, "latest only: candidate-only")
+	if sharedIndex < 0 || baseOnlyIndex < 0 || latestOnlyIndex < 0 {
+		t.Fatalf("output missing expected result rows:\n%s", output)
+	}
+	if !(sharedIndex < baseOnlyIndex && baseOnlyIndex < latestOnlyIndex) {
+		t.Fatalf("expected overlapping results before non-overlap rows:\n%s", output)
+	}
+	if !strings.Contains(output, "Recommendation: candidate improved or held steady") {
+		t.Fatalf("partial overlap alone should not downgrade recommendation:\n%s", output)
+	}
+}
+
+func TestRenderEvalComparisonTextReportsNoOverlappingResults(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"base-only": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.5}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"candidate-only": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.75}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	var stdout bytes.Buffer
+	if err := renderEvalComparisonText(&stdout, comparison); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"no matching eval results",
+		"base only: base-only",
+		"latest only: candidate-only",
+		"Recommendation: no matching eval results; compare job selection before promotion.",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestBuildEvalComparisonRecommendsRegressionForMatchedResultRewardDrop(t *testing.T) {
+	comparison := buildEvalComparison(compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"shared": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.75}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "tracked",
+	}, compareJob{
+		RelPath:   ".runme/evals/jobs/candidate",
+		ResultRel: ".runme/evals/jobs/candidate/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"shared": {Trials: 1, Metrics: []map[string]interface{}{{"reward": 0.5}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "evals/tasks"}},
+			Agents:   []promoteAgentConfig{{Name: "runme-codex"}},
+		},
+		Selection: "local",
+	}, "HEAD")
+
+	if !strings.Contains(comparison.Recommendation, "candidate regressed") {
+		t.Fatalf("recommendation = %q", comparison.Recommendation)
+	}
+}
+
 func TestEvalComparerReadsTrackedBaseFromGit(t *testing.T) {
 	tmp := t.TempDir()
 	repo, err := git.PlainInit(tmp, false)
@@ -200,7 +486,7 @@ func TestEvalComparerReadsTrackedBaseFromGit(t *testing.T) {
 	jobsRoot := filepath.Join(tmp, ".runme", "evals", "jobs")
 	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
 	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
-	writePromoteJobWithMean(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
 	if _, err := wt.Add(".runme/evals/jobs/2026-06-25__09-00-00/result.json"); err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +503,7 @@ func TestEvalComparerReadsTrackedBaseFromGit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	writePromoteJobWithMean(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
 	t.Chdir(tmp)
 
 	var stdout bytes.Buffer
@@ -241,9 +527,9 @@ func TestEvalComparerLatestSkipsOracleOnlyJobsByDefault(t *testing.T) {
 	baseDir := filepath.Join(jobsRoot, "2026-06-25__08-00-00")
 	agentDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
 	oracleDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
-	writePromoteJobWithMean(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
-	writePromoteJobWithMean(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
-	writePromoteJobWithMeanAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithRewardAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
 	t.Chdir(tmp)
 
 	var stdout bytes.Buffer
@@ -268,9 +554,9 @@ func TestEvalComparerLatestCanIncludeOracleOnlyJobs(t *testing.T) {
 	baseDir := filepath.Join(jobsRoot, "2026-06-25__08-00-00")
 	agentDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
 	oracleDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
-	writePromoteJobWithMean(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
-	writePromoteJobWithMean(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
-	writePromoteJobWithMeanAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T08:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, agentDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithRewardAgent(t, oracleDir, "2026-06-25T10:00:00Z", "oracle", 1, 1, 0, 1.0)
 	t.Chdir(tmp)
 
 	var stdout bytes.Buffer
@@ -295,8 +581,8 @@ func TestResolveCompareBaseSkipsIncompleteTrackedJobs(t *testing.T) {
 	jobsRoot := filepath.Join(tmp, "jobs")
 	completeDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
 	incompleteDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
-	writePromoteJobWithMean(t, completeDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
-	writePromoteJobWithMean(t, incompleteDir, "2026-06-25T10:00:00Z", 1, 0, 0, 0.75)
+	writePromoteJobWithReward(t, completeDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, incompleteDir, "2026-06-25T10:00:00Z", 1, 0, 0, 0.75)
 
 	job, err := resolveCompareBase(compareBaseOptions{
 		git: fakeCompareGit{
@@ -359,12 +645,12 @@ func localCompareJob(t *testing.T, root, jobDir, selection string) compareJob {
 	}
 }
 
-func writePromoteJobWithMean(t *testing.T, jobDir, finishedAt string, total, completed, errors int, mean float64) {
+func writePromoteJobWithReward(t *testing.T, jobDir, finishedAt string, total, completed, errors int, reward float64) {
 	t.Helper()
-	writePromoteJobWithMeanAgent(t, jobDir, finishedAt, "runme-codex", total, completed, errors, mean)
+	writePromoteJobWithRewardAgent(t, jobDir, finishedAt, "runme-codex", total, completed, errors, reward)
 }
 
-func writePromoteJobWithMeanAgent(t *testing.T, jobDir, finishedAt, agent string, total, completed, errors int, mean float64) {
+func writePromoteJobWithRewardAgent(t *testing.T, jobDir, finishedAt, agent string, total, completed, errors int, reward float64) {
 	t.Helper()
 	writePromoteJob(t, jobDir, finishedAt)
 	result := fmt.Sprintf(`{
@@ -379,11 +665,11 @@ func writePromoteJobWithMeanAgent(t *testing.T, jobDir, finishedAt, agent string
 				"%s__dataset": {
 					"n_trials": %d,
 					"n_errors": %d,
-					"metrics": [{"mean": %.3f}]
+					"metrics": [{"reward": %.3f}]
 				}
 			}
 		}
-	}`, finishedAt, finishedAt, finishedAt, total, completed, errors, agent, total, errors, mean)
+	}`, finishedAt, finishedAt, finishedAt, total, completed, errors, agent, total, errors, reward)
 	writeFile(t, filepath.Join(jobDir, "result.json"), result)
 	config := `{
 		"datasets": [{"path": "dataset", "task_names": ["task"]}],

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -100,7 +100,7 @@ func (p *EvalPromoter) Run(args []string) error {
 		includeOracle: p.opts.IncludeOracle,
 		allowErrors:   p.opts.AllowErrors,
 	}); warning != "" {
-		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s\n\n", warning, jobsRel)
+		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s; newer eval jobs were skipped\n\n", warning, jobsRel)
 	}
 	resultRel, err := gitClient.Rel(result.Path)
 	if err != nil {

--- a/internal/harbor/eval_promote_job.go
+++ b/internal/harbor/eval_promote_job.go
@@ -207,7 +207,7 @@ func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult p
 	if !foundNewer {
 		return ""
 	}
-	return "no newer complete promotable eval job found"
+	return "using latest complete promotable eval job"
 }
 
 func isPromoteJobNewer(result promoteJobResult, name string, selectedTimestamp time.Time, selectedName string) bool {

--- a/internal/harbor/eval_promote_message.go
+++ b/internal/harbor/eval_promote_message.go
@@ -3,7 +3,6 @@ package harbor
 import (
 	"fmt"
 	"io"
-	"sort"
 	"strings"
 )
 
@@ -45,13 +44,17 @@ func renderPromoteCommitMessageWithLabel(data promoteMessageData, label func(str
 		_, _ = fmt.Fprintf(&b, "%s %s\n", label("Tasks:"), tasks)
 	}
 	_, _ = fmt.Fprintln(&b)
+	if results := data.resultsSummary(); len(results) > 0 {
+		_, _ = fmt.Fprintln(&b, label("Results:"))
+		for _, result := range results {
+			_, _ = fmt.Fprintf(&b, " %s\n", result)
+		}
+	}
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Job:"), data.jobSummary())
+	_, _ = fmt.Fprintln(&b)
 	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Agent:"), data.agentSummary())
 	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Model:"), data.modelSummary())
-	_, _ = fmt.Fprintf(&b, "%s %s\n\n", label("Environment:"), data.environmentSummary())
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Result:"), data.resultSummary())
-	if score := data.scoreSummary(); score != "" {
-		_, _ = fmt.Fprintf(&b, "%s %s\n", label("Score:"), score)
-	}
+	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Environment:"), data.environmentSummary())
 	return b.String()
 }
 
@@ -108,7 +111,7 @@ func (d promoteMessageData) environmentSummary() string {
 	return "unknown"
 }
 
-func (d promoteMessageData) resultSummary() string {
+func (d promoteMessageData) jobSummary() string {
 	stats := d.result.Stats
 	parts := []string{
 		fmt.Sprintf("completed=%d/%d", stats.CompletedTrials, d.result.TotalTrials),
@@ -120,40 +123,17 @@ func (d promoteMessageData) resultSummary() string {
 	return strings.Join(parts, ", ")
 }
 
-func (d promoteMessageData) scoreSummary() string {
-	if score, ok := singlePromoteMean(d.result.Stats); ok {
-		return fmt.Sprintf("mean=%.3f", score)
-	}
-	return ""
-}
-
-func singlePromoteMean(stats promoteJobStats) (float64, bool) {
-	var means []float64
-	keys := make([]string, 0, len(stats.Evals))
-	for key := range stats.Evals {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	for _, key := range keys {
-		for _, metric := range stats.Evals[key].Metrics {
-			if value, ok := promoteMetricNumber(metric["mean"]); ok {
-				means = append(means, value)
-			}
+func (d promoteMessageData) resultsSummary() []string {
+	summaries := summarizeEvalResults(d.result, d.config)
+	values := make([]string, 0, len(summaries))
+	for _, summary := range summaries {
+		reward := "n/a"
+		if summary.RewardStatus == evalRewardStatusAmbiguous {
+			reward = "n/a (ambiguous)"
+		} else if summary.Reward != nil {
+			reward = fmt.Sprintf("%.3f", *summary.Reward)
 		}
+		values = append(values, fmt.Sprintf("%s: reward=%s", summary.Key, reward))
 	}
-	if len(means) != 1 {
-		return 0, false
-	}
-	return means[0], true
-}
-
-func promoteMetricNumber(value interface{}) (float64, bool) {
-	switch typed := value.(type) {
-	case float64:
-		return typed, true
-	case int:
-		return float64(typed), true
-	default:
-		return 0, false
-	}
+	return values
 }

--- a/internal/harbor/eval_promote_message_test.go
+++ b/internal/harbor/eval_promote_message_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestRenderPromoteCommitMessageUsesJobRollup(t *testing.T) {
+func TestRenderPromoteCommitMessageUsesJobAndResultRollups(t *testing.T) {
 	msg := renderPromoteCommitMessage(promoteMessageData{
 		subject:    defaultPromoteSubject,
 		jobPath:    ".runme/evals/jobs/job",
@@ -28,7 +28,7 @@ func TestRenderPromoteCommitMessageUsesJobRollup(t *testing.T) {
 				ErroredTrials:   0,
 				Evals: map[string]promoteEvalStats{
 					"codex__dataset": {
-						Metrics: []map[string]interface{}{{"mean": 0.75}},
+						Metrics: []map[string]interface{}{{"reward": 0.75}},
 					},
 				},
 			},
@@ -44,16 +44,37 @@ func TestRenderPromoteCommitMessageUsesJobRollup(t *testing.T) {
 		"Agent: codex",
 		"Model: gpt-5-codex",
 		"Environment: " + runmeEnvironmentImportPath,
-		"Result: completed=2/2, errors=0, evals=1",
-		"Score: mean=0.750",
+		"Job: completed=2/2, errors=0, evals=1",
+		"Results:",
+		"dataset: reward=0.750",
+		"\nResults:\n dataset: reward=0.750\nJob: completed=2/2, errors=0, evals=1\n\nAgent: codex\n",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("message missing %q:\n%s", want, msg)
 		}
 	}
+	for _, unwanted := range []string{
+		"Result: completed=",
+		"Score:",
+		"mean",
+		"codex__dataset: reward=",
+	} {
+		if strings.Contains(msg, unwanted) {
+			t.Fatalf("message should not contain %q:\n%s", unwanted, msg)
+		}
+	}
+	assertPromoteMessageOrder(t, msg,
+		"Dataset: evals/tasks",
+		"Results:",
+		"dataset: reward=0.750",
+		"Job: completed=2/2, errors=0, evals=1",
+		"Agent: codex",
+		"Model: gpt-5-codex",
+		"Environment: "+runmeEnvironmentImportPath,
+	)
 }
 
-func TestRenderPromoteCommitMessageSeparatesResultFromScore(t *testing.T) {
+func TestRenderPromoteCommitMessageOmitsResultsWithoutEvals(t *testing.T) {
 	msg := renderPromoteCommitMessage(promoteMessageData{
 		subject:    defaultPromoteSubject,
 		jobPath:    ".runme/evals/jobs/job",
@@ -70,15 +91,12 @@ func TestRenderPromoteCommitMessageSeparatesResultFromScore(t *testing.T) {
 			Stats: promoteJobStats{
 				CompletedTrials: 2,
 				ErroredTrials:   0,
-				Evals: map[string]promoteEvalStats{
-					"runme-codex__dataset": {},
-				},
 			},
 		},
 	})
 
 	for _, want := range []string{
-		"Result: completed=2/2, errors=0, evals=1",
+		"Job: completed=2/2, errors=0",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("message missing %q:\n%s", want, msg)
@@ -90,9 +108,12 @@ func TestRenderPromoteCommitMessageSeparatesResultFromScore(t *testing.T) {
 	if strings.Contains(msg, "Score:") {
 		t.Fatalf("message should not contain Score without score metric:\n%s", msg)
 	}
+	if strings.Contains(msg, "Results:") {
+		t.Fatalf("message should not contain Results without eval summaries:\n%s", msg)
+	}
 }
 
-func TestRenderPromoteCommitMessageIgnoresNamedMetricDimensions(t *testing.T) {
+func TestRenderPromoteCommitMessageDefaultsMissingRewardToZero(t *testing.T) {
 	msg := renderPromoteCommitMessage(promoteMessageData{
 		subject:    defaultPromoteSubject,
 		jobPath:    ".runme/evals/jobs/job",
@@ -117,12 +138,35 @@ func TestRenderPromoteCommitMessageIgnoresNamedMetricDimensions(t *testing.T) {
 		},
 	})
 
-	if strings.Contains(msg, "Score:") {
-		t.Fatalf("message should not contain Score for named metric dimensions:\n%s", msg)
+	for _, want := range []string{
+		"Results:",
+		"dataset: reward=0.000",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("message missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "Score:") || strings.Contains(msg, "mean") {
+		t.Fatalf("message should use reward results, not score/mean:\n%s", msg)
 	}
 }
 
-func TestRenderPromoteCommitMessageIgnoresRewardWithoutMean(t *testing.T) {
+func assertPromoteMessageOrder(t *testing.T, msg string, values ...string) {
+	t.Helper()
+	previous := -1
+	for _, value := range values {
+		index := strings.Index(msg, value)
+		if index == -1 {
+			t.Fatalf("message missing %q:\n%s", value, msg)
+		}
+		if index <= previous {
+			t.Fatalf("message has %q out of order:\n%s", value, msg)
+		}
+		previous = index
+	}
+}
+
+func TestRenderPromoteCommitMessageMarksAmbiguousReward(t *testing.T) {
 	msg := renderPromoteCommitMessage(promoteMessageData{
 		subject:    defaultPromoteSubject,
 		jobPath:    ".runme/evals/jobs/job",
@@ -137,14 +181,20 @@ func TestRenderPromoteCommitMessageIgnoresRewardWithoutMean(t *testing.T) {
 				CompletedTrials: 1,
 				Evals: map[string]promoteEvalStats{
 					"runme-codex__dataset": {
-						Metrics: []map[string]interface{}{{"reward": 0.5}},
+						Metrics: []map[string]interface{}{
+							{"reward": 0.5},
+							{"reward": 0.75},
+						},
 					},
 				},
 			},
 		},
 	})
 
-	if strings.Contains(msg, "Score:") {
-		t.Fatalf("message should not contain Score without mean:\n%s", msg)
+	if !strings.Contains(msg, "dataset: reward=n/a (ambiguous)") {
+		t.Fatalf("message should mark ambiguous rewards:\n%s", msg)
+	}
+	if strings.Contains(msg, "Score:") || strings.Contains(msg, "mean") {
+		t.Fatalf("message should use reward results, not score/mean:\n%s", msg)
 	}
 }

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -109,10 +109,10 @@ func TestEvalPromoterWarnsWhenNewerJobsAreNotPromotable(t *testing.T) {
 	if err := promoter.Run(nil); err != nil {
 		t.Fatal(err)
 	}
-	if got := stderr.String(); !strings.Contains(got, "warning: no newer complete promotable eval job found under jobs") {
+	if got := stderr.String(); !strings.Contains(got, "warning: using latest complete promotable eval job under jobs; newer eval jobs were skipped") {
 		t.Fatalf("stderr = %q", got)
 	}
-	if got := stderr.String(); !strings.Contains(got, "warning: no newer complete promotable eval job found under jobs\n\n") {
+	if got := stderr.String(); !strings.Contains(got, "warning: using latest complete promotable eval job under jobs; newer eval jobs were skipped\n\n") {
 		t.Fatalf("stderr missing trailing blank line after warning: %q", got)
 	}
 }
@@ -138,7 +138,7 @@ func TestEvalPromoterDoesNotWarnWhenNewerPromotableJobExists(t *testing.T) {
 	if err := promoter.Run(nil); err != nil {
 		t.Fatal(err)
 	}
-	if got := stderr.String(); strings.Contains(got, "no newer complete promotable eval job") {
+	if got := stderr.String(); strings.Contains(got, "newer eval jobs were skipped") {
 		t.Fatalf("stderr = %q", got)
 	}
 }

--- a/internal/harbor/eval_result_summary.go
+++ b/internal/harbor/eval_result_summary.go
@@ -1,0 +1,164 @@
+package harbor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const evalRewardStatusAmbiguous = "ambiguous"
+
+type evalResultSummary struct {
+	Key          string
+	RawKey       string
+	Stats        promoteEvalStats
+	Reward       *float64
+	RewardStatus string
+}
+
+func summarizeEvalResults(result promoteJobResult, config promoteJobConfig) []evalResultSummary {
+	entries := normalizedEvalResultEntries(result, config)
+	keys := sortedEvalResultEntryKeys(entries)
+	summaries := make([]evalResultSummary, 0, len(keys))
+	for _, key := range keys {
+		entry := entries[key]
+		reward, status := evalReward(entry.stats)
+		summaries = append(summaries, evalResultSummary{
+			Key:          key,
+			RawKey:       entry.key,
+			Stats:        entry.stats,
+			Reward:       reward,
+			RewardStatus: status,
+		})
+	}
+	return summaries
+}
+
+type evalResultEntry struct {
+	key   string
+	stats promoteEvalStats
+}
+
+func normalizedEvalResultEntries(result promoteJobResult, config promoteJobConfig) map[string]evalResultEntry {
+	keys := sortedEvalKeys(result.Stats.Evals)
+	entries := make(map[string]evalResultEntry, len(keys))
+	collisions := make(map[string]struct{})
+	for _, key := range keys {
+		identity := evalResultIdentity(key, config)
+		if _, ok := entries[identity]; ok {
+			collisions[identity] = struct{}{}
+		}
+		entries[identity] = evalResultEntry{
+			key:   key,
+			stats: result.Stats.Evals[key],
+		}
+	}
+	if len(collisions) == 0 {
+		return entries
+	}
+
+	entries = make(map[string]evalResultEntry, len(keys))
+	for _, key := range keys {
+		identity := evalResultIdentity(key, config)
+		if _, ok := collisions[identity]; ok {
+			identity = key
+		}
+		entries[identity] = evalResultEntry{
+			key:   key,
+			stats: result.Stats.Evals[key],
+		}
+	}
+	return entries
+}
+
+func evalResultIdentity(key string, config promoteJobConfig) string {
+	for _, agent := range sortedAgentKeys(config.Agents) {
+		if result, ok := strings.CutPrefix(key, agent+"__"); ok {
+			return result
+		}
+	}
+	return key
+}
+
+func sortedAgentKeys(agents []promoteAgentConfig) []string {
+	keys := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		key := agent.Name
+		if key == "" {
+			key = agent.ImportPath
+		}
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if len(keys[i]) != len(keys[j]) {
+			return len(keys[i]) > len(keys[j])
+		}
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+func sortedEvalResultEntryKeys(entries map[string]evalResultEntry) []string {
+	keys := make([]string, 0, len(entries))
+	for key := range entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedEvalKeys(evals map[string]promoteEvalStats) []string {
+	keys := make([]string, 0, len(evals))
+	for key := range evals {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func evalReward(eval promoteEvalStats) (*float64, string) {
+	var rewards []float64
+	for _, metric := range eval.Metrics {
+		if value, ok := promoteMetricNumber(metric["reward"]); ok {
+			rewards = append(rewards, value)
+		}
+	}
+	switch len(rewards) {
+	case 0:
+		reward := 0.0
+		return &reward, ""
+	case 1:
+		return &rewards[0], ""
+	default:
+		return nil, evalRewardStatusAmbiguous
+	}
+}
+
+func combinedRewardStatus(base, candidate string) string {
+	if base == "" && candidate == "" {
+		return ""
+	}
+	if base == candidate {
+		return base
+	}
+	if base == "" {
+		base = "ok"
+	}
+	if candidate == "" {
+		candidate = "ok"
+	}
+	return fmt.Sprintf("base %s, candidate %s", base, candidate)
+}
+
+func promoteMetricNumber(value interface{}) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case int:
+		return float64(typed), true
+	default:
+		return 0, false
+	}
+}


### PR DESCRIPTION
## Summary

- split `runme eval compare` output into job execution counters and matched eval results
- remove the misleading job-level `mean` rollup from text and JSON output
- compare overlapping `stats.evals` entries by mean, with base-only/latest-only rows reported after matches
- keep partial overlap informational instead of treating it as a regression

## Testing

- `go test ./internal/harbor -run EvalCompare`
- `go test ./cmd -run EvalCompare`
- `runme run test`
