### PR TITLE
fix: scope eval compare and promote by dataset

### DIFF
--- a/cmd/eval_compare.go
+++ b/cmd/eval_compare.go
@@ -22,6 +22,7 @@ var newEvalComparer = func(opts harbor.EvalCompareOptions) evalComparer {
 type evalCompareOptions struct {
 	jobsDir       string
 	job           string
+	datasetPath   string
 	base          string
 	format        string
 	includeOracle bool
@@ -39,24 +40,25 @@ func evalCompareCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "compare",
+		Use:   "compare [dataset-path]",
 		Short: "Compare the latest Git-tracked eval job with the latest local eval job",
-		Long: `Compare eval job execution summaries and matching eval results between
-the last Git-tracked eval job and a local candidate eval job. By default, the
-candidate is the newest local job under --jobs-dir. The command is read-only
-and prints an advisory recommendation based on job counters and overlapping
-result rewards. It does not promote, commit, or enforce policy.`,
-		Args: cobra.NoArgs,
+		Long: `Compare eval jobs for a dataset.
+
+When dataset-path is omitted, runme eval compare uses ./` + harbor.DefaultEvalDatasetPath + `.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()
 			opts.stderr = cmd.ErrOrStderr()
+			if len(args) > 0 {
+				opts.datasetPath = args[0]
+			}
 			return runEvalCompare(opts, args)
 		},
 	}
 
 	flags := cmd.Flags()
 	flags.StringVar(&opts.jobsDir, "jobs-dir", "", "Eval jobs directory; defaults to .runme/evals/jobs under the project root")
-	flags.StringVar(&opts.job, "job", "", "Compare against a specific local eval job instead of the newest local job")
+	flags.StringVar(&opts.job, "job", "", "Compare against a specific local eval job")
 	flags.StringVar(&opts.base, "base", "HEAD", "Git ref used to find the tracked baseline eval job")
 	flags.StringVar(&opts.format, "format", "text", "Output format: text or json")
 	flags.BoolVar(&opts.includeOracle, "include-oracle", false, "Allow comparing eval jobs that only used Harbor's oracle agent")
@@ -69,6 +71,7 @@ func runEvalCompare(opts evalCompareOptions, args []string) error {
 	err := newEvalComparer(harbor.EvalCompareOptions{
 		JobsDir:       opts.jobsDir,
 		Job:           opts.job,
+		DatasetPath:   opts.datasetPath,
 		Base:          opts.base,
 		Format:        opts.format,
 		IncludeOracle: opts.includeOracle,

--- a/cmd/eval_compare_test.go
+++ b/cmd/eval_compare_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/runmedev/runme/v3/internal/harbor"
@@ -26,6 +27,7 @@ func TestEvalCompareCmdPassesOptionsToHarborComparer(t *testing.T) {
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
 		"compare",
+		"examples/harbor/datasets/runme-rewardkit",
 		"--jobs-dir", "jobs",
 		"--job", "jobs/job-1",
 		"--base", "HEAD~1",
@@ -45,11 +47,12 @@ func TestEvalCompareCmdPassesOptionsToHarborComparer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(gotArgs, []string(nil)) {
+	if !reflect.DeepEqual(gotArgs, []string{"examples/harbor/datasets/runme-rewardkit"}) {
 		t.Fatalf("args = %#v", gotArgs)
 	}
 	if gotOpts.JobsDir != "jobs" ||
 		gotOpts.Job != "jobs/job-1" ||
+		gotOpts.DatasetPath != "examples/harbor/datasets/runme-rewardkit" ||
 		gotOpts.Base != "HEAD~1" ||
 		gotOpts.Format != "json" ||
 		!gotOpts.IncludeOracle ||
@@ -57,6 +60,18 @@ func TestEvalCompareCmdPassesOptionsToHarborComparer(t *testing.T) {
 		gotOpts.Stdout != &stdout ||
 		gotOpts.Stderr != &stderr {
 		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalCompareCmdRejectsMultipleDatasetPaths(t *testing.T) {
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"compare", "one", "two"})
+	restoreEvalComparer(t, func(harbor.EvalCompareOptions) evalComparer {
+		return fakeEvalComparer{}
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error")
 	}
 }
 
@@ -78,6 +93,29 @@ func TestEvalCompareCmdDefaultsBaseAndFormat(t *testing.T) {
 	}
 	if gotOpts.Format != "text" {
 		t.Fatalf("Format = %q, want text", gotOpts.Format)
+	}
+}
+
+func TestEvalCompareCmdHelpMentionsDatasetDefault(t *testing.T) {
+	cmd := evalCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"compare", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Usage:\n  eval compare [dataset-path] [flags]",
+		"Compare eval jobs for a dataset.",
+		"When dataset-path is omitted, runme eval compare uses ./" + harbor.DefaultEvalDatasetPath + ".",
+		"--job string        Compare against a specific local eval job",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/cmd/eval_promote.go
+++ b/cmd/eval_promote.go
@@ -22,6 +22,7 @@ var newEvalPromoter = func(opts harbor.EvalPromoteOptions) evalPromoter {
 type evalPromoteOptions struct {
 	jobsDir       string
 	job           string
+	datasetPath   string
 	latest        bool
 	dryRun        bool
 	evidenceOnly  bool
@@ -41,12 +42,18 @@ func evalPromoteCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "promote",
+		Use:   "promote [dataset-path]",
 		Short: "Commit staged changes with eval job evidence",
-		Args:  cobra.NoArgs,
+		Long: `Commit staged changes with eval job evidence.
+
+When dataset-path is omitted, runme eval promote uses ./` + harbor.DefaultEvalDatasetPath + `.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()
 			opts.stderr = cmd.ErrOrStderr()
+			if len(args) > 0 {
+				opts.datasetPath = args[0]
+			}
 			return runEvalPromote(opts, args)
 		},
 	}
@@ -70,6 +77,7 @@ func runEvalPromote(opts evalPromoteOptions, args []string) error {
 	err := newEvalPromoter(harbor.EvalPromoteOptions{
 		JobsDir:       opts.jobsDir,
 		Job:           opts.job,
+		DatasetPath:   opts.datasetPath,
 		Latest:        opts.latest,
 		DryRun:        opts.dryRun,
 		EvidenceOnly:  opts.evidenceOnly,

--- a/cmd/eval_promote_test.go
+++ b/cmd/eval_promote_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/runmedev/runme/v3/internal/harbor"
@@ -26,6 +27,7 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 	cmd.SetErr(&stderr)
 	cmd.SetArgs([]string{
 		"promote",
+		"examples/harbor/datasets/runme-rewardkit",
 		"--jobs-dir", "jobs",
 		"--job", "jobs/job-1",
 		"--dry-run",
@@ -48,11 +50,12 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(gotArgs, []string(nil)) {
+	if !reflect.DeepEqual(gotArgs, []string{"examples/harbor/datasets/runme-rewardkit"}) {
 		t.Fatalf("args = %#v", gotArgs)
 	}
 	if gotOpts.JobsDir != "jobs" ||
 		gotOpts.Job != "jobs/job-1" ||
+		gotOpts.DatasetPath != "examples/harbor/datasets/runme-rewardkit" ||
 		!gotOpts.DryRun ||
 		!gotOpts.EvidenceOnly ||
 		!gotOpts.Artifacts ||
@@ -64,6 +67,18 @@ func TestEvalPromoteCmdPassesOptionsToHarborPromoter(t *testing.T) {
 		gotOpts.Stdout != &stdout ||
 		gotOpts.Stderr != &stderr {
 		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalPromoteCmdRejectsMultipleDatasetPaths(t *testing.T) {
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"promote", "one", "two"})
+	restoreEvalPromoter(t, func(harbor.EvalPromoteOptions) evalPromoter {
+		return fakeEvalPromoter{}
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error")
 	}
 }
 
@@ -82,6 +97,30 @@ func TestEvalPromoteCmdPassesLatest(t *testing.T) {
 
 	if !gotOpts.Latest {
 		t.Fatal("Latest = false, want true")
+	}
+}
+
+func TestEvalPromoteCmdHelpMentionsDatasetDefault(t *testing.T) {
+	cmd := evalCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"promote", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Usage:\n  eval promote [dataset-path] [flags]",
+		"Commit staged changes with eval job evidence.",
+		"When dataset-path is omitted, runme eval promote uses ./" + harbor.DefaultEvalDatasetPath + ".",
+		"--job string        Eval job directory to promote",
+		"Promote the latest eval job under --jobs-dir",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/internal/harbor/eval_compare.go
+++ b/internal/harbor/eval_compare.go
@@ -9,6 +9,7 @@ import (
 type EvalCompareOptions struct {
 	JobsDir       string
 	Job           string
+	DatasetPath   string
 	Base          string
 	Format        string
 	IncludeOracle bool
@@ -39,8 +40,11 @@ func NewEvalComparer(opts EvalCompareOptions) *EvalComparer {
 }
 
 func (c *EvalComparer) Run(args []string) error {
-	if len(args) > 0 {
-		return fmt.Errorf("accepts no arguments")
+	if len(args) > 1 {
+		return fmt.Errorf("accepts at most 1 dataset path, received %d", len(args))
+	}
+	if len(args) == 1 {
+		c.opts.DatasetPath = args[0]
 	}
 	if c.opts.Format != "text" && c.opts.Format != "json" {
 		return fmt.Errorf("unsupported format %q; expected text or json", c.opts.Format)
@@ -58,11 +62,16 @@ func (c *EvalComparer) Run(args []string) error {
 			return err
 		}
 	}
+	datasetFilter, err := newEvalDatasetFilter(c.opts.DatasetPath, gitClient)
+	if err != nil {
+		return err
+	}
 
 	base, err := resolveCompareBase(compareBaseOptions{
-		git:      gitClient,
-		baseRef:  c.opts.Base,
-		jobsRoot: paths.jobsDir,
+		git:           gitClient,
+		baseRef:       c.opts.Base,
+		jobsRoot:      paths.jobsDir,
+		datasetFilter: datasetFilter,
 	})
 	if err != nil {
 		return err
@@ -74,6 +83,7 @@ func (c *EvalComparer) Run(args []string) error {
 		includeOracle: c.opts.IncludeOracle,
 		allowErrors:   c.opts.AllowErrors,
 		git:           gitClient,
+		datasetFilter: datasetFilter,
 	})
 	if err != nil {
 		return err

--- a/internal/harbor/eval_compare_job.go
+++ b/internal/harbor/eval_compare_job.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type evalJobRef struct {
@@ -51,9 +52,10 @@ func (j evalJobRef) ComparisonJob(baseRef string) evalComparisonJob {
 }
 
 type compareBaseOptions struct {
-	git      compareGit
-	baseRef  string
-	jobsRoot string
+	git           compareGit
+	baseRef       string
+	jobsRoot      string
+	datasetFilter evalDatasetFilter
 }
 
 type compareCandidateOptions struct {
@@ -62,12 +64,14 @@ type compareCandidateOptions struct {
 	includeOracle bool
 	allowErrors   bool
 	git           compareGit
+	datasetFilter evalDatasetFilter
 }
 
 type evalJobStore struct {
-	jobsDir string
-	git     compareGit
-	policy  promoteJobPolicy
+	jobsDir       string
+	git           compareGit
+	policy        promoteJobPolicy
+	datasetFilter evalDatasetFilter
 }
 
 func (s evalJobStore) LatestTracked(baseRef string) (evalJobRef, error) {
@@ -76,15 +80,15 @@ func (s evalJobStore) LatestTracked(baseRef string) (evalJobRef, error) {
 		return evalJobRef{}, err
 	}
 	for _, job := range jobs {
-		if incompletePromoteJobReason(job.Result) == "" {
+		if incompletePromoteJobReason(job.Result) == "" && s.datasetFilter.matches(job.Config) {
 			return job, nil
 		}
 	}
-	return evalJobRef{}, fmt.Errorf("no complete Git-tracked eval job found under %s at %s", s.jobsDir, baseRef)
+	return evalJobRef{}, fmt.Errorf("no complete Git-tracked eval job found for dataset %s under %s at %s", s.datasetFilter.displayPath(), s.jobsDir, baseRef)
 }
 
 func (s evalJobStore) LatestLocal() (evalJobRef, string, error) {
-	jobDir, selection, err := latestPromoteJob(s.jobsDir, s.policy)
+	jobDir, selection, err := latestPromoteJob(s.jobsDir, s.policy, s.datasetFilter)
 	if err != nil {
 		return evalJobRef{}, "", err
 	}
@@ -120,6 +124,9 @@ func (s evalJobStore) localJob(jobDir, selection string) (evalJobRef, error) {
 	if err := validatePromoteJobPolicy(result, config, s.policy); err != nil {
 		return evalJobRef{}, err
 	}
+	if !s.datasetFilter.matches(config) {
+		return evalJobRef{}, fmt.Errorf("eval job dataset does not match requested dataset %s", s.datasetFilter.displayPath())
+	}
 	jobRel, err := s.git.Rel(jobDir)
 	if err != nil {
 		return evalJobRef{}, err
@@ -139,8 +146,9 @@ func (s evalJobStore) localJob(jobDir, selection string) (evalJobRef, error) {
 
 func resolveCompareBase(opts compareBaseOptions) (compareJob, error) {
 	return evalJobStore{
-		jobsDir: opts.jobsRoot,
-		git:     opts.git,
+		jobsDir:       opts.jobsRoot,
+		git:           opts.git,
+		datasetFilter: opts.datasetFilter,
 	}.LatestTracked(opts.baseRef)
 }
 
@@ -150,9 +158,10 @@ func resolveCompareCandidate(opts compareCandidateOptions) (compareJob, error) {
 		allowErrors:   opts.allowErrors,
 	}
 	store := evalJobStore{
-		jobsDir: opts.jobsDir,
-		git:     opts.git,
-		policy:  policy,
+		jobsDir:       opts.jobsDir,
+		git:           opts.git,
+		policy:        policy,
+		datasetFilter: opts.datasetFilter,
 	}
 	if opts.job == "" {
 		job, _, err := store.LatestLocal()
@@ -160,4 +169,77 @@ func resolveCompareCandidate(opts compareCandidateOptions) (compareJob, error) {
 	}
 	job, _, err := store.ExplicitLocal(opts.job)
 	return job, err
+}
+
+type evalDatasetFilter struct {
+	paths []string
+}
+
+func newEvalDatasetFilter(path string, git interface{ Rel(string) (string, error) }) (evalDatasetFilter, error) {
+	if strings.TrimSpace(path) == "" {
+		path = DefaultEvalDatasetPath
+	}
+
+	var paths []string
+	addPath := func(candidate string) {
+		candidate = normalizeEvalDatasetConfigPath(candidate)
+		if candidate == "" {
+			return
+		}
+		for _, existing := range paths {
+			if existing == candidate {
+				return
+			}
+		}
+		paths = append(paths, candidate)
+	}
+
+	if filepath.IsAbs(path) {
+		rel, err := git.Rel(path)
+		if err != nil {
+			return evalDatasetFilter{}, err
+		}
+		addPath(rel)
+	} else {
+		addPath(path)
+		if normalizeEvalDatasetConfigPath(path) != normalizeEvalDatasetConfigPath(DefaultEvalDatasetPath) {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return evalDatasetFilter{}, err
+			}
+			if rel, err := git.Rel(filepath.Join(cwd, path)); err == nil {
+				addPath(rel)
+			}
+		}
+	}
+	return evalDatasetFilter{paths: paths}, nil
+}
+
+func (f evalDatasetFilter) matches(config promoteJobConfig) bool {
+	if len(f.paths) == 0 {
+		return true
+	}
+	for _, dataset := range config.Datasets {
+		path := normalizeEvalDatasetConfigPath(dataset.Path)
+		for _, want := range f.paths {
+			if path == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (f evalDatasetFilter) displayPath() string {
+	if len(f.paths) == 0 {
+		return DefaultEvalDatasetPath
+	}
+	return f.paths[0]
+}
+
+func normalizeEvalDatasetConfigPath(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(strings.TrimSpace(path)))
 }

--- a/internal/harbor/eval_compare_test.go
+++ b/internal/harbor/eval_compare_test.go
@@ -55,6 +55,115 @@ func TestEvalComparerComparesTrackedBaseWithLatestLocalCandidate(t *testing.T) {
 	}
 }
 
+func TestEvalComparerDefaultsToDefaultDatasetPath(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	unrelatedBaseDir := filepath.Join(jobsRoot, "2026-06-25__11-00-00")
+	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	unrelatedCandidateDir := filepath.Join(jobsRoot, "2026-06-25__12-00-00")
+	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
+	writePromoteJobWithRewardForDataset(t, unrelatedBaseDir, "2026-06-25T11:00:00Z", "examples/other", 1, 1, 0, 1.0)
+	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
+	writePromoteJobWithRewardForDataset(t, unrelatedCandidateDir, "2026-06-25T12:00:00Z", "examples/other", 1, 1, 0, 1.0)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	err := NewEvalComparer(EvalCompareOptions{
+		JobsDir: jobsRoot,
+		Stdout:  &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{
+				localCompareJob(t, tmp, unrelatedBaseDir, "tracked in test"),
+				localCompareJob(t, tmp, baseDir, "tracked in test"),
+			},
+		},
+	}).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Base:   jobs/2026-06-25__09-00-00  tracked in HEAD",
+		"Latest: jobs/2026-06-25__10-00-00  local",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "2026-06-25__11-00-00") || strings.Contains(output, "2026-06-25__12-00-00") {
+		t.Fatalf("output includes unrelated dataset job:\n%s", output)
+	}
+}
+
+func TestEvalComparerDatasetPathFiltersTrackedBaseAndLatestLocalCandidate(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	unrelatedBaseDir := filepath.Join(jobsRoot, "2026-06-25__11-00-00")
+	candidateDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	unrelatedCandidateDir := filepath.Join(jobsRoot, "2026-06-25__12-00-00")
+	writePromoteJobWithRewardForDataset(t, baseDir, "2026-06-25T09:00:00Z", "examples/target", 1, 1, 0, 0.5)
+	writePromoteJobWithRewardForDataset(t, unrelatedBaseDir, "2026-06-25T11:00:00Z", "examples/other", 1, 1, 0, 1.0)
+	writePromoteJobWithRewardForDataset(t, candidateDir, "2026-06-25T10:00:00Z", "examples/target", 1, 1, 0, 0.75)
+	writePromoteJobWithRewardForDataset(t, unrelatedCandidateDir, "2026-06-25T12:00:00Z", "examples/other", 1, 1, 0, 1.0)
+	t.Chdir(tmp)
+
+	var stdout bytes.Buffer
+	err := NewEvalComparer(EvalCompareOptions{
+		JobsDir:     jobsRoot,
+		DatasetPath: "examples/target",
+		Stdout:      &stdout,
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{
+				localCompareJob(t, tmp, unrelatedBaseDir, "tracked in test"),
+				localCompareJob(t, tmp, baseDir, "tracked in test"),
+			},
+		},
+	}).Run(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Base:   jobs/2026-06-25__09-00-00  tracked in HEAD") ||
+		!strings.Contains(output, "Latest: jobs/2026-06-25__10-00-00  local") {
+		t.Fatalf("output selected wrong jobs:\n%s", output)
+	}
+	if strings.Contains(output, "2026-06-25__11-00-00") || strings.Contains(output, "2026-06-25__12-00-00") {
+		t.Fatalf("output includes unrelated dataset job:\n%s", output)
+	}
+}
+
+func TestEvalComparerExplicitJobMustMatchDatasetPath(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithRewardForDataset(t, baseDir, "2026-06-25T09:00:00Z", "examples/target", 1, 1, 0, 0.5)
+	writePromoteJobWithRewardForDataset(t, jobDir, "2026-06-25T10:00:00Z", "examples/other", 1, 1, 0, 0.75)
+	t.Chdir(tmp)
+
+	err := NewEvalComparer(EvalCompareOptions{
+		JobsDir:     jobsRoot,
+		Job:         jobDir,
+		DatasetPath: "examples/target",
+		Git: fakeCompareGit{
+			root: cleanExistingPath(tmp),
+			jobs: []compareJob{localCompareJob(t, tmp, baseDir, "tracked in test")},
+		},
+	}).Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "does not match requested dataset examples/target") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
 func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	tmp := t.TempDir()
 	jobsRoot := filepath.Join(tmp, "jobs")
@@ -63,7 +172,7 @@ func TestEvalComparerJSONOutputIsSmallComparisonObject(t *testing.T) {
 	writePromoteJobWithReward(t, baseDir, "2026-06-25T09:00:00Z", 1, 1, 0, 0.5)
 	writePromoteJobWithReward(t, candidateDir, "2026-06-25T10:00:00Z", 1, 1, 0, 0.75)
 	config := `{
-		"datasets": [{"path": "dataset"}],
+		"datasets": [{"path": "` + DefaultEvalDatasetPath + `"}],
 		"agents": [{"name": "runme-codex", "model_name": "model"}],
 		"environment": {"type": "runme"}
 	}`
@@ -898,10 +1007,20 @@ func localCompareJob(t *testing.T, root, jobDir, selection string) compareJob {
 
 func writePromoteJobWithReward(t *testing.T, jobDir, finishedAt string, total, completed, errors int, reward float64) {
 	t.Helper()
-	writePromoteJobWithRewardAgent(t, jobDir, finishedAt, "runme-codex", total, completed, errors, reward)
+	writePromoteJobWithRewardAgentForDataset(t, jobDir, finishedAt, "runme-codex", DefaultEvalDatasetPath, total, completed, errors, reward)
 }
 
 func writePromoteJobWithRewardAgent(t *testing.T, jobDir, finishedAt, agent string, total, completed, errors int, reward float64) {
+	t.Helper()
+	writePromoteJobWithRewardAgentForDataset(t, jobDir, finishedAt, agent, DefaultEvalDatasetPath, total, completed, errors, reward)
+}
+
+func writePromoteJobWithRewardForDataset(t *testing.T, jobDir, finishedAt, datasetPath string, total, completed, errors int, reward float64) {
+	t.Helper()
+	writePromoteJobWithRewardAgentForDataset(t, jobDir, finishedAt, "runme-codex", datasetPath, total, completed, errors, reward)
+}
+
+func writePromoteJobWithRewardAgentForDataset(t *testing.T, jobDir, finishedAt, agent, datasetPath string, total, completed, errors int, reward float64) {
 	t.Helper()
 	writePromoteJob(t, jobDir, finishedAt)
 	result := fmt.Sprintf(`{
@@ -923,8 +1042,18 @@ func writePromoteJobWithRewardAgent(t *testing.T, jobDir, finishedAt, agent stri
 	}`, finishedAt, finishedAt, finishedAt, total, completed, errors, agent, total, errors, reward)
 	writeFile(t, filepath.Join(jobDir, "result.json"), result)
 	config := `{
-		"datasets": [{"path": "dataset", "task_names": ["task"]}],
+		"datasets": [{"path": "` + datasetPath + `", "task_names": ["task"]}],
 		"agents": [{"name": "` + agent + `", "model_name": "model"}],
+		"environment": {"type": "runme"}
+	}`
+	writeFile(t, filepath.Join(jobDir, "config.json"), config)
+}
+
+func writePromoteJobConfigForDataset(t *testing.T, jobDir, datasetPath string) {
+	t.Helper()
+	config := `{
+		"datasets": [{"path": "` + datasetPath + `", "task_names": ["task"]}],
+		"agents": [{"name": "runme-codex", "model_name": "model"}],
 		"environment": {"type": "runme"}
 	}`
 	writeFile(t, filepath.Join(jobDir, "config.json"), config)

--- a/internal/harbor/eval_promote.go
+++ b/internal/harbor/eval_promote.go
@@ -15,6 +15,7 @@ const (
 type EvalPromoteOptions struct {
 	JobsDir       string
 	Job           string
+	DatasetPath   string
 	Latest        bool
 	DryRun        bool
 	EvidenceOnly  bool
@@ -46,8 +47,11 @@ func NewEvalPromoter(opts EvalPromoteOptions) *EvalPromoter {
 }
 
 func (p *EvalPromoter) Run(args []string) error {
-	if len(args) > 0 {
-		return fmt.Errorf("accepts no arguments")
+	if len(args) > 1 {
+		return fmt.Errorf("accepts at most 1 dataset path, received %d", len(args))
+	}
+	if len(args) == 1 {
+		p.opts.DatasetPath = args[0]
 	}
 	if p.opts.Job == "" && !p.opts.Latest {
 		return fmt.Errorf("one of --job or --latest is required")
@@ -69,15 +73,20 @@ func (p *EvalPromoter) Run(args []string) error {
 			return err
 		}
 	}
+	datasetFilter, err := newEvalDatasetFilter(p.opts.DatasetPath, gitClient)
+	if err != nil {
+		return err
+	}
 
 	policy := promoteJobPolicy{
 		includeOracle: p.opts.IncludeOracle,
 		allowErrors:   p.opts.AllowErrors,
 	}
 	store := evalJobStore{
-		jobsDir: jobsRoot,
-		git:     gitClient,
-		policy:  policy,
+		jobsDir:       jobsRoot,
+		git:           gitClient,
+		policy:        policy,
+		datasetFilter: datasetFilter,
 	}
 
 	var candidate evalJobRef
@@ -96,12 +105,12 @@ func (p *EvalPromoter) Run(args []string) error {
 		return err
 	}
 	if p.opts.Latest {
-		candidate.Selection = fmt.Sprintf("latest job under %s", jobsRel)
+		candidate.Selection = fmt.Sprintf("latest job under %s for dataset %s", jobsRel, datasetFilter.displayPath())
 	}
-	if warning := newerPromotableJobWarning(jobsRoot, jobDir, candidate.Result, policy); warning != "" {
+	if warning := newerPromotableJobWarning(jobsRoot, jobDir, candidate.Result, policy, datasetFilter); warning != "" {
 		_, _ = fmt.Fprintf(p.opts.Stderr, "warning: %s under %s; newer eval jobs were skipped\n\n", warning, jobsRel)
 	}
-	comparison, hasComparison, err := p.comparison(jobsRoot, candidate, gitClient)
+	comparison, hasComparison, err := p.comparison(jobsRoot, candidate, gitClient, datasetFilter)
 	if err != nil {
 		return err
 	}
@@ -193,10 +202,11 @@ func (p *EvalPromoter) Run(args []string) error {
 	return nil
 }
 
-func (p *EvalPromoter) comparison(jobsRoot string, candidate evalJobRef, gitClient compareGit) (evalComparison, bool, error) {
+func (p *EvalPromoter) comparison(jobsRoot string, candidate evalJobRef, gitClient compareGit, datasetFilter evalDatasetFilter) (evalComparison, bool, error) {
 	base, err := (evalJobStore{
-		jobsDir: jobsRoot,
-		git:     gitClient,
+		jobsDir:       jobsRoot,
+		git:           gitClient,
+		datasetFilter: datasetFilter,
 	}).LatestTracked(promoteComparisonBaseRef)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "no complete Git-tracked eval job found") {

--- a/internal/harbor/eval_promote_job.go
+++ b/internal/harbor/eval_promote_job.go
@@ -13,6 +13,7 @@ import (
 type promoteJobOptions struct {
 	jobsDir       string
 	job           string
+	datasetPath   string
 	latest        bool
 	includeOracle bool
 	allowErrors   bool
@@ -77,12 +78,16 @@ func resolvePromoteJob(opts promoteJobOptions) (jobsRoot, jobDir, selection stri
 		return "", "", "", err
 	}
 	jobsRoot = paths.jobsDir
+	datasetFilter, err := newEvalDatasetFilter(opts.datasetPath, goGitRelAdapter{})
+	if err != nil {
+		return "", "", "", err
+	}
 
 	if opts.latest {
 		jobDir, selection, err = latestPromoteJob(jobsRoot, promoteJobPolicy{
 			includeOracle: opts.includeOracle,
 			allowErrors:   opts.allowErrors,
-		})
+		}, datasetFilter)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -101,6 +106,13 @@ func resolvePromoteJob(opts promoteJobOptions) (jobsRoot, jobDir, selection stri
 	if err := validatePromoteJobDir(jobsRoot, jobDir); err != nil {
 		return "", "", "", err
 	}
+	config, err := readPromoteJobConfig(jobDir)
+	if err != nil {
+		return "", "", "", err
+	}
+	if !datasetFilter.matches(config) {
+		return "", "", "", fmt.Errorf("eval job dataset does not match requested dataset %s", datasetFilter.displayPath())
+	}
 	return jobsRoot, jobDir, "explicit --job", nil
 }
 
@@ -109,7 +121,7 @@ type promoteJobPolicy struct {
 	allowErrors   bool
 }
 
-func latestPromoteJob(jobsRoot string, policy promoteJobPolicy) (string, string, error) {
+func latestPromoteJob(jobsRoot string, policy promoteJobPolicy, datasetFilter evalDatasetFilter) (string, string, error) {
 	entries, err := os.ReadDir(jobsRoot)
 	if err != nil {
 		return "", "", err
@@ -128,6 +140,9 @@ func latestPromoteJob(jobsRoot string, policy promoteJobPolicy) (string, string,
 		if err != nil {
 			continue
 		}
+		if !datasetFilter.matches(config) {
+			continue
+		}
 		if err := validatePromoteJobPolicy(result, config, policy); err != nil {
 			continue
 		}
@@ -141,7 +156,7 @@ func latestPromoteJob(jobsRoot string, policy promoteJobPolicy) (string, string,
 		})
 	}
 	if len(candidates) == 0 {
-		return "", "", fmt.Errorf("no promotable eval jobs found under %s; use --include-oracle for oracle-only jobs or --allow-errors for errored jobs", jobsRoot)
+		return "", "", fmt.Errorf("no promotable eval jobs found for dataset %s under %s; use --include-oracle for oracle-only jobs or --allow-errors for errored jobs", datasetFilter.displayPath(), jobsRoot)
 	}
 	sort.Slice(candidates, func(i, j int) bool {
 		left, right := candidates[i], candidates[j]
@@ -155,7 +170,7 @@ func latestPromoteJob(jobsRoot string, policy promoteJobPolicy) (string, string,
 		}
 		return left.modTime.After(right.modTime)
 	})
-	return candidates[0].dir, "latest job under --jobs-dir", nil
+	return candidates[0].dir, fmt.Sprintf("latest job under --jobs-dir for dataset %s", datasetFilter.displayPath()), nil
 }
 
 func validatePromoteJobPolicy(result promoteJobResult, config promoteJobConfig, policy promoteJobPolicy) error {
@@ -171,7 +186,7 @@ func validatePromoteJobPolicy(result promoteJobResult, config promoteJobConfig, 
 	return nil
 }
 
-func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult promoteJobResult, policy promoteJobPolicy) string {
+func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult promoteJobResult, policy promoteJobPolicy, datasetFilter evalDatasetFilter) string {
 	entries, err := os.ReadDir(jobsRoot)
 	if err != nil {
 		return ""
@@ -195,11 +210,14 @@ func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult p
 		if !isPromoteJobNewer(result, entry.Name(), selectedTimestamp, selectedName) {
 			continue
 		}
-		foundNewer = true
 		config, err := readPromoteJobConfig(dir)
 		if err != nil {
 			continue
 		}
+		if !datasetFilter.matches(config) {
+			continue
+		}
+		foundNewer = true
 		if validatePromoteJobPolicy(result, config, policy) == nil {
 			return ""
 		}
@@ -208,6 +226,24 @@ func newerPromotableJobWarning(jobsRoot, selectedJobDir string, selectedResult p
 		return ""
 	}
 	return "using latest complete promotable eval job"
+}
+
+type goGitRelAdapter struct{}
+
+func (goGitRelAdapter) Rel(path string) (string, error) {
+	path = cleanExistingPath(path)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(cleanExistingPath(cwd), path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %s is outside current working directory %s", path, cwd)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 func isPromoteJobNewer(result promoteJobResult, name string, selectedTimestamp time.Time, selectedName string) bool {

--- a/internal/harbor/eval_promote_job_test.go
+++ b/internal/harbor/eval_promote_job_test.go
@@ -71,7 +71,7 @@ func TestResolvePromoteJobLatestUsesHarborTimestamps(t *testing.T) {
 	if gotJobDir != cleanExistingPath(newJob) {
 		t.Fatalf("jobDir = %q, want %q", gotJobDir, cleanExistingPath(newJob))
 	}
-	if selection != "latest job under --jobs-dir" {
+	if selection != "latest job under --jobs-dir for dataset "+DefaultEvalDatasetPath {
 		t.Fatalf("selection = %q", selection)
 	}
 }
@@ -289,7 +289,10 @@ func writePromoteJobWithAgent(t *testing.T, jobDir, finishedAt, agent string, er
 	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte(result), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	config := `{"agents":[{"name":"` + agent + `"}]}`
+	config := `{
+		"datasets": [{"path": "` + DefaultEvalDatasetPath + `"}],
+		"agents": [{"name":"` + agent + `"}]
+	}`
 	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte(config), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +320,11 @@ func writeIncompletePromoteJob(t *testing.T, jobDir, finishedAt string, running,
 	if err := os.WriteFile(filepath.Join(jobDir, "result.json"), []byte(result), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte(`{"agents":[{"name":"codex"}]}`), 0o644); err != nil {
+	config := `{
+		"datasets": [{"path": "` + DefaultEvalDatasetPath + `"}],
+		"agents": [{"name":"codex"}]
+	}`
+	if err := os.WriteFile(filepath.Join(jobDir, "config.json"), []byte(config), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/harbor/eval_promote_test.go
+++ b/internal/harbor/eval_promote_test.go
@@ -144,6 +144,137 @@ func TestEvalPromoterDoesNotWarnWhenNewerPromotableJobExists(t *testing.T) {
 	}
 }
 
+func TestEvalPromoterLatestDefaultsToDefaultDatasetPath(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	selectedJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	unrelatedJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, selectedJob, "2026-06-25T09:00:00Z")
+	writePromoteJobWithRewardForDataset(t, unrelatedJob, "2026-06-25T10:00:00Z", "examples/other", 1, 1, 0, 1.0)
+
+	var stdout bytes.Buffer
+	gitClient := &recordingPromoteGit{
+		root:     tmp,
+		jobFiles: []string{"jobs/2026-06-25__09-00-00/result.json"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		DryRun:  true,
+		Stdout:  &stdout,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Selected eval job: jobs/2026-06-25__09-00-00") {
+		t.Fatalf("stdout = %q", output)
+	}
+	if strings.Contains(output, "2026-06-25__10-00-00") {
+		t.Fatalf("stdout includes unrelated dataset job: %q", output)
+	}
+}
+
+func TestEvalPromoterLatestFiltersByDatasetPathAndComparisonBase(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	baseDir := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	unrelatedBaseDir := filepath.Join(jobsRoot, "2026-06-25__11-00-00")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	unrelatedJobDir := filepath.Join(jobsRoot, "2026-06-25__12-00-00")
+	writePromoteJobWithRewardForDataset(t, baseDir, "2026-06-25T09:00:00Z", "examples/target", 1, 1, 0, 0.5)
+	writePromoteJobWithRewardForDataset(t, unrelatedBaseDir, "2026-06-25T11:00:00Z", "examples/other", 1, 1, 0, 1.0)
+	writePromoteJobWithRewardForDataset(t, jobDir, "2026-06-25T10:00:00Z", "examples/target", 1, 1, 0, 0.75)
+	writePromoteJobWithRewardForDataset(t, unrelatedJobDir, "2026-06-25T12:00:00Z", "examples/other", 1, 1, 0, 1.0)
+
+	var stdout bytes.Buffer
+	gitClient := &recordingPromoteGit{
+		root: tmp,
+		trackedJobs: []evalJobRef{
+			localCompareJob(t, tmp, unrelatedBaseDir, "tracked in test"),
+			localCompareJob(t, tmp, baseDir, "tracked in test"),
+		},
+		jobFiles: []string{"jobs/2026-06-25__10-00-00/result.json"},
+	}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:     jobsRoot,
+		DatasetPath: "examples/target",
+		Latest:      true,
+		DryRun:      true,
+		Stdout:      &stdout,
+		Git:         gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"Selected eval job: jobs/2026-06-25__10-00-00",
+		"Base:   jobs/2026-06-25__09-00-00  tracked in HEAD",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "2026-06-25__11-00-00") || strings.Contains(output, "2026-06-25__12-00-00") {
+		t.Fatalf("stdout includes unrelated dataset job:\n%s", output)
+	}
+}
+
+func TestEvalPromoterExplicitJobMustMatchDatasetPath(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	jobDir := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJobWithRewardForDataset(t, jobDir, "2026-06-25T10:00:00Z", "examples/other", 1, 1, 0, 0.75)
+
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir:     jobsRoot,
+		Job:         jobDir,
+		DatasetPath: "examples/target",
+		DryRun:      true,
+		Git:         gitClient,
+	})
+
+	err := promoter.Run(nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "does not match requested dataset examples/target") {
+		t.Fatalf("error = %q", err.Error())
+	}
+}
+
+func TestEvalPromoterNewerJobWarningIgnoresOtherDatasets(t *testing.T) {
+	tmp := t.TempDir()
+	jobsRoot := filepath.Join(tmp, "jobs")
+	selectedJob := filepath.Join(jobsRoot, "2026-06-25__09-00-00")
+	incompleteOtherDatasetJob := filepath.Join(jobsRoot, "2026-06-25__10-00-00")
+	writePromoteJob(t, selectedJob, "2026-06-25T09:00:00Z")
+	writeIncompletePromoteJob(t, incompleteOtherDatasetJob, "2026-06-25T10:00:00Z", 0, 1, 0)
+	writePromoteJobConfigForDataset(t, incompleteOtherDatasetJob, "examples/other")
+
+	var stderr bytes.Buffer
+	gitClient := &recordingPromoteGit{root: tmp}
+	promoter := NewEvalPromoter(EvalPromoteOptions{
+		JobsDir: jobsRoot,
+		Latest:  true,
+		DryRun:  true,
+		Stderr:  &stderr,
+		Git:     gitClient,
+	})
+
+	if err := promoter.Run(nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := stderr.String(); strings.Contains(got, "newer eval jobs were skipped") {
+		t.Fatalf("stderr = %q", got)
+	}
+}
+
 func TestEvalPromoterDryRunShowsCompareGateWithoutFailing(t *testing.T) {
 	tmp := t.TempDir()
 	jobsRoot := filepath.Join(tmp, "jobs")


### PR DESCRIPTION
## Summary
- add optional dataset path support to `runme eval compare` and `runme eval promote`
- default compare/promote dataset filtering to `evals/tasks`, matching `runme eval`
- filter tracked baselines, latest local candidates, explicit jobs, and newer-job warnings by dataset path
- add coverage for default filtering, explicit dataset paths, explicit `--job` mismatch validation, and command argument wiring

## Testing
- `go test ./internal/harbor -run 'EvalCompare|EvalPromote|PromoteJob'`\n- `go test ./cmd -run Eval`\n- `runme run test`