### PR TITLE
Set terminal titles for active commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,8 @@ func Root() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			setTerminalTitle(cmd.OutOrStdout(), cmd.CommandPath())
+
 			if strings.HasPrefix(fChdir, "~") {
 				cmd.PrintErrf("WARNING: --chdir starts with ~ which should be resolved by shell. Try re-running with --chdir %s (note lack of =) if it fails.\n\n", fChdir)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -155,6 +155,8 @@ func runCmd() *cobra.Command {
 				return errors.New("No tasks to execute with the tag provided")
 			}
 
+			setTerminalTitle(cmd.OutOrStdout(), runTerminalTitle(runTasks, runAll, runWithIndex, runIndex, cmdTags))
+
 			ctx, cancel := ctxWithSigCancel(cmd.Context())
 			defer cancel()
 

--- a/cmd/run_terminal_title.go
+++ b/cmd/run_terminal_title.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/runmedev/runme/v3/internal/terminal"
+	"github.com/runmedev/runme/v3/project"
+)
+
+func setTerminalTitle(w io.Writer, title string) {
+	terminal.SetTitle(w, title)
+}
+
+func runTerminalTitle(tasks []project.Task, runAll, runWithIndex bool, runIndex int, tags []string) string {
+	title := runTerminalTitleOptions{
+		tasks:   tasks,
+		all:     runAll,
+		indexed: runWithIndex,
+		index:   runIndex,
+		tags:    tags,
+	}.Title()
+
+	return string(title)
+}
+
+type runTerminalTitleOptions struct {
+	tasks   []project.Task
+	all     bool
+	indexed bool
+	index   int
+	tags    []string
+}
+
+func (o runTerminalTitleOptions) Title() terminal.Title {
+	if len(o.tags) > 0 {
+		return terminal.Title("runme run " + runTerminalTitleTags(o.tags).String())
+	}
+
+	if o.all {
+		return "runme run all tasks"
+	}
+
+	return terminal.Title("runme run " + o.taskLabels().String())
+}
+
+func (o runTerminalTitleOptions) taskLabels() terminalTitleItems {
+	names := make(terminalTitleItems, 0, len(o.tasks))
+	for i, task := range o.tasks {
+		label := runTerminalTitleTask{
+			task:    task,
+			indexed: o.indexed && i == 0,
+			index:   o.index,
+		}
+		names = append(names, label.String())
+	}
+	return names
+}
+
+type runTerminalTitleTags []string
+
+func (t runTerminalTitleTags) String() string {
+	label := "tag"
+	if len(t) > 1 {
+		label = "tags"
+	}
+	return label + " " + terminalTitleItems(t).String()
+}
+
+type runTerminalTitleTask struct {
+	task    project.Task
+	indexed bool
+	index   int
+}
+
+func (t runTerminalTitleTask) String() string {
+	if t.task.CodeBlock == nil {
+		return "unnamed"
+	}
+
+	if t.indexed && t.task.CodeBlock.IsUnnamed() {
+		return fmt.Sprintf("#%d", t.index)
+	}
+
+	if !t.task.CodeBlock.IsUnnamed() && strings.TrimSpace(t.task.CodeBlock.Name()) != "" {
+		return t.task.CodeBlock.Name()
+	}
+
+	if firstLine := strings.TrimSpace(t.task.CodeBlock.FirstLine()); firstLine != "" {
+		return fmt.Sprintf("%q", firstLine)
+	}
+
+	return "unnamed"
+}
+
+type terminalTitleItems []string
+
+func (items terminalTitleItems) String() string {
+	items = items.Compact()
+	if len(items) == 0 {
+		return "unnamed"
+	}
+
+	if len(items) <= 2 {
+		return strings.Join(items, ",")
+	}
+
+	return fmt.Sprintf("%s +%d", strings.Join(items[:2], ","), len(items)-2)
+}
+
+func (items terminalTitleItems) Compact() terminalTitleItems {
+	compacted := make(terminalTitleItems, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		compacted = append(compacted, item)
+	}
+	return compacted
+}

--- a/cmd/terminal_title_test.go
+++ b/cmd/terminal_title_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/runmedev/runme/v3/document"
+	"github.com/runmedev/runme/v3/document/identity"
+	"github.com/runmedev/runme/v3/internal/terminal"
+	"github.com/runmedev/runme/v3/project"
+)
+
+func TestSetTerminalTitleDoesNotWriteToBuffer(t *testing.T) {
+	var buf bytes.Buffer
+
+	setTerminalTitle(&buf, "runme run build")
+
+	require.Empty(t, buf.String())
+}
+
+func TestSanitizeTerminalTitle(t *testing.T) {
+	title := terminal.SanitizeTitle(" \x1b]0;bad\x07\nrunme\rrun build\t ")
+
+	require.Equal(t, "]0;badrunmerun build", title)
+}
+
+func TestSanitizeTerminalTitleTruncates(t *testing.T) {
+	title := terminal.SanitizeTitle(strings.Repeat("a", 101))
+
+	require.Len(t, title, 100)
+	require.True(t, strings.HasSuffix(title, "..."))
+}
+
+func TestRunTerminalTitle(t *testing.T) {
+	tasks := terminalTitleTasks(t, `# Test
+
+`+"```sh { name=build }\n"+`npm run build
+`+"```\n\n"+`Another task
+
+`+"```sh { name=test }\n"+`npm test
+`+"```\n\n"+`Unnamed task
+
+`+"```sh\n"+`docker compose up
+`+"```\n")
+
+	require.Equal(t, "runme run build", runTerminalTitle(tasks[:1], false, false, -1, nil))
+	require.Equal(t, "runme run build,test", runTerminalTitle(tasks[:2], false, false, -1, nil))
+	require.Equal(t, `runme run build,test +1`, runTerminalTitle(tasks, false, false, -1, nil))
+	require.Equal(t, `runme run "docker compose up"`, runTerminalTitle(tasks[2:], false, false, -1, nil))
+	require.Equal(t, "runme run #2", runTerminalTitle(tasks[2:], false, true, 2, nil))
+	require.Equal(t, "runme run all tasks", runTerminalTitle(tasks, true, false, -1, nil))
+	require.Equal(t, "runme run tag ci", runTerminalTitle(tasks, false, false, -1, []string{"ci"}))
+	require.Equal(t, "runme run tags ci,release", runTerminalTitle(tasks, false, false, -1, []string{"ci", "release"}))
+	require.Equal(t, "runme run tags ci,release +1", runTerminalTitle(tasks, false, false, -1, []string{"ci", "release", "nightly"}))
+}
+
+func terminalTitleTasks(t *testing.T, markdown string) []project.Task {
+	t.Helper()
+
+	resolver := identity.NewResolver(identity.DefaultLifecycleIdentity)
+	doc := document.New([]byte(markdown), resolver)
+	root, err := doc.Root()
+	require.NoError(t, err)
+
+	blocks := document.CollectCodeBlocks(root)
+	tasks := make([]project.Task, len(blocks))
+	for i, block := range blocks {
+		tasks[i] = project.Task{CodeBlock: block}
+	}
+	return tasks
+}

--- a/internal/cmd/beta/beta_cmd.go
+++ b/internal/cmd/beta/beta_cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/runmedev/runme/v3/internal/cmd/beta/server"
 	"github.com/runmedev/runme/v3/internal/config"
 	"github.com/runmedev/runme/v3/internal/config/autoconfig"
+	"github.com/runmedev/runme/v3/internal/terminal"
 )
 
 type commonFlags struct {
@@ -33,6 +34,8 @@ All commands are experimental and not yet ready for production use.
 All commands use the runme.yaml configuration file.`,
 		Hidden: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			terminal.SetTitle(cmd.OutOrStdout(), cmd.CommandPath())
+
 			if cFlags.silent {
 				cmd.SetErr(io.Discard)
 			}

--- a/internal/cmd/beta/server/server_cmd.go
+++ b/internal/cmd/beta/server/server_cmd.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/runmedev/runme/v3/internal/config"
 	"github.com/runmedev/runme/v3/internal/config/autoconfig"
+	"github.com/runmedev/runme/v3/internal/terminal"
 )
 
 func Cmd() *cobra.Command {
@@ -13,6 +14,8 @@ func Cmd() *cobra.Command {
 		Short:  "Commands to manage and call a runme server.",
 		Hidden: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			terminal.SetTitle(cmd.OutOrStdout(), cmd.CommandPath())
+
 			return autoconfig.Invoke(
 				func(
 					cfg *config.Config,

--- a/internal/terminal/title.go
+++ b/internal/terminal/title.go
@@ -1,0 +1,73 @@
+package terminal
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mattn/go-isatty"
+)
+
+const (
+	noTitleEnv = "RUNME_NO_TERMINAL_TITLE"
+	titleMax   = 100
+)
+
+type Title string
+
+func SetTitle(w io.Writer, title string) {
+	TitleWriter{w: w}.Set(Title(title))
+}
+
+type TitleWriter struct {
+	w io.Writer
+}
+
+func (t TitleWriter) Set(title Title) {
+	if os.Getenv(noTitleEnv) != "" || os.Getenv("TERM") == "dumb" {
+		return
+	}
+
+	f, ok := t.w.(*os.File)
+	if !ok || !isTerminal(f.Fd()) {
+		return
+	}
+
+	title = title.Sanitize()
+	if title.Empty() {
+		return
+	}
+
+	_, _ = fmt.Fprintf(t.w, "\x1b]0;%s\x1b\\", title)
+}
+
+func (t Title) Empty() bool {
+	return t == ""
+}
+
+func (t Title) Sanitize() Title {
+	return Title(SanitizeTitle(string(t)))
+}
+
+func SanitizeTitle(title string) string {
+	title = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, title)
+
+	title = strings.TrimSpace(title)
+	if utf8.RuneCountInString(title) <= titleMax {
+		return title
+	}
+
+	runes := []rune(title)
+	return string(runes[:titleMax-3]) + "..."
+}
+
+func isTerminal(fd uintptr) bool {
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}


### PR DESCRIPTION
## Summary
- set the terminal title from the resolved Cobra command path for interactive TTY runs
- refine `runme run` titles after task resolution using task names, tag/all labels, index fallback, and short command snippets for unnamed tasks
- add TTY/env/TERM guards plus OSC 0 ST-terminated title emission and focused tests

## Testing
- `go test ./cmd -run 'TerminalTitle|PromptEnvVars'`
- `runme run test`