### PR TITLE
feat: add Runme Antigravity eval agent

### DIFF
--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -56,11 +56,11 @@ a task directory inside the dataset, such as `simple-agent` or
 
 `runme eval` delegates to `runme-harbor`, so these examples remain compatible
 with the underlying `harbor run` workflow. The adapter supports `oracle`,
-`codex`, `claude-code`, and `openclaw` agents and runs local agent CLIs through
-`runme harbor stdio` by default. The default environment is `runme`; pass
-`--env runme` to select it explicitly. Passing a non-Runme Harbor environment,
-such as `--env docker`, delegates the selected environment and agent to Harbor
-without the Runme-specific agent wrappers.
+`antigravity-cli`, `codex`, `claude-code`, `cursor-cli`, and `openclaw` agents
+and runs local agent CLIs through `runme harbor stdio` by default. The default
+environment is `runme`; pass `--env runme` to select it explicitly. Passing a
+non-Runme Harbor environment, such as `--env docker`, delegates the selected
+environment and agent to Harbor without the Runme-specific agent wrappers.
 
 Set `--runme-bin` to use a specific Runme binary. Set `--runme-arg` one or more
 times to pass global Runme flags before `harbor stdio`.

--- a/examples/harbor/datasets/runme-smoke/simple-agent/instruction.md
+++ b/examples/harbor/datasets/runme-smoke/simple-agent/instruction.md
@@ -1,4 +1,5 @@
-Create a file named `result.txt`.
+Create a file named `result.txt` in the current working directory for this task.
+Do not create it in a scratch directory, home directory, or any other location.
 
 The file must contain exactly:
 

--- a/integrations/harbor/src/runme_harbor/__init__.py
+++ b/integrations/harbor/src/runme_harbor/__init__.py
@@ -1,8 +1,15 @@
 from .environment import HarborProtocolError, RunmeEnvironment
-from .runme_agents import RunmeClaudeCode, RunmeCodex, RunmeCursorCli, RunmeOpenClaw
+from .runme_agents import (
+    RunmeAntigravityCli,
+    RunmeClaudeCode,
+    RunmeCodex,
+    RunmeCursorCli,
+    RunmeOpenClaw,
+)
 
 __all__ = [
     "HarborProtocolError",
+    "RunmeAntigravityCli",
     "RunmeClaudeCode",
     "RunmeCodex",
     "RunmeCursorCli",

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -15,20 +15,8 @@ from urllib.request import url2pathname
 
 
 PACKAGE_NAME = "runme-harbor"
-ENVIRONMENT_IMPORT_PATH = "runme_harbor.environment:RunmeEnvironment"
-CODEX_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCodex"
-CLAUDE_IMPORT_PATH = "runme_harbor.runme_agents:RunmeClaudeCode"
-CURSOR_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCursorCli"
-OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
 MIN_HARBOR_VERSION = (0, 16, 0)
 MAX_HARBOR_VERSION = (0, 17, 0)
-AGENT_ARGUMENTS = {
-    "oracle": ("--agent", "oracle"),
-    "codex": ("--agent", CODEX_IMPORT_PATH),
-    "claude-code": ("--agent", CLAUDE_IMPORT_PATH),
-    "cursor-cli": ("--agent", CURSOR_IMPORT_PATH),
-    "openclaw": ("--agent", OPENCLAW_IMPORT_PATH),
-}
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/integrations/harbor/src/runme_harbor/metadata_sync.py
+++ b/integrations/harbor/src/runme_harbor/metadata_sync.py
@@ -10,11 +10,22 @@ from harbor.models.trajectories.trajectory import Trajectory
 from harbor.models.trial.config import AgentConfig
 from harbor.models.trial.result import ModelInfo, TrialResult
 
-from runme_harbor.cli import AGENT_ARGUMENTS, ENVIRONMENT_IMPORT_PATH
-
 
 ORIGINAL_CONFIG_BACKUP = "config.harbor.json"
 ORIGINAL_RESULT_BACKUP = "result.harbor.json"
+ENVIRONMENT_IMPORT_PATH = "runme_harbor.environment:RunmeEnvironment"
+ANTIGRAVITY_IMPORT_PATH = "runme_harbor.runme_agents:RunmeAntigravityCli"
+CLAUDE_IMPORT_PATH = "runme_harbor.runme_agents:RunmeClaudeCode"
+CODEX_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCodex"
+CURSOR_IMPORT_PATH = "runme_harbor.runme_agents:RunmeCursorCli"
+OPENCLAW_IMPORT_PATH = "runme_harbor.runme_agents:RunmeOpenClaw"
+RUNME_AGENT_IMPORT_PATHS = {
+    "runme-antigravity-cli": ANTIGRAVITY_IMPORT_PATH,
+    "runme-claude-code": CLAUDE_IMPORT_PATH,
+    "runme-codex": CODEX_IMPORT_PATH,
+    "runme-cursor-cli": CURSOR_IMPORT_PATH,
+    "runme-openclaw": OPENCLAW_IMPORT_PATH,
+}
 
 
 @dataclass(frozen=True)
@@ -58,16 +69,13 @@ def _sync_job_metadata(job_dir: Path) -> bool:
         return results_synced
 
     synced_agents = [
-        _synced_agent_config(agent, original_config=original_config)
-        for agent in observed_agents
+        _synced_agent_config(agent, original_config=original_config) for agent in observed_agents
     ]
     updates: dict[str, object] = {"agents": synced_agents}
     if _has_runme_agent(synced_agents):
         updates["environment"] = _synced_environment(config, original_config=original_config)
 
-    synced_config = config.model_copy(
-        update=updates
-    )
+    synced_config = config.model_copy(update=updates)
     synced_json = synced_config.model_dump_json(indent=4)
     current_json = config_path.read_text()
     if _same_json(current_json, synced_json):
@@ -171,9 +179,15 @@ def _synced_agent_config(
     original_config: JobConfig | None,
 ) -> AgentConfig:
     original_agent = _matching_original_agent(observed, original_config=original_config)
-    import_path = original_agent.import_path if original_agent else _runme_agent_import_paths().get(observed.name)
+    import_path = (
+        original_agent.import_path
+        if original_agent
+        else _runme_agent_import_paths().get(observed.name)
+    )
     if import_path:
-        return AgentConfig(name=observed.name, import_path=import_path, model_name=observed.model_name)
+        return AgentConfig(
+            name=observed.name, import_path=import_path, model_name=observed.model_name
+        )
     return AgentConfig(name=observed.name, model_name=observed.model_name)
 
 
@@ -212,17 +226,7 @@ def _synced_environment(
 
 
 def _runme_agent_import_paths() -> dict[str, str]:
-    agent_import_paths: dict[str, str] = {}
-    for args in AGENT_ARGUMENTS.values():
-        if len(args) != 2 or args[0] != "--agent":
-            continue
-        import_path = args[1]
-        if ":" not in import_path:
-            continue
-        agent_name = _agent_name_from_import_path(import_path)
-        if agent_name:
-            agent_import_paths[agent_name] = import_path
-    return agent_import_paths
+    return dict(RUNME_AGENT_IMPORT_PATHS)
 
 
 def _agent_name_from_import_path(import_path: str) -> str | None:

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -5,7 +5,9 @@ import shutil
 import tempfile
 from hashlib import sha256
 from pathlib import Path
+from typing import Any
 
+from harbor.agents.installed.antigravity_cli import AntigravityCli
 from harbor.agents.installed.base import CliFlag, with_prompt_template
 from harbor.agents.installed.claude_code import ClaudeCode
 from harbor.agents.installed.codex import Codex
@@ -13,7 +15,106 @@ from harbor.agents.installed.cursor_cli import CursorCli
 from harbor.agents.installed.openclaw import OpenClaw
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories.trajectory import Trajectory
 from harbor.models.trial.paths import EnvironmentPaths
+
+
+class RunmeAntigravityCli(AntigravityCli):
+    """Antigravity CLI-backed Runme agent without container bootstrap.
+
+    Harbor's installed Antigravity agent assumes a disposable container and
+    installs Google's `agy` CLI during setup. Runme Harbor executes through
+    Runme's runtime, so this wrapper expects `agy` to already be available and
+    configured.
+    """
+
+    @staticmethod
+    def name() -> str:
+        return "runme-antigravity-cli"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        return None
+
+    async def setup(self, environment: BaseEnvironment) -> None:
+        return None
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        escaped_instruction = shlex.quote(instruction)
+
+        if self.model_name and "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        model = self.model_name.split("/")[-1] if self.model_name else None
+
+        # Gemini CLI refuses to honor `--yolo` in an untrusted workspace and
+        # overrides approval mode back to "default".
+        env = {"GEMINI_CLI_TRUST_WORKSPACE": "true"}
+
+        auth_vars = [
+            "GEMINI_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
+            "GOOGLE_GENAI_USE_VERTEXAI",
+            "GOOGLE_API_KEY",
+        ]
+        for var in auth_vars:
+            if var in os.environ:
+                env[var] = os.environ[var]
+
+        skills_command = self._build_register_skills_command()
+        if skills_command:
+            await self.exec_as_agent(environment, command=skills_command, env=env)
+
+        settings_command, _ = self._build_settings_command(model)
+        if settings_command:
+            await self.exec_as_agent(environment, command=settings_command, env=env)
+
+        cli_flags = self.build_cli_flags()
+        extra_flags = (cli_flags + " ") if cli_flags else ""
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=(
+                    'export PATH="$HOME/.local/bin:$PATH"\n'
+                    f"agy --dangerously-skip-permissions {extra_flags}"
+                    f"--prompt={escaped_instruction} "
+                    "2>&1 </dev/null | stdbuf -oL tee /logs/agent/antigravity-cli.txt"
+                ),
+                env=env,
+            )
+        finally:
+            try:
+                await self.exec_as_agent(
+                    environment,
+                    command=(
+                        "src=$(find ~/.agy/antigravity-cli/tmp -type f "
+                        "\\( -name 'session-*.jsonl' -o -name 'session-*.json' \\) "
+                        "-printf '%T@ %p\\n' 2>/dev/null | sort -nr | head -n1 "
+                        "| awk '{print $2}'); "
+                        'if [ -n "$src" ]; then '
+                        'cp "$src" "/logs/agent/antigravity-cli.trajectory.${src##*.}"; '
+                        "fi"
+                    ),
+                )
+            except Exception:
+                pass
+
+            self.populate_context_post_run(context)
+
+    def _convert_gemini_to_atif(self, gemini_trajectory: dict[str, Any]) -> Trajectory | None:
+        trajectory = super()._convert_gemini_to_atif(gemini_trajectory)
+        if trajectory is None:
+            return None
+        return trajectory.model_copy(
+            update={"agent": trajectory.agent.model_copy(update={"name": self.name()})}
+        )
 
 
 class RunmeClaudeCode(ClaudeCode):

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -31,6 +31,10 @@ def test_main_version_flag_prints_package_version(
     assert capsys.readouterr().out == "runme-harbor 1.2.3\n\ninstall: package\n"
 
 
+def test_cli_does_not_own_agent_metadata_mapping() -> None:
+    assert not hasattr(cli, "AGENT_ARGUMENTS")
+
+
 def test_version_text_includes_install_and_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -78,10 +82,7 @@ def test_install_source_detects_editable_source(
 ) -> None:
     class FakeDistribution:
         def read_text(self, _name: str) -> str:
-            return (
-                '{"url":"file:///repo/integrations/harbor",'
-                '"dir_info":{"editable":true}}'
-            )
+            return '{"url":"file:///repo/integrations/harbor","dir_info":{"editable":true}}'
 
     monkeypatch.setattr(cli.importlib.metadata, "distribution", lambda _name: FakeDistribution())
 

--- a/integrations/harbor/tests/test_metadata_sync.py
+++ b/integrations/harbor/tests/test_metadata_sync.py
@@ -6,13 +6,12 @@ from harbor.models.job.config import JobConfig
 from harbor.models.trial.config import AgentConfig
 from harbor.models.trial.result import TrialResult
 
-from runme_harbor.cli import (
+from runme_harbor.metadata_sync import (
+    ANTIGRAVITY_IMPORT_PATH,
     CLAUDE_IMPORT_PATH,
     CODEX_IMPORT_PATH,
     CURSOR_IMPORT_PATH,
     ENVIRONMENT_IMPORT_PATH,
-)
-from runme_harbor.metadata_sync import (
     ORIGINAL_CONFIG_BACKUP,
     ORIGINAL_RESULT_BACKUP,
     sync_jobs_metadata,
@@ -116,6 +115,37 @@ def test_sync_jobs_metadata_uses_cursor_cli_import_path(tmp_path: Path) -> None:
     config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
     assert _agent_summaries(config) == [
         ("runme-cursor-cli", CURSOR_IMPORT_PATH, "cursor/composer-2")
+    ]
+    assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
+
+
+def test_sync_jobs_metadata_uses_antigravity_cli_import_path(tmp_path: Path) -> None:
+    job_dir = _write_job_config(
+        tmp_path,
+        agents=[
+            AgentConfig(
+                import_path=ANTIGRAVITY_IMPORT_PATH,
+                model_name="google/planned-model",
+            )
+        ],
+    )
+    _write_trial_result(
+        job_dir,
+        "trial-1",
+        agent_name="runme-antigravity-cli",
+        provider="google",
+        model_name="gemini-3-pro-preview",
+    )
+
+    assert sync_jobs_metadata(tmp_path) == 1
+
+    config = JobConfig.model_validate_json((job_dir / "config.json").read_text())
+    assert _agent_summaries(config) == [
+        (
+            "runme-antigravity-cli",
+            ANTIGRAVITY_IMPORT_PATH,
+            "google/gemini-3-pro-preview",
+        )
     ]
     assert config.environment.import_path == ENVIRONMENT_IMPORT_PATH
 

--- a/integrations/harbor/tests/test_runme_antigravity_cli.py
+++ b/integrations/harbor/tests/test_runme_antigravity_cli.py
@@ -1,0 +1,139 @@
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from runme_harbor.runme_agents import RunmeAntigravityCli
+
+
+class FakeEnvironment:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path | str, str]] = []
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        self.uploads.append((source_path, target_path))
+
+
+def test_runme_antigravity_cli_name() -> None:
+    assert RunmeAntigravityCli.name() == "runme-antigravity-cli"
+
+
+def test_runme_antigravity_cli_skips_install_and_setup(tmp_path: Path) -> None:
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="google/gemini-3-pro-preview")
+    environment = FakeEnvironment()
+
+    assert asyncio.run(agent.install(environment)) is None
+    assert asyncio.run(agent.setup(environment)) is None
+
+
+def test_runme_antigravity_cli_uses_ambient_user_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "GEMINI_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_GENAI_USE_VERTEXAI",
+        "GOOGLE_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "ambient-key")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "ambient-project")
+
+    environment = FakeEnvironment()
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="google/gemini-3-pro-preview")
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    assert environment.uploads == []
+    assert len(calls) == 3
+    assert "settings.json" in calls[0][0]
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
+    assert "\nagy --dangerously-skip-permissions " in calls[1][0]
+    assert "--prompt='write result.txt'" in calls[1][0]
+    assert "/logs/agent/antigravity-cli.txt" in calls[1][0]
+    assert "find ~/.agy/antigravity-cli/tmp" in calls[2][0]
+    assert calls[0][1] == {
+        "GEMINI_API_KEY": "ambient-key",
+        "GEMINI_CLI_TRUST_WORKSPACE": "true",
+        "GOOGLE_CLOUD_PROJECT": "ambient-project",
+    }
+    assert calls[1][1] == calls[0][1]
+    assert all("curl -fsSL" not in command for command, _ in calls)
+    assert all("apt-get" not in command for command, _ in calls)
+
+
+def test_runme_antigravity_cli_can_use_local_default_model(tmp_path: Path) -> None:
+    environment = FakeEnvironment()
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name=None)
+    calls: list[tuple[str, dict[str, str] | None]] = []
+
+    async def fake_exec_as_agent(
+        _environment: Any,
+        command: str,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        calls.append((command, env))
+
+    agent.exec_as_agent = fake_exec_as_agent
+    agent.populate_context_post_run = lambda _context: None
+
+    asyncio.run(agent.run("write result.txt", environment, object()))
+
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
+    assert "\nagy --dangerously-skip-permissions " in calls[1][0]
+    assert "defaultModel" not in calls[0][0]
+    assert "--prompt='write result.txt'" in calls[1][0]
+
+
+def test_runme_antigravity_cli_rejects_unqualified_model(tmp_path: Path) -> None:
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="gemini-3-pro-preview")
+
+    with pytest.raises(ValueError, match="provider/model_name"):
+        asyncio.run(agent.run("write result.txt", FakeEnvironment(), object()))
+
+
+def test_runme_antigravity_cli_uses_runme_name_in_atif(tmp_path: Path) -> None:
+    agent = RunmeAntigravityCli(logs_dir=tmp_path, model_name="google/gemini-3-pro-preview")
+
+    trajectory = agent._convert_gemini_to_atif(
+        {
+            "sessionId": "session-1",
+            "messages": [
+                {
+                    "type": "user",
+                    "timestamp": "2026-07-01T17:00:00Z",
+                    "content": "write result.txt",
+                },
+                {
+                    "type": "gemini",
+                    "timestamp": "2026-07-01T17:00:01Z",
+                    "content": "done",
+                    "model": "gemini-3-pro-preview",
+                    "tokens": {
+                        "input": 10,
+                        "output": 4,
+                        "cached": 1,
+                    },
+                },
+            ],
+        }
+    )
+
+    assert trajectory is not None
+    assert trajectory.agent.name == "runme-antigravity-cli"
+    assert trajectory.agent.model_name == "gemini-3-pro-preview"

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -13,6 +13,7 @@ const (
 
 var runmeAgentSpecs = []runmeAgentSpec{
 	{name: "oracle"},
+	{name: "antigravity-cli", importPath: "runme_harbor.runme_agents:RunmeAntigravityCli"},
 	{name: "codex", importPath: "runme_harbor.runme_agents:RunmeCodex"},
 	{name: "claude-code", importPath: "runme_harbor.runme_agents:RunmeClaudeCode"},
 	{name: "cursor-cli", importPath: "runme_harbor.runme_agents:RunmeCursorCli"},

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -96,6 +96,34 @@ func TestRunEvalDelegatesOracle(t *testing.T) {
 	}
 }
 
+func TestRunEvalDelegatesAntigravityCli(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Agent = "antigravity-cli"
+	opts.Model = "google/gemini-3-pro-preview"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		"--path",
+		mustAbs(t, path),
+		"--jobs-dir", defaultJobsDir(t),
+		"--env", runmeEnvironmentImportPath,
+		"--agent", "runme_harbor.runme_agents:RunmeAntigravityCli",
+		"-y",
+		"--n-concurrent", "1",
+		"--model", "google/gemini-3-pro-preview",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
 func TestRunEvalDefaultsDatasetPath(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)


### PR DESCRIPTION
## Summary

- add `antigravity-cli` to the default Runme eval agent aliases, mapping it to a new `RunmeAntigravityCli` wrapper
- wrap Harbor's upstream Antigravity CLI agent without install/setup bootstrap and report internal metadata as `runme-antigravity-cli`
- move Runme agent import-path metadata out of `cli.py` and into metadata sync
- update Harbor examples and add Python/Go coverage

## Validation

- `uv run pytest tests/test_runme_antigravity_cli.py tests/test_metadata_sync.py tests/test_cli.py`
- `go test ./internal/harbor -run 'Eval|RunEvalDelegatesAntigravityCli'`
- `go test ./cmd -run Eval`
- `uv run ruff check src/runme_harbor/__init__.py src/runme_harbor/cli.py src/runme_harbor/metadata_sync.py src/runme_harbor/runme_agents.py tests/test_cli.py tests/test_metadata_sync.py tests/test_runme_antigravity_cli.py`
- `git diff --check`
- `runme run test`
