### PR TITLE
[codex] Omit empty eval task metadata

### DIFF
--- a/internal/harbor/eval_compare_render.go
+++ b/internal/harbor/eval_compare_render.go
@@ -35,11 +35,11 @@ type evalComparisonJob struct {
 }
 
 type evalComparisonMeta struct {
-	Dataset     evalComparisonDiff `json:"dataset"`
-	Tasks       evalComparisonDiff `json:"tasks"`
-	Agent       evalComparisonDiff `json:"agent"`
-	Model       evalComparisonDiff `json:"model"`
-	Environment evalComparisonDiff `json:"environment"`
+	Dataset     evalComparisonDiff  `json:"dataset"`
+	Tasks       *evalComparisonDiff `json:"tasks,omitempty"`
+	Agent       evalComparisonDiff  `json:"agent"`
+	Model       evalComparisonDiff  `json:"model"`
+	Environment evalComparisonDiff  `json:"environment"`
 }
 
 type evalComparisonStats struct {
@@ -143,10 +143,15 @@ func newEvalComparison(base, candidate evalJobRef, baseRef string) evalCompariso
 
 	metadata := evalComparisonMeta{
 		Dataset:     stringDiff(baseSummary.datasetSummary(), candidateSummary.datasetSummary()),
-		Tasks:       stringDiff(baseSummary.taskSummary(), candidateSummary.taskSummary()),
 		Agent:       stringDiff(baseSummary.agentSummary(), candidateSummary.agentSummary()),
 		Model:       stringDiff(baseSummary.modelSummary(), candidateSummary.modelSummary()),
 		Environment: stringDiff(baseSummary.environmentSummary(), candidateSummary.environmentSummary()),
+	}
+	baseTasks := baseSummary.taskSummary()
+	candidateTasks := candidateSummary.taskSummary()
+	if baseTasks != "" || candidateTasks != "" {
+		tasks := stringDiff(baseTasks, candidateTasks)
+		metadata.Tasks = &tasks
 	}
 	job := compareJobStats(base.Result, candidate.Result)
 	results := compareResults(base, candidate)
@@ -219,8 +224,11 @@ func renderEvalComparisonText(w io.Writer, comparison evalComparison) error {
 	_, _ = fmt.Fprintf(w, "%s %s  local\n\n", evalOutputLabel(w, "Latest:"), comparison.Candidate.Path)
 
 	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Dataset:"), comparison.Metadata.Dataset.Candidate)
-	if tasks := strings.TrimSpace(fmt.Sprint(comparison.Metadata.Tasks.Candidate)); tasks != "" {
-		_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Tasks:"), tasks)
+	if comparison.Metadata.Tasks != nil {
+		tasks := strings.TrimSpace(fmt.Sprint(comparison.Metadata.Tasks.Candidate))
+		if tasks != "" {
+			_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Tasks:"), tasks)
+		}
 	}
 	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Agent:"), comparison.Metadata.Agent.Candidate)
 	_, _ = fmt.Fprintf(w, "%s %s\n", evalOutputLabel(w, "Model:"), comparison.Metadata.Model.Candidate)
@@ -365,16 +373,21 @@ func sortedEvalResultSummaryKeys(entries map[string]evalResultSummary) []string 
 }
 
 func metadataMismatches(meta evalComparisonMeta) []evalComparisonDiff {
-	checks := []struct {
+	type metadataCheck struct {
 		name string
 		diff evalComparisonDiff
-	}{
-		{"dataset", meta.Dataset},
-		{"tasks", meta.Tasks},
-		{"agent", meta.Agent},
-		{"model", meta.Model},
-		{"environment", meta.Environment},
 	}
+	checks := []metadataCheck{
+		{"dataset", meta.Dataset},
+	}
+	if meta.Tasks != nil {
+		checks = append(checks, metadataCheck{"tasks", *meta.Tasks})
+	}
+	checks = append(checks,
+		metadataCheck{"agent", meta.Agent},
+		metadataCheck{"model", meta.Model},
+		metadataCheck{"environment", meta.Environment},
+	)
 	var mismatches []evalComparisonDiff
 	for _, check := range checks {
 		if check.diff.Base != check.diff.Candidate {

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -62,6 +62,13 @@ func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	candidateDir := filepath.Join(jobsRoot, "new")
 	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
 	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	config := `{
+		"datasets": [{"path": "dataset"}],
+		"agents": [{"name": "runme-codex", "model_name": "model"}],
+		"environment": {"type": "runme"}
+	}`
+	writeFile(t, filepath.Join(baseDir, "config.json"), config)
+	writeFile(t, filepath.Join(candidateDir, "config.json"), config)
 	t.Chdir(tmp)
 
 	var stdout bytes.Buffer
@@ -100,6 +107,13 @@ func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	if _, ok := parsed["recommendation"]; !ok {
 		t.Fatalf("json missing recommendation: %#v", parsed)
 	}
+	metadata, ok := parsed["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("json metadata has unexpected shape: %#v", parsed["metadata"])
+	}
+	if _, ok := metadata["tasks"]; ok {
+		t.Fatalf("json should omit empty metadata tasks: %#v", metadata)
+	}
 }
 
 func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
@@ -135,6 +149,42 @@ func TestBuildEvalComparisonReportsMetadataMismatches(t *testing.T) {
 	}
 	if gate := comparison.Gate(); gate.ReasonCode != promoteCompareGateReasonMetadata {
 		t.Fatalf("gate reason code = %q, want %q", gate.ReasonCode, promoteCompareGateReasonMetadata)
+	}
+}
+
+func TestBuildEvalComparisonReportsOneSidedTasksMetadata(t *testing.T) {
+	base := compareJob{
+		RelPath:   ".runme/evals/jobs/base",
+		ResultRel: ".runme/evals/jobs/base/result.json",
+		Result: promoteJobResult{
+			TotalTrials: 1,
+			Stats: promoteJobStats{
+				CompletedTrials: 1,
+				Evals: map[string]promoteEvalStats{
+					"oracle__dataset": {Metrics: []map[string]interface{}{{"reward": 1.0}}},
+				},
+			},
+		},
+		Config: promoteJobConfig{
+			Datasets: []promoteDatasetConfig{{Path: "dataset", TaskNames: []string{"one"}}},
+			Agents:   []promoteAgentConfig{{Name: "oracle", ModelName: "model"}},
+		},
+		Selection: "tracked",
+	}
+	candidate := base
+	candidate.RelPath = ".runme/evals/jobs/candidate"
+	candidate.ResultRel = ".runme/evals/jobs/candidate/result.json"
+	candidate.Config.Datasets = []promoteDatasetConfig{{Path: "dataset"}}
+
+	comparison := buildEvalComparison(base, candidate, "HEAD")
+	if comparison.Metadata.Tasks == nil {
+		t.Fatal("tasks metadata is nil, want one-sided diff")
+	}
+	if comparison.Metadata.Tasks.Base != "one" || comparison.Metadata.Tasks.Candidate != "" {
+		t.Fatalf("tasks metadata = %#v, want one -> empty", comparison.Metadata.Tasks)
+	}
+	if len(comparison.MetadataDiffs) != 1 || comparison.MetadataDiffs[0].Delta != "tasks" {
+		t.Fatalf("metadata diffs = %#v, want tasks diff", comparison.MetadataDiffs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Omit `metadata.tasks` from eval compare JSON when neither side has explicit task filters. Keep the field when one side declares tasks so metadata drift is still visible and still blocks promotion.

## Root Cause

Eval compare metadata uses `datasets[].task_names`, not discovered trial directories. Dataset-wide runs leave that value empty, so JSON output showed a low-signal `tasks` object with empty base and candidate values.

## Validation

- `go test ./internal/harbor -run 'TestEvalComparerJSONOutputIsSmallComparisonObject|TestBuildEvalComparisonReportsMetadataMismatches|TestBuildEvalComparisonReportsOneSidedTasksMetadata'`\n- `runme run lint test`