### PR TITLE
feat: record eval promote comparison delta

### DIFF
--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-const defaultPromoteSubject = "Promote changes verified by task eval"
+const (
+	defaultPromoteSubject    = "Promote changes verified by task eval"
+	promoteComparisonBaseRef = "HEAD"
+)
 
 type EvalPromoteOptions struct {
 	JobsDir       string
@@ -98,12 +101,25 @@ func (p *EvalPromoter) Run(args []string) error {
 	if warning := newerPromotableJobWarning(jobsRoot, jobDir, candidate.Result, policy); warning != "" {
 		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s; newer eval jobs were skipped\n\n", warning, jobsRel)
 	}
-	message := renderPromoteCommitMessage(candidate.MessageData(p.opts.Message, p.opts.EvidenceOnly))
-
 	comparison, hasComparison, err := p.comparison(jobsRoot, candidate, gitClient)
 	if err != nil {
 		return err
 	}
+	messageData := candidate.MessageData(p.opts.Message, p.opts.EvidenceOnly)
+	if hasComparison {
+		baseCommit, err := gitClient.ResolveRef(promoteComparisonBaseRef)
+		if err != nil {
+			return err
+		}
+		messageData.comparison = newPromoteMessageComparison(
+			comparison,
+			baseCommit,
+			comparison.Gate().Blocking && p.opts.PromoteAnyway,
+		)
+	} else {
+		messageData.comparison = noBaselinePromoteMessageComparison()
+	}
+	message := renderPromoteCommitMessage(messageData)
 
 	if p.opts.DryRun {
 		files, err := gitClient.JobFiles(jobDir, p.opts.Artifacts)
@@ -128,7 +144,7 @@ func (p *EvalPromoter) Run(args []string) error {
 		p.renderDryRunComparison(comparison, hasComparison)
 		_, _ = fmt.Fprintln(p.opts.Stdout, evalOutputLabel(p.opts.Stdout, "Proposed commit message:"))
 		_, _ = fmt.Fprintln(p.opts.Stdout)
-		_, _ = fmt.Fprint(p.opts.Stdout, renderPromoteCommitMessage(candidate.MessageData(p.opts.Message, p.opts.EvidenceOnly)))
+		_, _ = fmt.Fprint(p.opts.Stdout, message)
 		return nil
 	}
 
@@ -181,14 +197,14 @@ func (p *EvalPromoter) comparison(jobsRoot string, candidate evalJobRef, gitClie
 	base, err := (evalJobStore{
 		jobsDir: jobsRoot,
 		git:     gitClient,
-	}).LatestTracked("HEAD")
+	}).LatestTracked(promoteComparisonBaseRef)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "no complete Git-tracked eval job found") {
 			return evalComparison{}, false, nil
 		}
 		return evalComparison{}, false, err
 	}
-	return newEvalComparison(base, candidate, "HEAD"), true, nil
+	return newEvalComparison(base, candidate, promoteComparisonBaseRef), true, nil
 }
 
 func (p *EvalPromoter) renderDryRunComparison(comparison evalComparison, ok bool) {

--- a/internal/harbor/eval_promote_git.go
+++ b/internal/harbor/eval_promote_git.go
@@ -15,6 +15,7 @@ import (
 
 type promoteGit interface {
 	TrackedEvalJobs(string, string) ([]evalJobRef, error)
+	ResolveRef(string) (string, error)
 	StagedFiles() ([]string, error)
 	UnstagedFilesTouching([]string) ([]string, error)
 	LatestModTime([]string) (time.Time, error)
@@ -198,6 +199,14 @@ func (c *goGitPromoteClient) TrackedEvalJobs(baseRef, jobsRoot string) ([]evalJo
 		rel:  c.Rel,
 		tree: c.tree,
 	}.Jobs(baseRef, jobsRoot)
+}
+
+func (c *goGitPromoteClient) ResolveRef(ref string) (string, error) {
+	hash, err := c.repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return "", err
+	}
+	return hash.String(), nil
 }
 
 func (c *goGitPromoteClient) tree(ref string) (*object.Tree, error) {

--- a/internal/harbor/eval_promote_message.go
+++ b/internal/harbor/eval_promote_message.go
@@ -12,6 +12,18 @@ type promoteMessageData struct {
 	evidenceOnly bool
 	config       promoteJobConfig
 	result       promoteJobResult
+	comparison   promoteMessageComparison
+}
+
+type promoteMessageComparison struct {
+	hasBaseline bool
+	basePath    string
+	baseRef     string
+	baseCommit  string
+	job         evalComparisonStats
+	results     evalComparisonResults
+	gate        promoteCompareGate
+	overridden  bool
 }
 
 func renderPromoteCommitMessage(data promoteMessageData) string {
@@ -38,6 +50,8 @@ func renderPromoteCommitMessage(data promoteMessageData) string {
 		}
 	}
 	_, _ = fmt.Fprintf(&b, "Job: %s\n", data.jobSummary())
+	_, _ = fmt.Fprintln(&b)
+	data.comparison.render(&b)
 	_, _ = fmt.Fprintln(&b)
 	_, _ = fmt.Fprintf(&b, "Agent: %s\n", data.agentSummary())
 	_, _ = fmt.Fprintf(&b, "Model: %s\n", data.modelSummary())
@@ -126,4 +140,98 @@ func (d promoteMessageData) resultsSummary() []string {
 		values = append(values, fmt.Sprintf("%s: reward=%s", summary.Key, reward))
 	}
 	return values
+}
+
+func newPromoteMessageComparison(comparison evalComparison, baseCommit string, overridden bool) promoteMessageComparison {
+	return promoteMessageComparison{
+		hasBaseline: true,
+		basePath:    comparison.Base.Path,
+		baseRef:     comparison.Base.Ref,
+		baseCommit:  baseCommit,
+		job:         comparison.Job,
+		results:     comparison.Results,
+		gate:        comparison.Gate(),
+		overridden:  overridden,
+	}
+}
+
+func noBaselinePromoteMessageComparison() promoteMessageComparison {
+	return promoteMessageComparison{}
+}
+
+func (c promoteMessageComparison) shouldRender() bool {
+	return c.hasBaseline || c.baseRef != "" || c.baseCommit != ""
+}
+
+func (c promoteMessageComparison) render(b *strings.Builder) {
+	if !c.shouldRender() {
+		_, _ = fmt.Fprintln(b, "Comparison-Base: none")
+		_, _ = fmt.Fprintln(b, "Promotion-Gate: not evaluated")
+		return
+	}
+
+	_, _ = fmt.Fprintf(b, "Comparison-Base: %s tracked in %s", c.basePath, c.baseRef)
+	if short := shortCommitHash(c.baseCommit); short != "" {
+		_, _ = fmt.Fprintf(b, " (%s)", short)
+	}
+	_, _ = fmt.Fprintln(b)
+
+	c.renderResultDelta(b)
+	c.renderJobDelta(b)
+	c.renderPromotionGate(b)
+}
+
+func (c promoteMessageComparison) renderResultDelta(b *strings.Builder) {
+	if len(c.results.Comparisons) == 0 {
+		_, _ = fmt.Fprintln(b, "Result-Delta: no matching eval results")
+	} else {
+		_, _ = fmt.Fprintln(b, "Result-Delta:")
+		for _, result := range c.results.Comparisons {
+			_, _ = fmt.Fprintf(
+				b,
+				" %s: reward %s -> %s  %s\n",
+				result.Key,
+				displayValue(result.Reward.Base),
+				displayValue(result.Reward.Candidate),
+				signedDelta(result.Reward.Delta),
+			)
+		}
+	}
+	if len(c.results.BaseOnly) > 0 {
+		_, _ = fmt.Fprintf(b, "Base-Only-Results: %s\n", strings.Join(c.results.BaseOnly, ", "))
+	}
+	if len(c.results.CandidateOnly) > 0 {
+		_, _ = fmt.Fprintf(b, "Candidate-Only-Results: %s\n", strings.Join(c.results.CandidateOnly, ", "))
+	}
+}
+
+func (c promoteMessageComparison) renderJobDelta(b *strings.Builder) {
+	_, _ = fmt.Fprintf(
+		b,
+		"Job-Delta: completed %s, errors %s, evals %s\n",
+		signedDelta(c.job.Completed.Delta),
+		signedDelta(c.job.Errors.Delta),
+		signedDelta(c.job.Evals.Delta),
+	)
+}
+
+func (c promoteMessageComparison) renderPromotionGate(b *strings.Builder) {
+	switch {
+	case c.gate.Blocking && c.overridden:
+		_, _ = fmt.Fprintln(b, "Promotion-Gate: overridden")
+		_, _ = fmt.Fprintf(b, "Promotion-Gate-Reason: %s\n", c.gate.Reason)
+	case c.gate.Blocking:
+		_, _ = fmt.Fprintln(b, "Promotion-Gate: blocked")
+		_, _ = fmt.Fprintf(b, "Promotion-Gate-Reason: %s\n", c.gate.Reason)
+	default:
+		_, _ = fmt.Fprintln(b, "Promotion-Gate: passed")
+	}
+}
+
+func shortCommitHash(hash string) string {
+	hash = strings.TrimSpace(hash)
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:8]
 }

--- a/internal/harbor/eval_promote_message_test.go
+++ b/internal/harbor/eval_promote_message_test.go
@@ -45,9 +45,11 @@ func TestRenderPromoteCommitMessageUsesJobAndResultRollups(t *testing.T) {
 		"Model: gpt-5-codex",
 		"Environment: " + runmeEnvironmentImportPath,
 		"Job: completed=2/2, errors=0, evals=1",
+		"Comparison-Base: none",
+		"Promotion-Gate: not evaluated",
 		"Results:",
 		"dataset: reward=0.750",
-		"\nResults:\n dataset: reward=0.750\nJob: completed=2/2, errors=0, evals=1\n\nAgent: codex\n",
+		"\nResults:\n dataset: reward=0.750\nJob: completed=2/2, errors=0, evals=1\n\nComparison-Base: none\nPromotion-Gate: not evaluated\n\nAgent: codex\n",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("message missing %q:\n%s", want, msg)
@@ -68,6 +70,8 @@ func TestRenderPromoteCommitMessageUsesJobAndResultRollups(t *testing.T) {
 		"Results:",
 		"dataset: reward=0.750",
 		"Job: completed=2/2, errors=0, evals=1",
+		"Comparison-Base: none",
+		"Promotion-Gate: not evaluated",
 		"Agent: codex",
 		"Model: gpt-5-codex",
 		"Environment: "+runmeEnvironmentImportPath,

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -176,6 +176,11 @@ func TestEvalPromoterDryRunShowsCompareGateWithoutFailing(t *testing.T) {
 		"Promotion gate: blocked",
 		"Reason: candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway",
 		"Proposed commit message:",
+		"Comparison-Base: jobs/2026-06-25__09-00-00 tracked in HEAD (baa34cbd)",
+		"Result-Delta:\n dataset: reward 0.750 -> 0.500  -0.250",
+		"Job-Delta: completed +0, errors +0, evals +0",
+		"Promotion-Gate: blocked",
+		"Promotion-Gate-Reason: candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output missing %q:\n%s", want, output)
@@ -183,6 +188,40 @@ func TestEvalPromoterDryRunShowsCompareGateWithoutFailing(t *testing.T) {
 	}
 	if gitClient.addCalled || gitClient.commitCalled {
 		t.Fatal("dry-run should not add or commit")
+	}
+}
+
+func TestEvalPromoterCommitMessageRecordsPassedComparison(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithReward(t, jobDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+
+	gitClient := &recordingPromoteGit{
+		root:        tmp,
+		staged:      []string{"main.go"},
+		trackedJobs: []evalJobRef{localCompareJob(t, tmp, baseDir, "tracked in test")},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Comparison-Base: jobs/2026-06-25__09-00-00 tracked in HEAD (baa34cbd)",
+		"Result-Delta:\n dataset: reward 0.500 -> 0.750  +0.250",
+		"Job-Delta: completed +0, errors +0, evals +0",
+		"Promotion-Gate: passed",
+	} {
+		if !strings.Contains(gitClient.message, want) {
+			t.Fatalf("commit message missing %q:\n%s", want, gitClient.message)
+		}
 	}
 }
 
@@ -242,6 +281,16 @@ func TestEvalPromoterPromoteAnywayCommitsRegressedComparison(t *testing.T) {
 	}
 	if !gitClient.addCalled || !gitClient.commitCalled {
 		t.Fatal("expected add and commit")
+	}
+	for _, want := range []string{
+		"Comparison-Base: jobs/2026-06-25__09-00-00 tracked in HEAD (baa34cbd)",
+		"Result-Delta:\n dataset: reward 0.750 -> 0.500  -0.250",
+		"Promotion-Gate: overridden",
+		"Promotion-Gate-Reason: candidate regressed; rerun, inspect job/task details, or pass --promote-anyway to promote anyway",
+	} {
+		if !strings.Contains(gitClient.message, want) {
+			t.Fatalf("commit message missing %q:\n%s", want, gitClient.message)
+		}
 	}
 }
 
@@ -326,6 +375,9 @@ func TestEvalPromoterEvidenceOnlyCommitsJobWithoutStagedChanges(t *testing.T) {
 	}
 	if !strings.Contains(gitClient.message, "Promotion-Mode: eval-evidence-only") {
 		t.Fatalf("commit message missing evidence-only mode:\n%s", gitClient.message)
+	}
+	if !strings.Contains(gitClient.message, "Comparison-Base: none") {
+		t.Fatalf("commit message missing no-baseline comparison:\n%s", gitClient.message)
 	}
 }
 
@@ -463,6 +515,7 @@ type recordingPromoteGit struct {
 	root             string
 	staged           []string
 	trackedJobs      []evalJobRef
+	resolvedRef      string
 	stagedCalled     bool
 	addCalled        bool
 	jobFilesCalled   bool
@@ -485,6 +538,13 @@ func assertPlainProposedCommitMessage(t *testing.T, output string) {
 
 func (g *recordingPromoteGit) TrackedEvalJobs(string, string) ([]evalJobRef, error) {
 	return append([]evalJobRef(nil), g.trackedJobs...), nil
+}
+
+func (g *recordingPromoteGit) ResolveRef(string) (string, error) {
+	if g.resolvedRef != "" {
+		return g.resolvedRef, nil
+	}
+	return "baa34cbda7946f3646ce94b6c04e28ea6a6897cb", nil
 }
 
 func (g *recordingPromoteGit) StagedFiles() ([]string, error) {


### PR DESCRIPTION
## Summary

- Record compact eval comparison evidence in `runme eval promote` commit messages.
- Include the tracked baseline path with resolved `HEAD` short hash, reward/job deltas, and promotion gate status.
- Record no-baseline and `--promote-anyway` override states explicitly.

## Validation

- `go test ./internal/harbor -run 'EvalPromote|PromoteCommitMessage|EvalCompare'`
- `go test ./cmd -run Eval`
- `runme run test`

