### PR TITLE
feat: gate eval promote with compare

### DIFF
--- a/cmd/eval_promote.go
+++ b/cmd/eval_promote.go
@@ -28,6 +28,7 @@ type evalPromoteOptions struct {
 	artifacts     bool
 	includeOracle bool
 	allowErrors   bool
+	promoteAnyway bool
 	message       string
 	stdout        io.Writer
 	stderr        io.Writer
@@ -59,6 +60,7 @@ func evalPromoteCmd() *cobra.Command {
 	flags.BoolVar(&opts.artifacts, "artifacts", false, "Include full eval artifacts such as logs and trial outputs; may contain sensitive information")
 	flags.BoolVar(&opts.includeOracle, "include-oracle", false, "Allow promoting eval jobs that only used Harbor's oracle agent")
 	flags.BoolVar(&opts.allowErrors, "allow-errors", false, "Allow promoting eval jobs with errored trials")
+	flags.BoolVar(&opts.promoteAnyway, "promote-anyway", false, "Promote even when eval comparison blocks promotion")
 	flags.StringVar(&opts.message, "message", "", "Commit subject line; eval evidence is added to the commit body")
 
 	return cmd
@@ -74,6 +76,7 @@ func runEvalPromote(opts evalPromoteOptions, args []string) error {
 		Artifacts:     opts.artifacts,
 		IncludeOracle: opts.includeOracle,
 		AllowErrors:   opts.allowErrors,
+		PromoteAnyway: opts.promoteAnyway,
 		Message:       opts.message,
 		Stdout:        opts.stdout,
 		Stderr:        opts.stderr,

--- a/cmd/eval_promote_test.go
+++ b/cmd/eval_promote_test.go
@@ -33,6 +33,7 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		"--artifacts",
 		"--include-oracle",
 		"--allow-errors",
+		"--promote-anyway",
 		"--message", "Custom subject",
 	})
 	restoreEvalPromoter(t, func(opts harbor.EvalPromoteOptions) evalPromoter {
@@ -57,6 +58,7 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		!gotOpts.Artifacts ||
 		!gotOpts.IncludeOracle ||
 		!gotOpts.AllowErrors ||
+		!gotOpts.PromoteAnyway ||
 		gotOpts.Latest ||
 		gotOpts.Message != "Custom subject" ||
 		gotOpts.Stdout != &stdout ||

--- a/internal/harbor/eval_compare.go
+++ b/internal/harbor/eval_compare.go
@@ -81,7 +81,7 @@ func (c *EvalComparer) Run(args []string) error {
 
 	comparison := buildEvalComparison(base, candidate, c.opts.Base)
 	if c.opts.Format == "json" {
-		return renderEvalComparisonJSON(c.opts.Stdout, comparison)
+		return comparison.RenderJSON(c.opts.Stdout)
 	}
-	return renderEvalComparisonText(c.opts.Stdout, comparison)
+	return comparison.RenderText(c.opts.Stdout)
 }

--- a/internal/harbor/eval_compare_git.go
+++ b/internal/harbor/eval_compare_git.go
@@ -13,7 +13,7 @@ import (
 
 type compareGit interface {
 	Rel(string) (string, error)
-	TrackedEvalJobs(string, string) ([]compareJob, error)
+	TrackedEvalJobs(string, string) ([]evalJobRef, error)
 }
 
 type goGitCompareClient struct {
@@ -48,12 +48,36 @@ func (c *goGitCompareClient) Rel(path string) (string, error) {
 	return filepath.ToSlash(rel), nil
 }
 
-func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]compareJob, error) {
-	jobsRootRel, err := c.Rel(jobsRoot)
+func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]evalJobRef, error) {
+	return trackedEvalJobReader{
+		rel:  c.Rel,
+		tree: c.tree,
+	}.Jobs(baseRef, jobsRoot)
+}
+
+func (c *goGitCompareClient) tree(ref string) (*object.Tree, error) {
+	hash, err := c.repo.ResolveRevision(plumbing.Revision(ref))
 	if err != nil {
 		return nil, err
 	}
-	tree, err := c.tree(baseRef)
+	commit, err := c.repo.CommitObject(*hash)
+	if err != nil {
+		return nil, err
+	}
+	return commit.Tree()
+}
+
+type trackedEvalJobReader struct {
+	rel  func(string) (string, error)
+	tree func(string) (*object.Tree, error)
+}
+
+func (r trackedEvalJobReader) Jobs(baseRef, jobsRoot string) ([]evalJobRef, error) {
+	jobsRootRel, err := r.rel(jobsRoot)
+	if err != nil {
+		return nil, err
+	}
+	tree, err := r.tree(baseRef)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +86,7 @@ func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]compar
 	files := tree.Files()
 	defer files.Close()
 
-	var jobs []compareJob
+	var jobs []evalJobRef
 	err = files.ForEach(func(file *object.File) error {
 		if !strings.HasPrefix(file.Name, prefix) {
 			return nil
@@ -95,7 +119,7 @@ func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]compar
 			}
 		}
 
-		jobs = append(jobs, compareJob{
+		jobs = append(jobs, evalJobRef{
 			RelPath:   jobRel,
 			ResultRel: file.Name,
 			Result:    result,
@@ -111,19 +135,7 @@ func (c *goGitCompareClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]compar
 	return jobs, nil
 }
 
-func (c *goGitCompareClient) tree(ref string) (*object.Tree, error) {
-	hash, err := c.repo.ResolveRevision(plumbing.Revision(ref))
-	if err != nil {
-		return nil, err
-	}
-	commit, err := c.repo.CommitObject(*hash)
-	if err != nil {
-		return nil, err
-	}
-	return commit.Tree()
-}
-
-func sortCompareJobs(jobs []compareJob) {
+func sortCompareJobs(jobs []evalJobRef) {
 	sort.Slice(jobs, func(i, j int) bool {
 		left, right := jobs[i], jobs[j]
 		leftTime, rightTime := resultTimestamp(left.Result), resultTimestamp(right.Result)

--- a/internal/harbor/eval_compare_job.go
+++ b/internal/harbor/eval_compare_job.go
@@ -6,12 +6,48 @@ import (
 	"path/filepath"
 )
 
-type compareJob struct {
+type evalJobRef struct {
 	RelPath   string
 	ResultRel string
 	Result    promoteJobResult
 	Config    promoteJobConfig
 	Selection string
+}
+
+type compareJob = evalJobRef
+
+func (j evalJobRef) MessageData(subject string, evidenceOnly bool) promoteMessageData {
+	return promoteMessageData{
+		subject:      subject,
+		jobPath:      j.RelPath,
+		resultPath:   j.ResultRel,
+		evidenceOnly: evidenceOnly,
+		config:       j.Config,
+		result:       j.Result,
+	}
+}
+
+func (j evalJobRef) ResultSummaries() []evalResultSummary {
+	return summarizeEvalResults(j.Result, j.Config)
+}
+
+func (j evalJobRef) ResultSummaryMap() map[string]evalResultSummary {
+	summaries := j.ResultSummaries()
+	entries := make(map[string]evalResultSummary, len(summaries))
+	for _, summary := range summaries {
+		entries[summary.Key] = summary
+	}
+	return entries
+}
+
+func (j evalJobRef) ComparisonJob(baseRef string) evalComparisonJob {
+	return evalComparisonJob{
+		Path:      j.RelPath,
+		Result:    j.ResultRel,
+		Ref:       baseRef,
+		Selection: j.Selection,
+		Timestamp: formatCompareTimestamp(resultTimestamp(j.Result)),
+	}
 }
 
 type compareBaseOptions struct {
@@ -28,71 +64,100 @@ type compareCandidateOptions struct {
 	git           compareGit
 }
 
-func resolveCompareBase(opts compareBaseOptions) (compareJob, error) {
-	jobs, err := opts.git.TrackedEvalJobs(opts.baseRef, opts.jobsRoot)
+type evalJobStore struct {
+	jobsDir string
+	git     compareGit
+	policy  promoteJobPolicy
+}
+
+func (s evalJobStore) LatestTracked(baseRef string) (evalJobRef, error) {
+	jobs, err := s.git.TrackedEvalJobs(baseRef, s.jobsDir)
 	if err != nil {
-		return compareJob{}, err
+		return evalJobRef{}, err
 	}
 	for _, job := range jobs {
 		if incompletePromoteJobReason(job.Result) == "" {
 			return job, nil
 		}
 	}
-	return compareJob{}, fmt.Errorf("no complete Git-tracked eval job found under %s at %s", opts.jobsRoot, opts.baseRef)
+	return evalJobRef{}, fmt.Errorf("no complete Git-tracked eval job found under %s at %s", s.jobsDir, baseRef)
 }
 
-func resolveCompareCandidate(opts compareCandidateOptions) (compareJob, error) {
-	var jobDir, selection string
-	var err error
-	policy := promoteJobPolicy{
-		includeOracle: opts.includeOracle,
-		allowErrors:   opts.allowErrors,
+func (s evalJobStore) LatestLocal() (evalJobRef, string, error) {
+	jobDir, selection, err := latestPromoteJob(s.jobsDir, s.policy)
+	if err != nil {
+		return evalJobRef{}, "", err
 	}
-	if opts.job == "" {
-		jobDir, selection, err = latestPromoteJob(opts.jobsDir, policy)
-		if err != nil {
-			return compareJob{}, err
-		}
-	} else {
-		invocationCwd, err := os.Getwd()
-		if err != nil {
-			return compareJob{}, err
-		}
-		jobDir = opts.job
-		if !filepath.IsAbs(jobDir) {
-			jobDir = filepath.Join(invocationCwd, jobDir)
-		}
-		jobDir = cleanExistingPath(jobDir)
-		if err := validatePromoteJobDir(opts.jobsDir, jobDir); err != nil {
-			return compareJob{}, err
-		}
-		selection = "explicit --job"
-	}
+	job, err := s.localJob(jobDir, selection)
+	return job, jobDir, err
+}
 
+func (s evalJobStore) ExplicitLocal(jobDir string) (evalJobRef, string, error) {
+	invocationCwd, err := os.Getwd()
+	if err != nil {
+		return evalJobRef{}, "", err
+	}
+	if !filepath.IsAbs(jobDir) {
+		jobDir = filepath.Join(invocationCwd, jobDir)
+	}
+	jobDir = cleanExistingPath(jobDir)
+	if err := validatePromoteJobDir(s.jobsDir, jobDir); err != nil {
+		return evalJobRef{}, "", err
+	}
+	job, err := s.localJob(jobDir, "explicit --job")
+	return job, jobDir, err
+}
+
+func (s evalJobStore) localJob(jobDir, selection string) (evalJobRef, error) {
 	result, err := readPromoteJobResult(jobDir)
 	if err != nil {
-		return compareJob{}, err
+		return evalJobRef{}, err
 	}
 	config, err := readPromoteJobConfig(jobDir)
 	if err != nil {
-		return compareJob{}, err
+		return evalJobRef{}, err
 	}
-	if err := validatePromoteJobPolicy(result, config, policy); err != nil {
-		return compareJob{}, err
+	if err := validatePromoteJobPolicy(result, config, s.policy); err != nil {
+		return evalJobRef{}, err
 	}
-	jobRel, err := opts.git.Rel(jobDir)
+	jobRel, err := s.git.Rel(jobDir)
 	if err != nil {
-		return compareJob{}, err
+		return evalJobRef{}, err
 	}
-	resultRel, err := opts.git.Rel(result.Path)
+	resultRel, err := s.git.Rel(result.Path)
 	if err != nil {
-		return compareJob{}, err
+		return evalJobRef{}, err
 	}
-	return compareJob{
+	return evalJobRef{
 		RelPath:   jobRel,
 		ResultRel: resultRel,
 		Result:    result,
 		Config:    config,
 		Selection: selection,
 	}, nil
+}
+
+func resolveCompareBase(opts compareBaseOptions) (compareJob, error) {
+	return evalJobStore{
+		jobsDir: opts.jobsRoot,
+		git:     opts.git,
+	}.LatestTracked(opts.baseRef)
+}
+
+func resolveCompareCandidate(opts compareCandidateOptions) (compareJob, error) {
+	policy := promoteJobPolicy{
+		includeOracle: opts.includeOracle,
+		allowErrors:   opts.allowErrors,
+	}
+	store := evalJobStore{
+		jobsDir: opts.jobsDir,
+		git:     opts.git,
+		policy:  policy,
+	}
+	if opts.job == "" {
+		job, _, err := store.LatestLocal()
+		return job, err
+	}
+	job, _, err := store.ExplicitLocal(opts.job)
+	return job, err
 }

--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -71,9 +71,70 @@ type evalComparisonDiff struct {
 	Delta     interface{} `json:"delta,omitempty"`
 }
 
+type promoteCompareGateReason string
+
+const (
+	promoteCompareGateReasonRegressed promoteCompareGateReason = "regressed"
+	promoteCompareGateReasonNoResults promoteCompareGateReason = "no_results"
+	promoteCompareGateReasonMetadata  promoteCompareGateReason = "metadata"
+	promoteCompareGateReasonSummary   promoteCompareGateReason = "summary"
+)
+
+type promoteCompareGateReasonText struct {
+	blockMessage   string
+	recommendation string
+}
+
 type promoteCompareGate struct {
-	Blocking bool
-	Reason   string
+	Blocking   bool
+	Reason     string
+	ReasonCode promoteCompareGateReason
+}
+
+func newPromoteCompareGate(reason promoteCompareGateReason) promoteCompareGate {
+	return promoteCompareGate{
+		Blocking:   true,
+		ReasonCode: reason,
+		Reason:     reason.blockMessage(),
+	}
+}
+
+func (r promoteCompareGateReason) text() promoteCompareGateReasonText {
+	switch r {
+	case promoteCompareGateReasonRegressed:
+		return promoteCompareGateReasonText{
+			blockMessage:   "candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway",
+			recommendation: "candidate regressed; rerun or inspect job/task details before promotion.",
+		}
+	case promoteCompareGateReasonNoResults:
+		return promoteCompareGateReasonText{
+			blockMessage:   "no matching eval results; compare job selection or pass --promote-anyway to promote anyway",
+			recommendation: "no matching eval results; compare job selection before promotion.",
+		}
+	case promoteCompareGateReasonMetadata:
+		return promoteCompareGateReasonText{
+			blockMessage:   "metadata differs; review mismatches or pass --promote-anyway to promote anyway",
+			recommendation: "metadata differs; review mismatches before promotion.",
+		}
+	case promoteCompareGateReasonSummary:
+		return promoteCompareGateReasonText{
+			blockMessage:   "summary changed; inspect job/task details or pass --promote-anyway to promote anyway",
+			recommendation: "summary changed; inspect job/task details before promotion.",
+		}
+	default:
+		return promoteCompareGateReasonText{}
+	}
+}
+
+func (r promoteCompareGateReason) blockMessage() string {
+	return r.text().blockMessage
+}
+
+func (r promoteCompareGateReason) recommendation() string {
+	if recommendation := r.text().recommendation; recommendation != "" {
+		return recommendation
+	}
+	return "candidate improved or held steady; promotion looks reasonable after normal review."
 }
 
 func newEvalComparison(base, candidate evalJobRef, baseRef string) evalComparison {
@@ -121,22 +182,22 @@ func (c evalComparison) Gate() promoteCompareGate {
 	}
 	job := c.Job
 	if intDelta(job.Errors) > 0 || intDelta(job.Completed) < 0 {
-		return promoteCompareGate{Blocking: true, Reason: "candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway"}
+		return newPromoteCompareGate(promoteCompareGateReasonRegressed)
 	}
 	if len(c.Results.Comparisons) == 0 {
-		return promoteCompareGate{Blocking: true, Reason: "no matching eval results; compare job selection or pass --promote-anyway to promote anyway"}
+		return newPromoteCompareGate(promoteCompareGateReasonNoResults)
 	}
 	if len(c.MetadataDiffs) > 0 {
-		return promoteCompareGate{Blocking: true, Reason: "metadata differs; review mismatches or pass --promote-anyway to promote anyway"}
+		return newPromoteCompareGate(promoteCompareGateReasonMetadata)
 	}
 	for _, result := range c.Results.Comparisons {
 		if floatDelta(result.Reward) < 0 {
-			return promoteCompareGate{Blocking: true, Reason: "candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway"}
+			return newPromoteCompareGate(promoteCompareGateReasonRegressed)
 		}
 	}
 	for _, result := range c.Results.Comparisons {
 		if result.RewardStatus != "" {
-			return promoteCompareGate{Blocking: true, Reason: "summary changed; inspect job/task details or pass --promote-anyway to promote anyway"}
+			return newPromoteCompareGate(promoteCompareGateReasonSummary)
 		}
 	}
 	return promoteCompareGate{}
@@ -150,16 +211,7 @@ func (c evalComparison) recommendation() string {
 		}
 		return "candidate improved or held steady; promotion looks reasonable after normal review."
 	}
-	switch {
-	case strings.HasPrefix(gate.Reason, "candidate regressed"):
-		return "candidate regressed; rerun or inspect job/task details before promotion."
-	case strings.HasPrefix(gate.Reason, "no matching eval results"):
-		return "no matching eval results; compare job selection before promotion."
-	case strings.HasPrefix(gate.Reason, "metadata differs"):
-		return "metadata differs; review mismatches before promotion."
-	default:
-		return "summary changed; inspect job/task details before promotion."
-	}
+	return gate.ReasonCode.recommendation()
 }
 
 func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {

--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -7,6 +7,13 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/runmedev/runme/v3/internal/ansi"
+)
+
+const (
+	evalResultImprovedStyle  = "green"
+	evalResultRegressedStyle = "red"
 )
 
 type evalComparison struct {
@@ -64,9 +71,14 @@ type evalComparisonDiff struct {
 	Delta     interface{} `json:"delta,omitempty"`
 }
 
-func buildEvalComparison(base, candidate compareJob, baseRef string) evalComparison {
-	baseSummary := promoteMessageData{config: base.Config, result: base.Result}
-	candidateSummary := promoteMessageData{config: candidate.Config, result: candidate.Result}
+type promoteCompareGate struct {
+	Blocking bool
+	Reason   string
+}
+
+func newEvalComparison(base, candidate evalJobRef, baseRef string) evalComparison {
+	baseSummary := base.MessageData("", false)
+	candidateSummary := candidate.MessageData("", false)
 
 	metadata := evalComparisonMeta{
 		Dataset:     stringDiff(baseSummary.datasetSummary(), candidateSummary.datasetSummary()),
@@ -80,26 +92,74 @@ func buildEvalComparison(base, candidate compareJob, baseRef string) evalCompari
 	mismatches := metadataMismatches(metadata)
 
 	comparison := evalComparison{
-		Base: evalComparisonJob{
-			Path:      base.RelPath,
-			Result:    base.ResultRel,
-			Ref:       baseRef,
-			Selection: base.Selection,
-			Timestamp: formatCompareTimestamp(resultTimestamp(base.Result)),
-		},
-		Candidate: evalComparisonJob{
-			Path:      candidate.RelPath,
-			Result:    candidate.ResultRel,
-			Selection: candidate.Selection,
-			Timestamp: formatCompareTimestamp(resultTimestamp(candidate.Result)),
-		},
+		Base:          base.ComparisonJob(baseRef),
+		Candidate:     candidate.ComparisonJob(""),
 		Metadata:      metadata,
 		MetadataDiffs: mismatches,
 		Job:           job,
 		Results:       results,
 	}
-	comparison.Recommendation = compareRecommendation(comparison)
+	comparison.Recommendation = comparison.recommendation()
 	return comparison
+}
+
+func buildEvalComparison(base, candidate compareJob, baseRef string) evalComparison {
+	return newEvalComparison(base, candidate, baseRef)
+}
+
+func (c evalComparison) RenderText(w io.Writer) error {
+	return renderEvalComparisonText(w, c)
+}
+
+func (c evalComparison) RenderJSON(w io.Writer) error {
+	return renderEvalComparisonJSON(w, c)
+}
+
+func (c evalComparison) Gate() promoteCompareGate {
+	if sameComparisonJob(c.Base, c.Candidate) {
+		return promoteCompareGate{}
+	}
+	job := c.Job
+	if intDelta(job.Errors) > 0 || intDelta(job.Completed) < 0 {
+		return promoteCompareGate{Blocking: true, Reason: "candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway"}
+	}
+	if len(c.Results.Comparisons) == 0 {
+		return promoteCompareGate{Blocking: true, Reason: "no matching eval results; compare job selection or pass --promote-anyway to promote anyway"}
+	}
+	if len(c.MetadataDiffs) > 0 {
+		return promoteCompareGate{Blocking: true, Reason: "metadata differs; review mismatches or pass --promote-anyway to promote anyway"}
+	}
+	for _, result := range c.Results.Comparisons {
+		if floatDelta(result.Reward) < 0 {
+			return promoteCompareGate{Blocking: true, Reason: "candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway"}
+		}
+	}
+	for _, result := range c.Results.Comparisons {
+		if result.RewardStatus != "" {
+			return promoteCompareGate{Blocking: true, Reason: "summary changed; inspect job/task details or pass --promote-anyway to promote anyway"}
+		}
+	}
+	return promoteCompareGate{}
+}
+
+func (c evalComparison) recommendation() string {
+	gate := c.Gate()
+	if !gate.Blocking {
+		if sameComparisonJob(c.Base, c.Candidate) {
+			return "base and latest are the same eval job; nothing to compare."
+		}
+		return "candidate improved or held steady; promotion looks reasonable after normal review."
+	}
+	switch {
+	case strings.HasPrefix(gate.Reason, "candidate regressed"):
+		return "candidate regressed; rerun or inspect job/task details before promotion."
+	case strings.HasPrefix(gate.Reason, "no matching eval results"):
+		return "no matching eval results; compare job selection before promotion."
+	case strings.HasPrefix(gate.Reason, "metadata differs"):
+		return "metadata differs; review mismatches before promotion."
+	default:
+		return "summary changed; inspect job/task details before promotion."
+	}
 }
 
 func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
@@ -128,18 +188,7 @@ func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
 	_, _ = fmt.Fprintf(w, "  %s     %v -> %v  %s\n\n", evalOutputLabel(w, "evals:"), comparison.Job.Evals.Base, comparison.Job.Evals.Candidate, signedDelta(comparison.Job.Evals.Delta))
 
 	_, _ = fmt.Fprintln(w, evalOutputLabel(w, "Results:"))
-	if len(comparison.Results.Comparisons) == 0 {
-		_, _ = fmt.Fprintln(w, "  no matching eval results")
-	}
-	for _, result := range comparison.Results.Comparisons {
-		_, _ = fmt.Fprintf(w, "  %s reward %s -> %s  %s\n", evalOutputLabel(w, result.Key+":"), displayValue(result.Reward.Base), displayValue(result.Reward.Candidate), signedDelta(result.Reward.Delta))
-	}
-	if len(comparison.Results.BaseOnly) > 0 {
-		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "base only:"), strings.Join(comparison.Results.BaseOnly, ", "))
-	}
-	if len(comparison.Results.CandidateOnly) > 0 {
-		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "latest only:"), strings.Join(comparison.Results.CandidateOnly, ", "))
-	}
+	comparison.Results.RenderText(w)
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Recommendation:"), comparison.Recommendation)
 	return nil
@@ -176,9 +225,47 @@ func compareJobStats(base, candidate promoteJobResult) evalComparisonStats {
 	}
 }
 
-func compareResults(base, candidate compareJob) evalComparisonResults {
-	baseEntries := evalResultSummaryMap(base.Result, base.Config)
-	candidateEntries := evalResultSummaryMap(candidate.Result, candidate.Config)
+func (r evalComparisonResults) RenderText(w io.Writer) {
+	if len(r.Comparisons) == 0 {
+		_, _ = fmt.Fprintln(w, "  no matching eval results")
+	}
+	for _, result := range r.Comparisons {
+		_, _ = fmt.Fprintf(w, "  %s\n", result.RenderText(w))
+	}
+	if len(r.BaseOnly) > 0 {
+		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "base only:"), strings.Join(r.BaseOnly, ", "))
+	}
+	if len(r.CandidateOnly) > 0 {
+		_, _ = fmt.Fprintf(w, "  %s %s\n", evalOutputLabel(w, "latest only:"), strings.Join(r.CandidateOnly, ", "))
+	}
+}
+
+func (r evalComparisonResult) RenderText(w io.Writer) string {
+	line := fmt.Sprintf("%s: reward %s -> %s  %s", r.Key, displayValue(r.Reward.Base), displayValue(r.Reward.Candidate), signedDelta(r.Reward.Delta))
+	if style := r.rewardDeltaStyle(); style != "" {
+		return ansi.ColorForWriter(w, line, style)
+	}
+	return line
+}
+
+func (r evalComparisonResult) rewardDeltaStyle() string {
+	delta, ok := r.Reward.Delta.(float64)
+	if !ok {
+		return ""
+	}
+	switch {
+	case delta < 0:
+		return evalResultRegressedStyle
+	case delta > 0:
+		return evalResultImprovedStyle
+	default:
+		return ""
+	}
+}
+
+func compareResults(base, candidate evalJobRef) evalComparisonResults {
+	baseEntries := base.ResultSummaryMap()
+	candidateEntries := candidate.ResultSummaryMap()
 	baseKeys := sortedEvalResultSummaryKeys(baseEntries)
 	candidateKeys := sortedEvalResultSummaryKeys(candidateEntries)
 	candidateSet := make(map[string]struct{}, len(candidateKeys))
@@ -216,15 +303,6 @@ func compareResults(base, candidate compareJob) evalComparisonResults {
 	return results
 }
 
-func evalResultSummaryMap(result promoteJobResult, config promoteJobConfig) map[string]evalResultSummary {
-	summaries := summarizeEvalResults(result, config)
-	entries := make(map[string]evalResultSummary, len(summaries))
-	for _, summary := range summaries {
-		entries[summary.Key] = summary
-	}
-	return entries
-}
-
 func sortedEvalResultSummaryKeys(entries map[string]evalResultSummary) []string {
 	keys := make([]string, 0, len(entries))
 	for key := range entries {
@@ -253,33 +331,6 @@ func metadataMismatches(meta evalComparisonMeta) []evalComparisonDiff {
 		}
 	}
 	return mismatches
-}
-
-func compareRecommendation(comparison evalComparison) string {
-	if sameComparisonJob(comparison.Base, comparison.Candidate) {
-		return "base and latest are the same eval job; nothing to compare."
-	}
-	job := comparison.Job
-	if intDelta(job.Errors) > 0 || intDelta(job.Completed) < 0 {
-		return "candidate regressed; rerun or inspect job/task details before promotion."
-	}
-	if len(comparison.Results.Comparisons) == 0 {
-		return "no matching eval results; compare job selection before promotion."
-	}
-	if len(comparison.MetadataDiffs) > 0 {
-		return "metadata differs; review mismatches before promotion."
-	}
-	for _, result := range comparison.Results.Comparisons {
-		if floatDelta(result.Reward) < 0 {
-			return "candidate regressed; rerun or inspect job/task details before promotion."
-		}
-	}
-	for _, result := range comparison.Results.Comparisons {
-		if result.RewardStatus != "" {
-			return "summary changed; inspect job/task details before promotion."
-		}
-	}
-	return "candidate improved or held steady; promotion looks reasonable after normal review."
 }
 
 func sameComparisonJob(base, candidate evalComparisonJob) bool {

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -133,6 +133,9 @@ func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
 	if !strings.Contains(comparison.Recommendation, "metadata differs") {
 		t.Fatalf("recommendation = %q", comparison.Recommendation)
 	}
+	if gate := comparison.Gate(); gate.ReasonCode != promoteCompareGateReasonMetadata {
+		t.Fatalf("gate reason code = %q, want %q", gate.ReasonCode, promoteCompareGateReasonMetadata)
+	}
 }
 
 func TestBuildEvalComparisonMatchesResultsAcrossDifferentAgents(t *testing.T) {
@@ -428,6 +431,9 @@ func TestRenderEvalComparisonTextReportsNoOverlappingResults(t *testing.T) {
 			t.Fatalf("output missing %q:\n%s", want, output)
 		}
 	}
+	if gate := comparison.Gate(); gate.ReasonCode != promoteCompareGateReasonNoResults {
+		t.Fatalf("gate reason code = %q, want %q", gate.ReasonCode, promoteCompareGateReasonNoResults)
+	}
 }
 
 func TestBuildEvalComparisonRecommendsRegressionForMatchedResultRewardDrop(t *testing.T) {
@@ -469,6 +475,9 @@ func TestBuildEvalComparisonRecommendsRegressionForMatchedResultRewardDrop(t *te
 
 	if !strings.Contains(comparison.Recommendation, "candidate regressed") {
 		t.Fatalf("recommendation = %q", comparison.Recommendation)
+	}
+	if gate := comparison.Gate(); gate.ReasonCode != promoteCompareGateReasonRegressed {
+		t.Fatalf("gate reason code = %q, want %q", gate.ReasonCode, promoteCompareGateReasonRegressed)
 	}
 }
 

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -472,6 +472,28 @@ func TestBuildEvalComparisonRecommendsRegressionForMatchedResultRewardDrop(t *te
 	}
 }
 
+func TestEvalComparisonResultRewardDeltaStyle(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		delta interface{}
+		want  string
+	}{
+		{name: "regressed", delta: -0.25, want: evalResultRegressedStyle},
+		{name: "improved", delta: 0.25, want: evalResultImprovedStyle},
+		{name: "unchanged", delta: 0.0, want: ""},
+		{name: "missing", delta: nil, want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result := evalComparisonResult{
+				Reward: evalComparisonDiff{Delta: tc.delta},
+			}
+			if got := result.rewardDeltaStyle(); got != tc.want {
+				t.Fatalf("style = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEvalComparerReadsTrackedBaseFromGit(t *testing.T) {
 	tmp := t.TempDir()
 	repo, err := git.PlainInit(tmp, false)

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 const defaultPromoteSubject = "Promote changes verified by task eval"
@@ -17,6 +18,7 @@ type EvalPromoteOptions struct {
 	Artifacts     bool
 	IncludeOracle bool
 	AllowErrors   bool
+	PromoteAnyway bool
 	Message       string
 	Stdout        io.Writer
 	Stderr        io.Writer
@@ -51,31 +53,11 @@ func (p *EvalPromoter) Run(args []string) error {
 		return fmt.Errorf("--job cannot be used together with --latest")
 	}
 
-	jobsRoot, jobDir, selection, err := resolvePromoteJob(promoteJobOptions{
-		jobsDir:       p.opts.JobsDir,
-		job:           p.opts.Job,
-		latest:        p.opts.Latest,
-		includeOracle: p.opts.IncludeOracle,
-		allowErrors:   p.opts.AllowErrors,
-	})
+	paths, err := resolveEvalViewPaths(p.opts.JobsDir)
 	if err != nil {
 		return err
 	}
-
-	result, err := readPromoteJobResult(jobDir)
-	if err != nil {
-		return err
-	}
-	config, err := readPromoteJobConfig(jobDir)
-	if err != nil {
-		return err
-	}
-	if err := validatePromoteJobPolicy(result, config, promoteJobPolicy{
-		includeOracle: p.opts.IncludeOracle,
-		allowErrors:   p.opts.AllowErrors,
-	}); err != nil {
-		return err
-	}
+	jobsRoot := paths.jobsDir
 
 	gitClient := p.opts.Git
 	if gitClient == nil {
@@ -85,43 +67,51 @@ func (p *EvalPromoter) Run(args []string) error {
 		}
 	}
 
-	jobRel, err := gitClient.Rel(jobDir)
+	policy := promoteJobPolicy{
+		includeOracle: p.opts.IncludeOracle,
+		allowErrors:   p.opts.AllowErrors,
+	}
+	store := evalJobStore{
+		jobsDir: jobsRoot,
+		git:     gitClient,
+		policy:  policy,
+	}
+
+	var candidate evalJobRef
+	var jobDir string
+	if p.opts.Latest {
+		candidate, jobDir, err = store.LatestLocal()
+	} else {
+		candidate, jobDir, err = store.ExplicitLocal(p.opts.Job)
+	}
 	if err != nil {
 		return err
 	}
+
 	jobsRel, err := gitClient.Rel(jobsRoot)
 	if err != nil {
 		return err
 	}
 	if p.opts.Latest {
-		selection = fmt.Sprintf("latest job under %s", jobsRel)
+		candidate.Selection = fmt.Sprintf("latest job under %s", jobsRel)
 	}
-	if warning := newerPromotableJobWarning(jobsRoot, jobDir, result, promoteJobPolicy{
-		includeOracle: p.opts.IncludeOracle,
-		allowErrors:   p.opts.AllowErrors,
-	}); warning != "" {
+	if warning := newerPromotableJobWarning(jobsRoot, jobDir, candidate.Result, policy); warning != "" {
 		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s; newer eval jobs were skipped\n\n", warning, jobsRel)
 	}
-	resultRel, err := gitClient.Rel(result.Path)
+	message := renderPromoteCommitMessage(candidate.MessageData(p.opts.Message, p.opts.EvidenceOnly))
+
+	comparison, hasComparison, err := p.comparison(jobsRoot, candidate, gitClient)
 	if err != nil {
 		return err
 	}
-	message := renderPromoteCommitMessage(promoteMessageData{
-		subject:      p.opts.Message,
-		jobPath:      jobRel,
-		resultPath:   resultRel,
-		evidenceOnly: p.opts.EvidenceOnly,
-		config:       config,
-		result:       result,
-	})
 
 	if p.opts.DryRun {
 		files, err := gitClient.JobFiles(jobDir, p.opts.Artifacts)
 		if err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selected eval job:"), jobRel)
-		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selection:"), selection)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selected eval job:"), candidate.RelPath)
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Selection:"), candidate.Selection)
 		if p.opts.Artifacts {
 			_, _ = fmt.Fprintf(p.opts.Stdout, "%s artifacts\n", evalOutputLabel(p.opts.Stdout, "Evidence mode:"))
 		} else {
@@ -135,14 +125,10 @@ func (p *EvalPromoter) Run(args []string) error {
 			_, _ = fmt.Fprintf(p.opts.Stdout, "%s */workdir/*\n", evalOutputLabel(p.opts.Stdout, "Excluded:"))
 		}
 		_, _ = fmt.Fprintln(p.opts.Stdout)
-		_, _ = fmt.Fprint(p.opts.Stdout, renderPromoteCommitMessageForWriter(p.opts.Stdout, promoteMessageData{
-			subject:      p.opts.Message,
-			jobPath:      jobRel,
-			resultPath:   resultRel,
-			evidenceOnly: p.opts.EvidenceOnly,
-			config:       config,
-			result:       result,
-		}))
+		p.renderDryRunComparison(comparison, hasComparison)
+		_, _ = fmt.Fprintln(p.opts.Stdout, evalOutputLabel(p.opts.Stdout, "Proposed commit message:"))
+		_, _ = fmt.Fprintln(p.opts.Stdout)
+		_, _ = fmt.Fprint(p.opts.Stdout, renderPromoteCommitMessage(candidate.MessageData(p.opts.Message, p.opts.EvidenceOnly)))
 		return nil
 	}
 
@@ -164,13 +150,19 @@ func (p *EvalPromoter) Run(args []string) error {
 			return fmt.Errorf("unstaged changes touch staged files: %s", joinDisplay(conflicts))
 		}
 	}
+	if hasComparison {
+		gate := comparison.Gate()
+		if gate.Blocking && !p.opts.PromoteAnyway {
+			return fmt.Errorf("promotion blocked by eval comparison: %s", gate.Reason)
+		}
+	}
 
 	if len(staged) > 0 {
 		latestStagedMod, err := gitClient.LatestModTime(staged)
 		if err != nil {
 			return err
 		}
-		if warning := stalePromoteWarning(result, latestStagedMod); warning != "" {
+		if warning := stalePromoteWarning(candidate.Result, latestStagedMod); warning != "" {
 			_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s\n", warning)
 		}
 	}
@@ -181,6 +173,40 @@ func (p *EvalPromoter) Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(p.opts.Stdout, "Promoted eval job %s in commit %s\n", jobRel, hash)
+	_, _ = fmt.Fprintf(p.opts.Stdout, "Promoted eval job %s in commit %s\n", candidate.RelPath, hash)
 	return nil
+}
+
+func (p *EvalPromoter) comparison(jobsRoot string, candidate evalJobRef, gitClient compareGit) (evalComparison, bool, error) {
+	base, err := (evalJobStore{
+		jobsDir: jobsRoot,
+		git:     gitClient,
+	}).LatestTracked("HEAD")
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "no complete Git-tracked eval job found") {
+			return evalComparison{}, false, nil
+		}
+		return evalComparison{}, false, err
+	}
+	return newEvalComparison(base, candidate, "HEAD"), true, nil
+}
+
+func (p *EvalPromoter) renderDryRunComparison(comparison evalComparison, ok bool) {
+	if !ok {
+		_, _ = fmt.Fprintln(p.opts.Stdout, evalOutputLabel(p.opts.Stdout, "Comparison:")+" no tracked baseline found")
+		_, _ = fmt.Fprintln(p.opts.Stdout)
+		return
+	}
+	_, _ = fmt.Fprintln(p.opts.Stdout, evalOutputLabel(p.opts.Stdout, "Comparison:"))
+	if err := comparison.RenderText(p.opts.Stdout); err != nil {
+		return
+	}
+	gate := comparison.Gate()
+	if gate.Blocking {
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s blocked\n", evalOutputLabel(p.opts.Stdout, "Promotion gate:"))
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s %s\n", evalOutputLabel(p.opts.Stdout, "Reason:"), gate.Reason)
+	} else {
+		_, _ = fmt.Fprintf(p.opts.Stdout, "%s passed\n", evalOutputLabel(p.opts.Stdout, "Promotion gate:"))
+	}
+	_, _ = fmt.Fprintln(p.opts.Stdout)
 }

--- a/internal/harbor/eval_promote_git.go
+++ b/internal/harbor/eval_promote_git.go
@@ -9,9 +9,12 @@ import (
 	"time"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 type promoteGit interface {
+	TrackedEvalJobs(string, string) ([]evalJobRef, error)
 	StagedFiles() ([]string, error)
 	UnstagedFilesTouching([]string) ([]string, error)
 	LatestModTime([]string) (time.Time, error)
@@ -188,6 +191,25 @@ func (c *goGitPromoteClient) Rel(path string) (string, error) {
 		return "", fmt.Errorf("path %s is outside git root %s", path, c.root)
 	}
 	return filepath.ToSlash(rel), nil
+}
+
+func (c *goGitPromoteClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]evalJobRef, error) {
+	return trackedEvalJobReader{
+		rel:  c.Rel,
+		tree: c.tree,
+	}.Jobs(baseRef, jobsRoot)
+}
+
+func (c *goGitPromoteClient) tree(ref string) (*object.Tree, error) {
+	hash, err := c.repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return nil, err
+	}
+	commit, err := c.repo.CommitObject(*hash)
+	if err != nil {
+		return nil, err
+	}
+	return commit.Tree()
 }
 
 func joinDisplay(values []string) string {

--- a/internal/harbor/eval_promote_message.go
+++ b/internal/harbor/eval_promote_message.go
@@ -2,7 +2,6 @@ package harbor
 
 import (
 	"fmt"
-	"io"
 	"strings"
 )
 
@@ -16,45 +15,33 @@ type promoteMessageData struct {
 }
 
 func renderPromoteCommitMessage(data promoteMessageData) string {
-	return renderPromoteCommitMessageWithLabel(data, func(label string) string {
-		return label
-	})
-}
-
-func renderPromoteCommitMessageForWriter(w io.Writer, data promoteMessageData) string {
-	return renderPromoteCommitMessageWithLabel(data, func(label string) string {
-		return evalOutputLabel(w, label)
-	})
-}
-
-func renderPromoteCommitMessageWithLabel(data promoteMessageData, label func(string) string) string {
 	var b strings.Builder
 	subject := strings.TrimSpace(data.subject)
 	if subject == "" {
 		subject = defaultPromoteSubject
 	}
 	_, _ = fmt.Fprintf(&b, "%s\n\n", subject)
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Eval-Job:"), data.jobPath)
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Eval-Result:"), data.resultPath)
+	_, _ = fmt.Fprintf(&b, "Eval-Job: %s\n", data.jobPath)
+	_, _ = fmt.Fprintf(&b, "Eval-Result: %s\n", data.resultPath)
 	if data.evidenceOnly {
-		_, _ = fmt.Fprintf(&b, "%s eval-evidence-only\n", label("Promotion-Mode:"))
+		_, _ = fmt.Fprintln(&b, "Promotion-Mode: eval-evidence-only")
 	}
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Dataset:"), data.datasetSummary())
+	_, _ = fmt.Fprintf(&b, "Dataset: %s\n", data.datasetSummary())
 	if tasks := data.taskSummary(); tasks != "" {
-		_, _ = fmt.Fprintf(&b, "%s %s\n", label("Tasks:"), tasks)
+		_, _ = fmt.Fprintf(&b, "Tasks: %s\n", tasks)
 	}
 	_, _ = fmt.Fprintln(&b)
 	if results := data.resultsSummary(); len(results) > 0 {
-		_, _ = fmt.Fprintln(&b, label("Results:"))
+		_, _ = fmt.Fprintln(&b, "Results:")
 		for _, result := range results {
 			_, _ = fmt.Fprintf(&b, " %s\n", result)
 		}
 	}
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Job:"), data.jobSummary())
+	_, _ = fmt.Fprintf(&b, "Job: %s\n", data.jobSummary())
 	_, _ = fmt.Fprintln(&b)
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Agent:"), data.agentSummary())
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Model:"), data.modelSummary())
-	_, _ = fmt.Fprintf(&b, "%s %s\n", label("Environment:"), data.environmentSummary())
+	_, _ = fmt.Fprintf(&b, "Agent: %s\n", data.agentSummary())
+	_, _ = fmt.Fprintf(&b, "Model: %s\n", data.modelSummary())
+	_, _ = fmt.Fprintf(&b, "Environment: %s\n", data.environmentSummary())
 	return b.String()
 }
 
@@ -124,7 +111,10 @@ func (d promoteMessageData) jobSummary() string {
 }
 
 func (d promoteMessageData) resultsSummary() []string {
-	summaries := summarizeEvalResults(d.result, d.config)
+	summaries := evalJobRef{
+		Result: d.result,
+		Config: d.config,
+	}.ResultSummaries()
 	values := make([]string, 0, len(summaries))
 	for _, summary := range summaries {
 		reward := "n/a"

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -52,9 +52,10 @@ func TestEvalPromoterDryRunDoesNotRequireStagedChanges(t *testing.T) {
 	if got := stdout.String(); strings.HasSuffix(got, "\n\n") {
 		t.Fatalf("stdout has trailing blank line: %q", got)
 	}
-	if got := stdout.String(); !strings.Contains(got, "Evidence mode: compact\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\n  jobs/2026-06-25__10-00-00/trial/verifier/reward.json\n\nPromote changes verified by task eval") {
+	if got := stdout.String(); !strings.Contains(got, "Evidence mode: compact\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\n  jobs/2026-06-25__10-00-00/trial/verifier/reward.json\n\nComparison: no tracked baseline found\n\nProposed commit message:\n\nPromote changes verified by task eval") {
 		t.Fatalf("stdout = %q", got)
 	}
+	assertPlainProposedCommitMessage(t, stdout.String())
 }
 
 func TestEvalPromoterDryRunShowsArtifactsModeAndWorkdirExclusion(t *testing.T) {
@@ -83,7 +84,7 @@ func TestEvalPromoterDryRunShowsArtifactsModeAndWorkdirExclusion(t *testing.T) {
 	if !gitClient.includeArtifacts {
 		t.Fatal("includeArtifacts = false, want true")
 	}
-	if got := stdout.String(); !strings.Contains(got, "Evidence mode: artifacts\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\nExcluded: */workdir/*\n\nPromote changes verified by task eval") {
+	if got := stdout.String(); !strings.Contains(got, "Evidence mode: artifacts\nFiles to add:\n  jobs/2026-06-25__10-00-00/result.json\nExcluded: */workdir/*\n\nComparison: no tracked baseline found\n\nProposed commit message:\n\nPromote changes verified by task eval") {
 		t.Fatalf("stdout = %q", got)
 	}
 }
@@ -140,6 +141,138 @@ func TestEvalPromoterDoesNotWarnWhenNewerPromotableJobExists(t *testing.T) {
 	}
 	if got := stderr.String(); strings.Contains(got, "newer eval jobs were skipped") {
 		t.Fatalf("stderr = %q", got)
+	}
+}
+
+func TestEvalPromoterDryRunShowsCompareGateWithoutFailing(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, jobDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.5)
+
+	var stdout bytes.Buffer
+	gitClient := &recordingPromoteGit{
+		root:        tmp,
+		trackedJobs: []evalJobRef{localCompareJob(t, tmp, baseDir, "tracked in test")},
+		jobFiles:    []string{"jobs/2026-06-25__10-00-00/result.json"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		DryRun:  true,
+		Stdout:  &stdout,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Comparison:",
+		"dataset: reward 0.750 -> 0.500  -0.250",
+		"Promotion gate: blocked",
+		"Reason: candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway",
+		"Proposed commit message:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if gitClient.addCalled || gitClient.commitCalled {
+		t.Fatal("dry-run should not add or commit")
+	}
+}
+
+func TestEvalPromoterBlocksRegressedComparison(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, jobDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.5)
+
+	gitClient := &recordingPromoteGit{
+		root:        tmp,
+		staged:      []string{"main.go"},
+		trackedJobs: []evalJobRef{localCompareJob(t, tmp, baseDir, "tracked in test")},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		Git:     gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "promotion blocked by eval comparison: candidate regressed") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if gitClient.addCalled || gitClient.commitCalled {
+		t.Fatal("blocked promotion should not add or commit")
+	}
+}
+
+func TestEvalPromoterPromoteAnywayCommitsRegressedComparison(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, jobDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.5)
+
+	gitClient := &recordingPromoteGit{
+		root:        tmp,
+		staged:      []string{"main.go"},
+		trackedJobs: []evalJobRef{localCompareJob(t, tmp, baseDir, "tracked in test")},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:       jobsRoot,
+		Latest:        true,
+		PromoteAnyway: true,
+		Git:           gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if !gitClient.addCalled || !gitClient.commitCalled {
+		t.Fatal("expected add and commit")
+	}
+}
+
+func TestEvalPromoterEvidenceOnlyUsesCompareGate(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithReward(t, jobDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.5)
+
+	gitClient := &recordingPromoteGit{
+		root:        tmp,
+		trackedJobs: []evalJobRef{localCompareJob(t, tmp, baseDir, "tracked in test")},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:      jobsRoot,
+		Latest:       true,
+		EvidenceOnly: true,
+		Git:          gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "promotion blocked by eval comparison: candidate regressed") {
+		t.Fatalf("error = %q", err.Error())
+	}
+	if gitClient.addCalled || gitClient.commitCalled {
+		t.Fatal("blocked evidence-only promotion should not add or commit")
 	}
 }
 
@@ -329,6 +462,7 @@ func TestEvalPromoterExplicitJobRejectsIncompleteJob(t *testing.T) {
 type recordingPromoteGit struct {
 	root             string
 	staged           []string
+	trackedJobs      []evalJobRef
 	stagedCalled     bool
 	addCalled        bool
 	jobFilesCalled   bool
@@ -336,6 +470,21 @@ type recordingPromoteGit struct {
 	includeArtifacts bool
 	jobFiles         []string
 	message          string
+}
+
+func assertPlainProposedCommitMessage(t *testing.T, output string) {
+	t.Helper()
+	parts := strings.SplitN(output, "Proposed commit message:\n\n", 2)
+	if len(parts) != 2 {
+		t.Fatalf("output missing proposed commit message:\n%s", output)
+	}
+	if strings.Contains(parts[1], "\x1b[") {
+		t.Fatalf("proposed commit message contains ANSI formatting:\n%q", parts[1])
+	}
+}
+
+func (g *recordingPromoteGit) TrackedEvalJobs(string, string) ([]evalJobRef, error) {
+	return append([]evalJobRef(nil), g.trackedJobs...), nil
 }
 
 func (g *recordingPromoteGit) StagedFiles() ([]string, error) {


### PR DESCRIPTION
## Summary

- Refactors eval job loading around shared `evalJobRef` / `evalJobStore` primitives used by both compare and promote.
- Moves comparison behavior onto the comparison model, including shared result rendering and promotion gate evaluation.
- Makes `runme eval promote` transparently compare the selected job against the tracked HEAD baseline.
- Blocks real promotion on compare gate failures unless `--promote-anyway` is passed.
- Updates `--dry-run` to show comparison/gate context and clearly label the proposed commit message.

## Behavior

- `runme eval promote --dry-run` exits successfully and reports whether real promotion would be blocked.
- `runme eval promote` blocks on regressions, no matching eval results, metadata mismatches, summary ambiguity, and job-level counter regressions.
- `runme eval promote --promote-anyway` bypasses the gate explicitly.
- `--evidence-only` uses the same gate as regular promotion.

## Tests

- `go test ./internal/harbor -run 'EvalPromote|EvalCompare'`
- `go test ./cmd -run Eval`
- `runme run test`
