### PR TITLE
fix docker command cleanup race

### DIFF
--- a/command/command_docker_test.go
+++ b/command/command_docker_test.go
@@ -39,6 +39,25 @@ func TestDockerCommand(t *testing.T) {
 		require.NoError(t, cmd.Wait(context.Background()))
 	})
 
+	t.Run("FastOutput", func(t *testing.T) {
+		for range 10 {
+			stdout := bytes.NewBuffer(nil)
+			cmd, err := factory.Build(
+				&ProgramConfig{
+					ProgramName: "echo",
+					Arguments:   []string{"-n", "test"},
+					Interactive: true,
+					Mode:        runnerv2.CommandMode_COMMAND_MODE_INLINE,
+				},
+				CommandOptions{Stdout: stdout},
+			)
+			require.NoError(t, err)
+			require.NoError(t, cmd.Start(context.Background()))
+			require.NoError(t, cmd.Wait(context.Background()))
+			assert.Equal(t, "test", stdout.String())
+		}
+	})
+
 	t.Run("Output", func(t *testing.T) {
 		t.Parallel()
 		stdout := bytes.NewBuffer(nil)

--- a/internal/dockerexec/cmd.go
+++ b/internal/dockerexec/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
@@ -34,6 +35,7 @@ type Cmd struct {
 
 	// containerID will be set in Start().
 	containerID string
+	autoRemove  bool
 
 	ioErrC chan error
 
@@ -57,9 +59,11 @@ func (c *Cmd) Start() error {
 		Image:        c.docker.image,
 		WorkingDir:   "/workspace",
 	}
+	c.autoRemove = !c.docker.debug
+
 	hostConfig := &container.HostConfig{
 		RestartPolicy:  container.RestartPolicy{Name: container.RestartPolicyDisabled},
-		AutoRemove:     !c.docker.debug,
+		AutoRemove:     false,
 		ConsoleSize:    [2]uint{80, 24},
 		ReadonlyRootfs: true,
 		Mounts: []mount.Mount{
@@ -200,7 +204,36 @@ func (c *Cmd) Wait() error {
 		}
 	}
 
+	// Wait owns cleanup for non-debug Docker commands. Callers must call Wait
+	// after Start so short-lived containers can still be inspected for process
+	// metadata before they are removed.
+	if errCleanup := c.removeContainer(); errCleanup != nil {
+		if err == nil {
+			err = errCleanup
+		} else {
+			c.logger.Info("ignoring container cleanup error as there was an earlier error", zap.Error(errCleanup))
+		}
+	}
+
 	return err
+}
+
+func (c *Cmd) removeContainer() error {
+	if !c.autoRemove || c.containerID == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := c.docker.client.ContainerRemove(
+		ctx,
+		c.containerID,
+		container.RemoveOptions{
+			Force: true,
+		},
+	)
+	return errors.WithStack(err)
 }
 
 type Process struct {

--- a/internal/dockerexec/docker_test.go
+++ b/internal/dockerexec/docker_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/errdefs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +30,45 @@ func TestDockerCommandContext(t *testing.T) {
 		cmd.Dir = workingDir
 		require.NoError(t, cmd.Start())
 		require.NoError(t, cmd.Wait())
+	})
+
+	t.Run("Cleanup", func(t *testing.T) {
+		cmd := docker.CommandContext(context.Background(), "true")
+		cmd.Dir = workingDir
+
+		require.NoError(t, cmd.Start())
+		require.NotEmpty(t, cmd.containerID)
+		_, err := docker.client.ContainerInspect(context.Background(), cmd.containerID)
+		require.NoError(t, err)
+
+		require.NoError(t, cmd.Wait())
+		_, err = docker.client.ContainerInspect(context.Background(), cmd.containerID)
+		require.True(t, errdefs.IsNotFound(err), "expected container to be removed, got %v", err)
+	})
+
+	t.Run("DebugLeavesContainer", func(t *testing.T) {
+		debugDocker, err := New(
+			&Options{
+				Debug: true,
+				Image: "alpine:3.19",
+			},
+		)
+		require.NoError(t, err)
+
+		cmd := debugDocker.CommandContext(context.Background(), "true")
+		cmd.Dir = workingDir
+
+		require.NoError(t, cmd.Start())
+		require.NotEmpty(t, cmd.containerID)
+		require.NoError(t, cmd.Wait())
+		_, err = debugDocker.client.ContainerInspect(context.Background(), cmd.containerID)
+		require.NoError(t, err)
+
+		require.NoError(t, debugDocker.client.ContainerRemove(
+			context.Background(),
+			cmd.containerID,
+			container.RemoveOptions{Force: true},
+		))
 	})
 
 	t.Run("NotTTY", func(t *testing.T) {

--- a/pkg/agent/runme/stream/handler_test.go
+++ b/pkg/agent/runme/stream/handler_test.go
@@ -152,7 +152,7 @@ func TestWebSocketHandler_ShutdownWaitsForTapFinalization(t *testing.T) {
 	}
 	select {
 	case <-processDone:
-	default:
+	case <-time.After(time.Second):
 		t.Fatal("Shutdown returned before multiplexer process exited")
 	}
 }


### PR DESCRIPTION
## Summary

- move Docker command cleanup out of Docker `AutoRemove` and into `Cmd.Wait`
- preserve debug mode by leaving debug containers available after `Wait`
- add docker-enabled coverage for cleanup behavior and fast output commands
- stabilize a Windows-sensitive shutdown test by waiting for the process goroutine instead of assuming it resumes in the same scheduler turn

## Why

GitHub Actions hit a race in `TestDockerCommand/Output`:

<https://github.com/runmedev/runme/actions/runs/28463360333/job/84356711159>

`Cmd.Start` previously started an auto-removing container and then inspected it for the PID. Fast commands like `echo -n test` can exit and be removed before `ContainerInspect`, producing `Error response from daemon: No such container`.

## Validation

```sh
go test -tags=docker_enabled -run '^TestDockerCommand$' -count=20 ./command
```

```sh
go test -tags=docker_enabled -run '^TestDockerCommandContext$' -count=5 ./internal/dockerexec
```

```sh
TZ=UTC TAGS=docker_enabled PKGS=./command RUN='^TestDockerCommand$' make test/coverage
```

```sh
TZ=UTC TAGS=docker_enabled make test/coverage
```

```sh
go test -run '^TestWebSocketHandler_ShutdownWaitsForTapFinalization$' -count=200 ./pkg/agent/runme/stream
```

```sh
runme run test
```
