### PR TITLE
Rename Harbor metadata backup files

### DIFF
--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -13,8 +13,8 @@ from harbor.models.trial.result import ModelInfo, TrialResult
 from runme_harbor.cli import AGENT_ARGUMENTS, ENVIRONMENT_IMPORT_PATH
 
 
-ORIGINAL_CONFIG_BACKUP = "config.original.json"
-ORIGINAL_RESULT_BACKUP = "result.original.json"
+ORIGINAL_CONFIG_BACKUP = "config.harbor.json"
+ORIGINAL_RESULT_BACKUP = "result.harbor.json"
 
 
 @dataclass(frozen=True)

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -43,8 +43,8 @@ def test_sync_jobs_metadata_uses_observed_runme_agent_import_paths(tmp_path: Pat
     assert _agent_summaries(config) == [("runme-codex", CODEX_IMPORT_PATH, "openai/gpt-5")]
     assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
 
-    assert ORIGINAL_CONFIG_BACKUP == "config.original.json"
-    backup = JobConfig.model_validate_json((job_dir / "config.original.json").read_text())
+    assert ORIGINAL_CONFIG_BACKUP == "config.harbor.json"
+    backup = JobConfig.model_validate_json((job_dir / "config.harbor.json").read_text())
     assert _agent_summaries(backup) == [
         (
             None,


### PR DESCRIPTION
## Summary
- rename Harbor metadata sync backups from `*.original.json` to `*.harbor.json`
- update metadata sync tests to expect the new backup filenames

## Tests
- `uv run pytest tests/test_metadata_sync.py`
- `runme run test`