### PR TITLE
test: add docker environment for deps eval

### DIFF
--- a/evals/tasks/update-minor-deps/environment/Dockerfile
+++ b/evals/tasks/update-minor-deps/environment/Dockerfile
@@ -3,3 +3,4 @@ FROM ghcr.io/runmedev/runme-build-env:latest
 WORKDIR /app/evals/tasks/update-minor-deps/workdir
 
 RUN git clone --depth=1 https://github.com/runmedev/runme.git .
+RUN make install/dev

--- a/evals/tasks/update-minor-deps/environment/Dockerfile
+++ b/evals/tasks/update-minor-deps/environment/Dockerfile
@@ -1,6 +1,12 @@
 FROM ghcr.io/runmedev/runme-build-env:latest
 
+ENV PATH="/usr/local/go/bin:/root/go/bin:${PATH}"
+ENV GOTOOLCHAIN=auto
+ENV RUNME_TEST_ENV=docker
+ENV BUILD_OUTPUT=/usr/local/bin/runme
+
 WORKDIR /app/evals/tasks/update-minor-deps/workdir
 
-RUN git clone --depth=1 https://github.com/runmedev/runme.git .
+RUN git clone https://github.com/runmedev/runme.git .
 RUN make install/dev
+RUN make build

--- a/evals/tasks/update-minor-deps/environment/Dockerfile
+++ b/evals/tasks/update-minor-deps/environment/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/runmedev/runme-build-env:latest
+
+WORKDIR /app/evals/tasks/update-minor-deps/workdir
+
+RUN git clone --depth=1 https://github.com/runmedev/runme.git .

--- a/evals/tasks/update-minor-deps/task.toml
+++ b/evals/tasks/update-minor-deps/task.toml
@@ -23,7 +23,7 @@ cpus = 1
 memory_mb = 2048
 storage_mb = 10240
 gpus = 0
-workdir = "/app"
+workdir = "/app/evals/tasks/update-minor-deps/workdir"
 skills_dir = "/app/.agents/skills"
 
 [environment.env]

--- a/evals/tasks/update-minor-deps/tests/score.go
+++ b/evals/tasks/update-minor-deps/tests/score.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	root               = "/app/evals/tasks/update-minor-deps/workdir"
+	taskWorkdirEnv     = "RUNME_TASK_WORKDIR"
+	defaultRoot        = "/app/evals/tasks/update-minor-deps/workdir"
 	agentLogDir        = "/logs/agent"
 	artifactsDir       = "/logs/artifacts"
 	verifierDir        = "/logs/verifier"
@@ -89,7 +90,7 @@ func newScorer() (*scorer, error) {
 
 func runGit(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
-	cmd.Dir = root
+	cmd.Dir = taskRoot()
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -98,6 +99,13 @@ func runGit(args ...string) (string, error) {
 		return "", fmt.Errorf("git %s failed: %w", strings.Join(args, " "), err)
 	}
 	return string(output), nil
+}
+
+func taskRoot() string {
+	if root := os.Getenv(taskWorkdirEnv); root != "" {
+		return root
+	}
+	return defaultRoot
 }
 
 func changedFiles() ([]string, error) {

--- a/evals/tasks/update-minor-deps/tests/score.go
+++ b/evals/tasks/update-minor-deps/tests/score.go
@@ -13,16 +13,20 @@ import (
 )
 
 const (
-	taskWorkdirEnv     = "RUNME_TASK_WORKDIR"
-	defaultRoot        = "/app/evals/tasks/update-minor-deps/workdir"
-	agentLogDir        = "/logs/agent"
-	artifactsDir       = "/logs/artifacts"
-	verifierDir        = "/logs/verifier"
-	prDraft            = artifactsDir + "/pr.md"
-	rewardPath         = verifierDir + "/reward.json"
-	rewardDetailsPath  = verifierDir + "/reward-details.json"
-	evalHarnessPrefix  = "evals/tasks/"
-	skillHarnessPrefix = ".agents/skills/update-minor-deps/"
+	taskWorkdirEnv       = "RUNME_TASK_WORKDIR"
+	agentLogDirEnv       = "RUNME_AGENT_LOG_DIR"
+	artifactsDirEnv      = "RUNME_ARTIFACTS_DIR"
+	verifierDirEnv       = "RUNME_VERIFIER_DIR"
+	rewardPathEnv        = "RUNME_REWARD_PATH"
+	rewardDetailsPathEnv = "RUNME_REWARD_DETAILS_PATH"
+	defaultRoot          = "/app/evals/tasks/update-minor-deps/workdir"
+	defaultAgentLogDir   = "/logs/agent"
+	defaultArtifactsDir  = "/logs/artifacts"
+	defaultVerifierDir   = "/logs/verifier"
+	defaultRewardPath    = defaultVerifierDir + "/reward.json"
+	defaultRewardDetails = defaultVerifierDir + "/reward-details.json"
+	evalHarnessPrefix    = "evals/tasks/"
+	skillHarnessPrefix   = ".agents/skills/update-minor-deps/"
 )
 
 var (
@@ -84,7 +88,7 @@ func newScorer() (*scorer, error) {
 		files:       files,
 		text:        collectAgentText(),
 		commands:    collectAgentCommands(),
-		prDraftText: readText(prDraft),
+		prDraftText: readText(prDraftPath()),
 	}, nil
 }
 
@@ -102,10 +106,38 @@ func runGit(args ...string) (string, error) {
 }
 
 func taskRoot() string {
-	if root := os.Getenv(taskWorkdirEnv); root != "" {
-		return root
+	return envPath(taskWorkdirEnv, defaultRoot)
+}
+
+func agentLogDir() string {
+	return envPath(agentLogDirEnv, defaultAgentLogDir)
+}
+
+func artifactsDir() string {
+	return envPath(artifactsDirEnv, defaultArtifactsDir)
+}
+
+func verifierDir() string {
+	return envPath(verifierDirEnv, defaultVerifierDir)
+}
+
+func prDraftPath() string {
+	return filepath.Join(artifactsDir(), "pr.md")
+}
+
+func rewardPath() string {
+	return envPath(rewardPathEnv, defaultRewardPath)
+}
+
+func rewardDetailsPath() string {
+	return envPath(rewardDetailsPathEnv, defaultRewardDetails)
+}
+
+func envPath(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
 	}
-	return defaultRoot
+	return fallback
 }
 
 func changedFiles() ([]string, error) {
@@ -173,10 +205,10 @@ func readText(path string) string {
 
 func collectAgentText() string {
 	var chunks []string
-	info, err := os.Stat(agentLogDir)
+	info, err := os.Stat(agentLogDir())
 	if err == nil && info.IsDir() {
 		var paths []string
-		_ = filepath.WalkDir(agentLogDir, func(path string, entry os.DirEntry, err error) error {
+		_ = filepath.WalkDir(agentLogDir(), func(path string, entry os.DirEntry, err error) error {
 			if err != nil || entry.IsDir() {
 				return nil
 			}
@@ -193,7 +225,7 @@ func collectAgentText() string {
 		}
 	}
 
-	chunks = append(chunks, readText(prDraft))
+	chunks = append(chunks, readText(prDraftPath()))
 	return strings.ToLower(strings.Join(chunks, "\n"))
 }
 
@@ -246,7 +278,7 @@ func commandFromATIFArguments(arguments map[string]json.RawMessage) string {
 }
 
 func collectAgentCommands() string {
-	return collectAgentCommandsFromDir(agentLogDir)
+	return collectAgentCommandsFromDir(agentLogDir())
 }
 
 func collectAgentCommandsFromDir(dir string) string {
@@ -605,10 +637,10 @@ func writeJSON(path string, value any, trailingNewline bool) error {
 }
 
 func run() error {
-	if err := os.MkdirAll(verifierDir, 0o750); err != nil {
+	if err := os.MkdirAll(verifierDir(), 0o750); err != nil {
 		return fmt.Errorf("create verifier dir: %w", err)
 	}
-	if err := os.MkdirAll(artifactsDir, 0o750); err != nil {
+	if err := os.MkdirAll(artifactsDir(), 0o750); err != nil {
 		return fmt.Errorf("create artifacts dir: %w", err)
 	}
 
@@ -620,16 +652,16 @@ func run() error {
 
 	diagnostics := map[string]any{
 		"changed_files": s.files,
-		"pr_draft":      prDraft,
-		"agent_log_dir": agentLogDir,
+		"pr_draft":      prDraftPath(),
+		"agent_log_dir": agentLogDir(),
 	}
-	if err := writeJSON(filepath.Join(verifierDir, "diagnostics.json"), diagnostics, false); err != nil {
+	if err := writeJSON(filepath.Join(verifierDir(), "diagnostics.json"), diagnostics, false); err != nil {
 		return fmt.Errorf("write diagnostics: %w", err)
 	}
-	if err := writeJSON(rewardPath, scores, true); err != nil {
+	if err := writeJSON(rewardPath(), scores, true); err != nil {
 		return fmt.Errorf("write reward: %w", err)
 	}
-	if err := writeJSON(rewardDetailsPath, rewardDetails(scores), true); err != nil {
+	if err := writeJSON(rewardDetailsPath(), rewardDetails(scores), true); err != nil {
 		return fmt.Errorf("write reward details: %w", err)
 	}
 	printRewardSummary(scores)

--- a/evals/tasks/update-minor-deps/tests/score.go
+++ b/evals/tasks/update-minor-deps/tests/score.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	root               = "/app"
+	root               = "/app/evals/tasks/update-minor-deps/workdir"
 	agentLogDir        = "/logs/agent"
 	artifactsDir       = "/logs/artifacts"
 	verifierDir        = "/logs/verifier"

--- a/evals/tasks/update-minor-deps/tests/score.go
+++ b/evals/tasks/update-minor-deps/tests/score.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -122,7 +123,7 @@ func verifierDir() string {
 }
 
 func prDraftPath() string {
-	return filepath.Join(artifactsDir(), "pr.md")
+	return path.Join(artifactsDir(), "pr.md")
 }
 
 func rewardPath() string {

--- a/evals/tasks/update-minor-deps/tests/score_test.go
+++ b/evals/tasks/update-minor-deps/tests/score_test.go
@@ -138,6 +138,24 @@ func TestRewardDetailsJSONShape(t *testing.T) {
 	}
 }
 
+func TestTaskRoot(t *testing.T) {
+	t.Run("uses env", func(t *testing.T) {
+		t.Setenv(taskWorkdirEnv, "/tmp/task-workdir")
+
+		if got := taskRoot(); got != "/tmp/task-workdir" {
+			t.Fatalf("taskRoot() = %q, want /tmp/task-workdir", got)
+		}
+	})
+
+	t.Run("falls back to default", func(t *testing.T) {
+		t.Setenv(taskWorkdirEnv, "")
+
+		if got := taskRoot(); got != defaultRoot {
+			t.Fatalf("taskRoot() = %q, want %q", got, defaultRoot)
+		}
+	})
+}
+
 func TestScoreDependencyUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/evals/tasks/update-minor-deps/tests/score_test.go
+++ b/evals/tasks/update-minor-deps/tests/score_test.go
@@ -156,6 +156,62 @@ func TestTaskRoot(t *testing.T) {
 	})
 }
 
+func TestRuntimePaths(t *testing.T) {
+	t.Run("uses env", func(t *testing.T) {
+		t.Setenv(agentLogDirEnv, "/tmp/agent")
+		t.Setenv(artifactsDirEnv, "/tmp/artifacts")
+		t.Setenv(verifierDirEnv, "/tmp/verifier")
+		t.Setenv(rewardPathEnv, "/tmp/reward.json")
+		t.Setenv(rewardDetailsPathEnv, "/tmp/reward-details.json")
+
+		if got := agentLogDir(); got != "/tmp/agent" {
+			t.Fatalf("agentLogDir() = %q, want /tmp/agent", got)
+		}
+		if got := artifactsDir(); got != "/tmp/artifacts" {
+			t.Fatalf("artifactsDir() = %q, want /tmp/artifacts", got)
+		}
+		if got := verifierDir(); got != "/tmp/verifier" {
+			t.Fatalf("verifierDir() = %q, want /tmp/verifier", got)
+		}
+		if got := prDraftPath(); got != "/tmp/artifacts/pr.md" {
+			t.Fatalf("prDraftPath() = %q, want /tmp/artifacts/pr.md", got)
+		}
+		if got := rewardPath(); got != "/tmp/reward.json" {
+			t.Fatalf("rewardPath() = %q, want /tmp/reward.json", got)
+		}
+		if got := rewardDetailsPath(); got != "/tmp/reward-details.json" {
+			t.Fatalf("rewardDetailsPath() = %q, want /tmp/reward-details.json", got)
+		}
+	})
+
+	t.Run("falls back to defaults", func(t *testing.T) {
+		t.Setenv(agentLogDirEnv, "")
+		t.Setenv(artifactsDirEnv, "")
+		t.Setenv(verifierDirEnv, "")
+		t.Setenv(rewardPathEnv, "")
+		t.Setenv(rewardDetailsPathEnv, "")
+
+		if got := agentLogDir(); got != defaultAgentLogDir {
+			t.Fatalf("agentLogDir() = %q, want %q", got, defaultAgentLogDir)
+		}
+		if got := artifactsDir(); got != defaultArtifactsDir {
+			t.Fatalf("artifactsDir() = %q, want %q", got, defaultArtifactsDir)
+		}
+		if got := verifierDir(); got != defaultVerifierDir {
+			t.Fatalf("verifierDir() = %q, want %q", got, defaultVerifierDir)
+		}
+		if got := prDraftPath(); got != defaultArtifactsDir+"/pr.md" {
+			t.Fatalf("prDraftPath() = %q, want %q", got, defaultArtifactsDir+"/pr.md")
+		}
+		if got := rewardPath(); got != defaultRewardPath {
+			t.Fatalf("rewardPath() = %q, want %q", got, defaultRewardPath)
+		}
+		if got := rewardDetailsPath(); got != defaultRewardDetails {
+			t.Fatalf("rewardDetailsPath() = %q, want %q", got, defaultRewardDetails)
+		}
+	})
+}
+
 func TestScoreDependencyUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/integrations/harbor/README.md
+++ b/integrations/harbor/README.md
@@ -15,6 +15,21 @@ uv tool install runme-harbor
 
 The `runme` CLI must be installed separately and available on `PATH`.
 
+## Runtime Environment
+
+Runme Harbor exposes these runtime paths to task and verifier commands:
+
+- `RUNME_TASK_WORKDIR`: resolved task workspace.
+- `RUNME_TASK_DIR`: task definition directory.
+- `RUNME_TASK_NAME`: task name.
+- `RUNME_TESTS_DIR`: uploaded verifier tests directory.
+- `RUNME_LOGS_DIR`: base trial logs directory.
+- `RUNME_AGENT_LOG_DIR`: agent logs directory.
+- `RUNME_ARTIFACTS_DIR`: artifact output directory.
+- `RUNME_VERIFIER_DIR`: verifier output directory.
+- `RUNME_REWARD_PATH`: canonical reward JSON path.
+- `RUNME_REWARD_DETAILS_PATH`: optional detailed reward JSON path.
+
 ## Build
 
 Build the distribution artifacts:

--- a/integrations/harbor/src/runme_harbor/environment.py
+++ b/integrations/harbor/src/runme_harbor/environment.py
@@ -48,6 +48,7 @@ class RunmeEnvironment(BaseEnvironment):
         self._workspace_root = (
             Path(workspace_root).expanduser() if workspace_root else Path.cwd()
         ).resolve()
+        self._task_dir = environment_dir.parent.resolve().absolute()
         self._runme_bin = runme_bin or os.environ.get("RUNME_BIN") or "runme"
         self._runme_args = _parse_runme_args(runme_args)
         self._command = list(command) if command is not None else None
@@ -131,7 +132,7 @@ class RunmeEnvironment(BaseEnvironment):
         env = _env_map_to_list(
             self._persistent_env,
             self.task_env_config.env,
-            {"RUNME_TASK_WORKDIR": str(self._resolved_task_workdir())},
+            self._runtime_env(),
         )
         await self._request(
             {"start": {"root": str(self._protocol_root), "env": env}},
@@ -318,6 +319,21 @@ class RunmeEnvironment(BaseEnvironment):
         if self._staged_workdir_host:
             return self._staged_workdir_host
         return self._map_remote_path(self.task_env_config.workdir or "/app")
+
+    def _runtime_env(self) -> dict[str, str]:
+        verifier_dir = self._root / "verifier"
+        return {
+            "RUNME_AGENT_LOG_DIR": str(self._root / "agent"),
+            "RUNME_ARTIFACTS_DIR": str(self._root / "artifacts"),
+            "RUNME_LOGS_DIR": str(self._root),
+            "RUNME_REWARD_DETAILS_PATH": str(verifier_dir / "reward-details.json"),
+            "RUNME_REWARD_PATH": str(verifier_dir / "reward.json"),
+            "RUNME_TASK_DIR": str(self._task_dir),
+            "RUNME_TASK_NAME": self.environment_name,
+            "RUNME_TASK_WORKDIR": str(self._resolved_task_workdir()),
+            "RUNME_TESTS_DIR": str(self._root / "tests"),
+            "RUNME_VERIFIER_DIR": str(verifier_dir),
+        }
 
     def _configured_workdir_remote(self) -> PurePosixPath | None:
         workdir = self.task_env_config.workdir

--- a/integrations/harbor/src/runme_harbor/environment.py
+++ b/integrations/harbor/src/runme_harbor/environment.py
@@ -128,7 +128,11 @@ class RunmeEnvironment(BaseEnvironment):
         )
         await client.start()
         self._client = client
-        env = _env_map_to_list(self._persistent_env, self.task_env_config.env)
+        env = _env_map_to_list(
+            self._persistent_env,
+            self.task_env_config.env,
+            {"RUNME_TASK_WORKDIR": str(self._resolved_task_workdir())},
+        )
         await self._request(
             {"start": {"root": str(self._protocol_root), "env": env}},
         )
@@ -309,6 +313,11 @@ class RunmeEnvironment(BaseEnvironment):
         )
         self._staged_workdir_remote = remote
         self._staged_workdir_host = target
+
+    def _resolved_task_workdir(self) -> Path:
+        if self._staged_workdir_host:
+            return self._staged_workdir_host
+        return self._map_remote_path(self.task_env_config.workdir or "/app")
 
     def _configured_workdir_remote(self) -> PurePosixPath | None:
         workdir = self.task_env_config.workdir

--- a/integrations/harbor/src/runme_harbor/environment.py
+++ b/integrations/harbor/src/runme_harbor/environment.py
@@ -293,8 +293,10 @@ class RunmeEnvironment(BaseEnvironment):
             return
 
         source = self._workspace_path_for_app_path(remote)
-        if source is None or not source.is_dir():
+        if source is None:
             return
+        if not source.is_dir():
+            source = self._workspace_root
 
         target = self._root / "workdir"
         if target.exists():

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -93,7 +93,10 @@ def test_environment_starts_runme_harbor_stdio(
     assert client.requests[0] == {
         "start": {
             "root": str(tmp_path),
-            "env": ["TASK_ENV=yes"],
+            "env": [
+                f"RUNME_TASK_WORKDIR={tmp_path}",
+                "TASK_ENV=yes",
+            ],
         }
     }
 
@@ -173,6 +176,7 @@ def test_nested_configured_workdir_is_staged_per_trial(
 
     client = FakeClient.instances[0]
     assert client.requests[0]["start"]["root"] == str(tmp_path)
+    assert f"RUNME_TASK_WORKDIR={staged}" in client.requests[0]["start"]["env"]
     request = client.requests[-1]["exec"]
     assert request["cwd"] == "trial/workdir"
     assert str(staged) in request["command"]
@@ -206,9 +210,34 @@ def test_missing_nested_configured_workdir_stages_workspace_root(
     staged = tmp_path / "trial" / "workdir"
     assert (staged / "go.mod").read_text() == "module example.com/repo\n"
 
-    request = FakeClient.instances[0].requests[-1]["exec"]
+    client = FakeClient.instances[0]
+    assert f"RUNME_TASK_WORKDIR={staged}" in client.requests[0]["start"]["env"]
+    request = client.requests[-1]["exec"]
     assert request["cwd"] == "trial/workdir"
     assert configured_workdir not in request["command"]
+
+
+def test_runtime_task_workdir_overrides_configured_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    environment = _make_env(
+        tmp_path,
+        task_env_config=EnvironmentConfig(
+            workdir="/app",
+            env={"RUNME_TASK_WORKDIR": "/wrong", "TASK_ENV": "yes"},
+        ),
+    )
+
+    asyncio.run(environment.start(force_build=False))
+
+    assert FakeClient.instances[0].requests[0]["start"]["env"] == [
+        f"RUNME_TASK_WORKDIR={tmp_path}",
+        "TASK_ENV=yes",
+    ]
 
 
 def test_upload_dir_rewrites_configured_workdir_paths_to_staged_workdir(

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -179,6 +179,38 @@ def test_nested_configured_workdir_is_staged_per_trial(
     assert "/app/examples/harbor/task/workdir" not in request["command"]
 
 
+def test_missing_nested_configured_workdir_stages_workspace_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "go.mod").write_text("module example.com/repo\n")
+
+    configured_workdir = "/app/evals/tasks/update-minor-deps/workdir"
+    environment = _make_env(
+        tmp_path,
+        workspace_root=workspace,
+        task_env_config=EnvironmentConfig(
+            workdir=configured_workdir,
+            env={"TASK_ENV": "yes"},
+        ),
+    )
+
+    asyncio.run(environment.start(force_build=False))
+    asyncio.run(environment.exec("git status --short"))
+
+    staged = tmp_path / "trial" / "workdir"
+    assert (staged / "go.mod").read_text() == "module example.com/repo\n"
+
+    request = FakeClient.instances[0].requests[-1]["exec"]
+    assert request["cwd"] == "trial/workdir"
+    assert configured_workdir not in request["command"]
+
+
 def test_upload_dir_rewrites_configured_workdir_paths_to_staged_workdir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -94,7 +94,17 @@ def test_environment_starts_runme_harbor_stdio(
         "start": {
             "root": str(tmp_path),
             "env": [
+                f"RUNME_AGENT_LOG_DIR={tmp_path / 'trial' / 'agent'}",
+                f"RUNME_ARTIFACTS_DIR={tmp_path / 'trial' / 'artifacts'}",
+                f"RUNME_LOGS_DIR={tmp_path / 'trial'}",
+                "RUNME_REWARD_DETAILS_PATH="
+                f"{tmp_path / 'trial' / 'verifier' / 'reward-details.json'}",
+                f"RUNME_REWARD_PATH={tmp_path / 'trial' / 'verifier' / 'reward.json'}",
+                f"RUNME_TASK_DIR={tmp_path}",
+                "RUNME_TASK_NAME=simple-agent",
                 f"RUNME_TASK_WORKDIR={tmp_path}",
+                f"RUNME_TESTS_DIR={tmp_path / 'trial' / 'tests'}",
+                f"RUNME_VERIFIER_DIR={tmp_path / 'trial' / 'verifier'}",
                 "TASK_ENV=yes",
             ],
         }
@@ -228,16 +238,25 @@ def test_runtime_task_workdir_overrides_configured_env(
         tmp_path,
         task_env_config=EnvironmentConfig(
             workdir="/app",
-            env={"RUNME_TASK_WORKDIR": "/wrong", "TASK_ENV": "yes"},
+            env={
+                "RUNME_ARTIFACTS_DIR": "/wrong",
+                "RUNME_REWARD_PATH": "/wrong",
+                "RUNME_TASK_WORKDIR": "/wrong",
+                "TASK_ENV": "yes",
+            },
         ),
     )
 
     asyncio.run(environment.start(force_build=False))
 
-    assert FakeClient.instances[0].requests[0]["start"]["env"] == [
-        f"RUNME_TASK_WORKDIR={tmp_path}",
-        "TASK_ENV=yes",
-    ]
+    env = FakeClient.instances[0].requests[0]["start"]["env"]
+    assert f"RUNME_ARTIFACTS_DIR={tmp_path / 'trial' / 'artifacts'}" in env
+    assert f"RUNME_REWARD_PATH={tmp_path / 'trial' / 'verifier' / 'reward.json'}" in env
+    assert f"RUNME_TASK_WORKDIR={tmp_path}" in env
+    assert "RUNME_ARTIFACTS_DIR=/wrong" not in env
+    assert "RUNME_REWARD_PATH=/wrong" not in env
+    assert "RUNME_TASK_WORKDIR=/wrong" not in env
+    assert "TASK_ENV=yes" in env
 
 
 def test_upload_dir_rewrites_configured_workdir_paths_to_staged_workdir(


### PR DESCRIPTION
## Summary

- Add an optional Docker environment for the update-minor-deps eval using the maintained Runme build environment image.
- Align the task workdir with the Docker workdir and clone a fresh Runme checkout for Docker runs.
- Make the verifier and RunmeEnvironment path staging handle the nested task workdir used by this eval.
- Expose runtime path metadata to task and verifier commands via environment variables.

## Runtime environment

Runme Harbor now provides these env vars for runtime paths:

- `RUNME_TASK_WORKDIR`: resolved task workspace.
- `RUNME_TASK_DIR`: task definition directory.
- `RUNME_TASK_NAME`: task name.
- `RUNME_TESTS_DIR`: uploaded verifier tests directory.
- `RUNME_LOGS_DIR`: base trial logs directory.
- `RUNME_AGENT_LOG_DIR`: agent logs directory.
- `RUNME_ARTIFACTS_DIR`: artifact output directory.
- `RUNME_VERIFIER_DIR`: verifier output directory.
- `RUNME_REWARD_PATH`: canonical reward JSON path.
- `RUNME_REWARD_DETAILS_PATH`: optional detailed reward JSON path.

## Validation

- `go test ./evals/tasks/update-minor-deps/tests`
- `uv run --project integrations/harbor pytest integrations/harbor/tests/test_environment.py`
- `runme run lint test`
- Local smoke eval: `runme eval --agent codex --model openai/gpt-5.4-mini`
- Docker smoke eval: `OPENAI_API_KEY="$OPENAI_API_KEY" runme eval --agent codex --model openai/gpt-5.4-mini --env docker`

The smoke evals used the temporary shortened instruction to confirm verifier execution; the task instruction was restored before commit.
