### PR TITLE
fix: address harbor release review findings

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -119,15 +118,7 @@ func runEval(opts evalOptions, args []string) error {
 	if errors.Is(err, harbor.ErrRunmeHarborMissing) {
 		return fmt.Errorf("`runme eval` requires the optional Python package `runme-harbor`.\n\nInstall it with:\n  uv tool install runme-harbor\n\nThen retry:\n  runme eval\n\nOr pass a dataset path explicitly:\n  runme eval <dataset-path>")
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
-	}
-	var codeErr interface{ ExitCode() int }
-	if errors.As(err, &codeErr) {
-		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
-	}
-	return err
+	return asExitCodeError(err)
 }
 
 func validateEvalArgs(_ *cobra.Command, args []string) error {

--- a/cmd/eval_compare.go
+++ b/cmd/eval_compare.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 
@@ -79,16 +77,5 @@ func runEvalCompare(opts evalCompareOptions, args []string) error {
 		Stdout:        opts.stdout,
 		Stderr:        opts.stderr,
 	}).Run(args)
-	if err == nil {
-		return nil
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
-	}
-	var codeErr interface{ ExitCode() int }
-	if errors.As(err, &codeErr) {
-		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
-	}
-	return err
+	return asExitCodeError(err)
 }

--- a/cmd/eval_promote.go
+++ b/cmd/eval_promote.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"errors"
 	"io"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 
@@ -89,16 +87,5 @@ func runEvalPromote(opts evalPromoteOptions, args []string) error {
 		Stdout:        opts.stdout,
 		Stderr:        opts.stderr,
 	}).Run(args)
-	if err == nil {
-		return nil
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
-	}
-	var codeErr interface{ ExitCode() int }
-	if errors.As(err, &codeErr) {
-		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
-	}
-	return err
+	return asExitCodeError(err)
 }

--- a/cmd/eval_view.go
+++ b/cmd/eval_view.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 
@@ -75,13 +74,5 @@ func runEvalView(opts evalViewOptions, args []string) error {
 	if errors.Is(err, harbor.ErrRunmeHarborMissing) {
 		return fmt.Errorf("`runme eval view` requires the optional Python package `runme-harbor`.\n\nInstall it with:\n  uv tool install runme-harbor\n\nThen retry:\n  runme eval view")
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
-	}
-	var codeErr interface{ ExitCode() int }
-	if errors.As(err, &codeErr) {
-		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
-	}
-	return err
+	return asExitCodeError(err)
 }

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -1,8 +1,32 @@
 package cmd
 
+import (
+	"errors"
+	"os/exec"
+)
+
 type ExitCodeError struct {
 	Code int
 	Err  error
+}
+
+// asExitCodeError maps an error that carries a process exit code into an
+// ExitCodeError, but only when the code is non-zero. A zero code from a
+// non-nil error must not be reported as success; such errors are returned
+// unchanged so the top-level handler exits with a failing status.
+func asExitCodeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
+		return ExitCodeError{Code: exitErr.ExitCode(), Err: err}
+	}
+	var codeErr interface{ ExitCode() int }
+	if errors.As(err, &codeErr) && codeErr.ExitCode() != 0 {
+		return ExitCodeError{Code: codeErr.ExitCode(), Err: err}
+	}
+	return err
 }
 
 func (e ExitCodeError) Error() string {

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type codeError struct {
+	code int
+}
+
+func (e codeError) Error() string { return "code error" }
+
+func (e codeError) ExitCode() int { return e.code }
+
+func TestAsExitCodeError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		require.NoError(t, asExitCodeError(nil))
+	})
+
+	t.Run("non-zero code is wrapped", func(t *testing.T) {
+		err := asExitCodeError(codeError{code: 2})
+		var exitErr ExitCodeError
+		require.ErrorAs(t, err, &exitErr)
+		require.Equal(t, 2, exitErr.Code)
+	})
+
+	t.Run("zero code is not reported as success", func(t *testing.T) {
+		src := codeError{code: 0}
+		err := asExitCodeError(src)
+		var exitErr ExitCodeError
+		require.False(t, errors.As(err, &exitErr), "zero exit code must not be wrapped as ExitCodeError")
+		require.ErrorIs(t, err, src)
+	})
+
+	t.Run("plain error passes through", func(t *testing.T) {
+		src := errors.New("boom")
+		require.ErrorIs(t, asExitCodeError(src), src)
+	})
+}

--- a/integrations/harbor/src/runme_harbor/environment.py
+++ b/integrations/harbor/src/runme_harbor/environment.py
@@ -310,7 +310,10 @@ class RunmeEnvironment(BaseEnvironment):
             source,
             target,
             symlinks=False,
-            ignore=_gitignore_filter(self._workspace_root),
+            # Exclude the trial root so that staging the whole workspace (the
+            # not-a-dir fallback above) cannot recurse into its own destination
+            # when self._root lives under the workspace.
+            ignore=_gitignore_filter(self._workspace_root, exclude=(self._root,)),
         )
         self._staged_workdir_remote = remote
         self._staged_workdir_host = target
@@ -318,7 +321,13 @@ class RunmeEnvironment(BaseEnvironment):
     def _resolved_task_workdir(self) -> Path:
         if self._staged_workdir_host:
             return self._staged_workdir_host
-        return self._map_remote_path(self.task_env_config.workdir or "/app")
+        try:
+            return self._map_remote_path(self.task_env_config.workdir or "/app")
+        except ValueError:
+            # A workdir that cannot be mapped into the Runme Harbor root (e.g. an
+            # absolute path outside /app) must not abort start(); fall back to the
+            # workspace root, matching the default for an unset workdir.
+            return self._workspace_root
 
     def _runtime_env(self) -> dict[str, str]:
         verifier_dir = self._root / "verifier"
@@ -487,12 +496,18 @@ def _env_map_to_list(*maps: dict[str, str] | None) -> list[str]:
     return [f"{key}={value}" for key, value in sorted(env.items())]
 
 
-def _gitignore_filter(workspace_root: Path):
+def _gitignore_filter(workspace_root: Path, exclude: tuple[Path, ...] = ()):
+    excluded_roots = {path.resolve() for path in exclude}
+
     def ignore(dir_path: str, names: list[str]) -> set[str]:
         ignored = set()
         base = Path(dir_path)
         for name in names:
-            if _is_git_ignored(workspace_root, base / name):
+            candidate = base / name
+            if excluded_roots and candidate.resolve() in excluded_roots:
+                ignored.add(name)
+                continue
+            if _is_git_ignored(workspace_root, candidate):
                 ignored.add(name)
         return ignored
 

--- a/integrations/harbor/tests/test_environment.py
+++ b/integrations/harbor/tests/test_environment.py
@@ -227,6 +227,57 @@ def test_missing_nested_configured_workdir_stages_workspace_root(
     assert configured_workdir not in request["command"]
 
 
+def test_absolute_workdir_outside_app_falls_back_to_workspace_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    environment = _make_env(
+        tmp_path,
+        task_env_config=EnvironmentConfig(
+            workdir="/workspace",
+            env={"TASK_ENV": "yes"},
+        ),
+    )
+
+    # An absolute workdir outside /app cannot be mapped into the Harbor root and
+    # must not abort start(); RUNME_TASK_WORKDIR falls back to the workspace root.
+    asyncio.run(environment.start(force_build=False))
+
+    env = FakeClient.instances[0].requests[0]["start"]["env"]
+    assert f"RUNME_TASK_WORKDIR={tmp_path}" in env
+
+
+def test_missing_configured_workdir_does_not_recurse_into_trial_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    FakeClient.instances.clear()
+    monkeypatch.setattr(env_module, "_StdioClient", FakeClient)
+
+    # Trial root lives under the workspace, so staging the whole workspace (the
+    # not-a-dir fallback) must not copy the trial dir into its own destination.
+    (tmp_path / "go.mod").write_text("module example.com/repo\n")
+
+    configured_workdir = "/app/does-not-exist"
+    environment = _make_env(
+        tmp_path,
+        workspace_root=tmp_path,
+        task_env_config=EnvironmentConfig(
+            workdir=configured_workdir,
+            env={"TASK_ENV": "yes"},
+        ),
+    )
+
+    asyncio.run(environment.start(force_build=False))
+
+    staged = tmp_path / "trial" / "workdir"
+    assert (staged / "go.mod").read_text() == "module example.com/repo\n"
+    assert not (staged / "trial").exists()
+
+
 def test_runtime_task_workdir_overrides_configured_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/internal/dockerexec/cmd.go
+++ b/internal/dockerexec/cmd.go
@@ -90,11 +90,23 @@ func (c *Cmd) Start() error {
 	}
 
 	c.containerID = resp.ID
+
+	// Wait() owns container cleanup, but callers do not call Wait() when Start()
+	// returns an error, so remove the container here on any failed start.
+	started := false
+	defer func() {
+		if !started {
+			if rmErr := c.removeContainer(); rmErr != nil {
+				c.logger.Warn("failed to remove container after Start error", zap.Error(rmErr))
+			}
+		}
+	}()
+
 	c.waitRespC, c.waitErrC = c.docker.client.ContainerWait(
 		c.ctx,
 		c.containerID,
-		// It's ok to wait for the "removed" state
-		// because the container is started with auto-remove.
+		// Wait for the "next exit" state; the container is removed manually by
+		// Wait()/removeContainer() rather than by daemon auto-remove.
 		container.WaitConditionNextExit,
 	)
 
@@ -161,6 +173,7 @@ func (c *Cmd) Start() error {
 		Pid: inspect.State.Pid,
 	}
 
+	started = true
 	return nil
 }
 

--- a/internal/dockerexec/docker_test.go
+++ b/internal/dockerexec/docker_test.go
@@ -5,7 +5,6 @@ package dockerexec
 import (
 	"bytes"
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -48,10 +47,11 @@ func TestDockerCommandContext(t *testing.T) {
 	})
 
 	t.Run("CleanupOnStartError", func(t *testing.T) {
-		cmd := docker.CommandContext(context.Background(), "true")
-		// A bind source that does not exist makes ContainerStart fail after the
-		// container has already been created, exercising the Start() error path.
-		cmd.Dir = filepath.Join(workingDir, "does-not-exist")
+		// A nonexistent entrypoint is created successfully but fails at
+		// ContainerStart, exercising the Start() error path after the container
+		// already exists.
+		cmd := docker.CommandContext(context.Background(), "this-command-does-not-exist")
+		cmd.Dir = workingDir
 
 		require.Error(t, cmd.Start())
 		require.NotEmpty(t, cmd.containerID, "expected container to be created before the failure")

--- a/internal/dockerexec/docker_test.go
+++ b/internal/dockerexec/docker_test.go
@@ -5,6 +5,7 @@ package dockerexec
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -44,6 +45,18 @@ func TestDockerCommandContext(t *testing.T) {
 		require.NoError(t, cmd.Wait())
 		_, err = docker.client.ContainerInspect(context.Background(), cmd.containerID)
 		require.True(t, errdefs.IsNotFound(err), "expected container to be removed, got %v", err)
+	})
+
+	t.Run("CleanupOnStartError", func(t *testing.T) {
+		cmd := docker.CommandContext(context.Background(), "true")
+		// A bind source that does not exist makes ContainerStart fail after the
+		// container has already been created, exercising the Start() error path.
+		cmd.Dir = filepath.Join(workingDir, "does-not-exist")
+
+		require.Error(t, cmd.Start())
+		require.NotEmpty(t, cmd.containerID, "expected container to be created before the failure")
+		_, err := docker.client.ContainerInspect(context.Background(), cmd.containerID)
+		require.True(t, errdefs.IsNotFound(err), "expected container to be removed after Start error, got %v", err)
 	})
 
 	t.Run("DebugLeavesContainer", func(t *testing.T) {

--- a/internal/harbor/eval_promote_job.go
+++ b/internal/harbor/eval_promote_job.go
@@ -147,12 +147,15 @@ func latestPromoteJob(jobsRoot string, policy promoteJobPolicy, datasetFilter ev
 			continue
 		}
 		timestamp := resultTimestamp(result)
-		info, _ := entry.Info()
+		var modTime time.Time
+		if info, err := entry.Info(); err == nil {
+			modTime = info.ModTime()
+		}
 		candidates = append(candidates, promoteJobCandidate{
 			dir:       dir,
 			name:      entry.Name(),
 			timestamp: timestamp,
-			modTime:   info.ModTime(),
+			modTime:   modTime,
 		})
 	}
 	if len(candidates) == 0 {


### PR DESCRIPTION
## Summary

Follow-up fixes from reviewing the `runme-harbor-v0.0.3..HEAD` (v0.0.6) release diff. Each item is a defect the review surfaced, ranked by severity.

- **Docker container leak on `Start()` error (must-fix).** Container cleanup moved from daemon `AutoRemove` to `Wait()`, but the caller returns on a `Start()` error without ever calling `Wait()`, so every container created before a mid-`Start` failure (`ContainerAttach`/`ContainerStart`/`ContainerInspect`) leaked. Added a deferred, success-guarded `removeContainer()` in `Start()`; debug mode still keeps containers. Also fixed the now-stale auto-remove comment.
- **`start()` crash for a workdir outside `/app`.** `_runtime_env()` eagerly resolved the task workdir and raised `ValueError` for any absolute workdir not under `/app`, aborting the trial. Now falls back to the workspace root.
- **copytree-into-itself footgun.** The "not a dir" staging fallback copies the whole workspace; when the trial root lives under the workspace it could recurse into its own destination. The trial root is now excluded from the copy.
- **Nil-pointer panic in `latestPromoteJob`.** `entry.Info()`'s error was swallowed and `info.ModTime()` dereferenced a nil `info` if the dir entry became stat-unreadable after `ReadDir`. Now guarded; `modTime` is only a sort tiebreaker.
- **`ExitCode()==0` masked failures.** The exit-code mapping (duplicated across four `eval` commands) wrapped any error exposing `ExitCode()` without checking it was non-zero, so a failing command reporting exit 0 exited successfully. Consolidated into a shared `asExitCodeError` helper that only wraps non-zero codes.

## Test plan

- `TZ=UTC go test ./cmd/... ./internal/harbor/...` — pass
- `go vet -tags docker_enabled ./internal/dockerexec/` — pass (new `CleanupOnStartError` subtest; the docker suite is gated behind `docker_enabled` and requires a daemon)
- `uv run pytest` in `integrations/harbor` — 74 pass (adds workdir-fallback and no-recursion cases)
- `gofumpt` clean; `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)