### PR TITLE
Add eval task scaffold command

### DIFF
--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -89,6 +89,7 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	cmd.AddCommand(evalViewCmd())
 	cmd.AddCommand(evalPromoteCmd())
 	cmd.AddCommand(evalCompareCmd())
+	cmd.AddCommand(evalTaskCmd())
 
 	return cmd
 }

--- a/cmd/eval_task.go
+++ b/cmd/eval_task.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type evalTaskNewer interface {
+	Run(args []string) error
+}
+
+var newEvalTaskNewer = func(opts harbor.EvalTaskNewOptions) evalTaskNewer {
+	return harbor.NewEvalTaskNewer(opts)
+}
+
+type evalTaskNewOptions struct {
+	tasksDir    string
+	org         string
+	description string
+	authors     []string
+	noSolution  bool
+	force       bool
+	stdout      io.Writer
+	stderr      io.Writer
+}
+
+func evalTaskCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "task",
+		Short: "Manage Harbor eval tasks",
+	}
+
+	cmd.AddCommand(evalTaskNewCmd())
+
+	return cmd
+}
+
+func evalTaskNewCmd() *cobra.Command {
+	opts := evalTaskNewOptions{
+		tasksDir: harbor.DefaultEvalDatasetPath,
+		stdout:   os.Stdout,
+		stderr:   os.Stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "new <org/name>",
+		Short: "Create a Harbor eval task for Runme",
+		Long: `Create a Harbor eval task scaffold for Runme.
+
+When --tasks-dir is omitted, runme eval task new writes under ./` + harbor.DefaultEvalDatasetPath + `.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.stdout = cmd.OutOrStdout()
+			opts.stderr = cmd.ErrOrStderr()
+			return runEvalTaskNew(opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.tasksDir, "tasks-dir", harbor.DefaultEvalDatasetPath, "Eval tasks directory")
+	flags.StringVar(&opts.org, "org", "", "Organization name for bare task names")
+	flags.StringVar(&opts.description, "description", "", "Task description")
+	flags.StringArrayVar(&opts.authors, "author", nil, "Author in 'Name <email>' or 'Name' format; can be repeated")
+	flags.BoolVar(&opts.noSolution, "no-solution", false, "Do not include solution template")
+	flags.BoolVar(&opts.force, "force", false, "Overwrite scaffold-owned files in an existing task directory")
+
+	return cmd
+}
+
+func runEvalTaskNew(opts evalTaskNewOptions, args []string) error {
+	err := newEvalTaskNewer(harbor.EvalTaskNewOptions{
+		TasksDir:    opts.tasksDir,
+		Org:         opts.org,
+		Description: opts.description,
+		Authors:     opts.authors,
+		NoSolution:  opts.noSolution,
+		Force:       opts.force,
+		Stdout:      opts.stdout,
+		Stderr:      opts.stderr,
+	}).Run(args)
+	return asExitCodeError(err)
+}

--- a/cmd/eval_task_test.go
+++ b/cmd/eval_task_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/runmedev/runme/v3/internal/harbor"
+)
+
+type fakeEvalTaskNewer struct {
+	err error
+}
+
+func (n fakeEvalTaskNewer) Run([]string) error {
+	return n.err
+}
+
+func TestEvalTaskNewCmdPassesOptionsToHarborTaskNewer(t *testing.T) {
+	var gotOpts harbor.EvalTaskNewOptions
+	var gotArgs []string
+	cmd := evalCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"task",
+		"new",
+		"runmedev/my-task",
+		"--tasks-dir", "custom/tasks",
+		"--org", "ignored",
+		"--description", "A useful task",
+		"--author", "Alice <alice@example.com>",
+		"--author", "Bob",
+		"--no-solution",
+		"--force",
+	})
+	restoreEvalTaskNewer(t, func(opts harbor.EvalTaskNewOptions) evalTaskNewer {
+		gotOpts = opts
+		return evalTaskNewerFunc(func(args []string) error {
+			gotArgs = append([]string(nil), args...)
+			return nil
+		})
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(gotArgs, []string{"runmedev/my-task"}) {
+		t.Fatalf("args = %#v", gotArgs)
+	}
+	if gotOpts.TasksDir != "custom/tasks" ||
+		gotOpts.Org != "ignored" ||
+		gotOpts.Description != "A useful task" ||
+		!reflect.DeepEqual(gotOpts.Authors, []string{"Alice <alice@example.com>", "Bob"}) ||
+		!gotOpts.NoSolution ||
+		!gotOpts.Force ||
+		gotOpts.Stdout != &stdout ||
+		gotOpts.Stderr != &stderr {
+		t.Fatalf("options = %#v", gotOpts)
+	}
+}
+
+func TestEvalTaskNewCmdRejectsMissingName(t *testing.T) {
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"task", "new"})
+	restoreEvalTaskNewer(t, func(harbor.EvalTaskNewOptions) evalTaskNewer {
+		return fakeEvalTaskNewer{}
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEvalTaskNewCmdRejectsExtraArgs(t *testing.T) {
+	cmd := evalCmd()
+	cmd.SetArgs([]string{"task", "new", "one", "two"})
+	restoreEvalTaskNewer(t, func(harbor.EvalTaskNewOptions) evalTaskNewer {
+		return fakeEvalTaskNewer{}
+	})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEvalTaskNewCmdHelpMentionsTasksDefault(t *testing.T) {
+	cmd := evalCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"task", "new", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Usage:\n  eval task new <org/name> [flags]",
+		"Create a Harbor eval task scaffold for Runme.",
+		"When --tasks-dir is omitted, runme eval task new writes under ./" + harbor.DefaultEvalDatasetPath + ".",
+		"--tasks-dir string",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+type evalTaskNewerFunc func([]string) error
+
+func (f evalTaskNewerFunc) Run(args []string) error {
+	return f(args)
+}
+
+func restoreEvalTaskNewer(t *testing.T, fn func(harbor.EvalTaskNewOptions) evalTaskNewer) {
+	t.Helper()
+	previous := newEvalTaskNewer
+	newEvalTaskNewer = fn
+	t.Cleanup(func() {
+		newEvalTaskNewer = previous
+	})
+}

--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -7,6 +7,12 @@ cwd: ../..
 These examples exercise Runme through Harbor's custom environment interface via
 `runme eval`.
 
+Create a new Runme-shaped eval task scaffold:
+
+```sh {"name":"new-eval-task"}
+runme eval task new runmedev/my-task
+```
+
 Run the smoke task with the oracle, which uses the known-good solution:
 
 ```sh {"name":"smoke-oracle"}

--- a/integrations/harbor/README.md
+++ b/integrations/harbor/README.md
@@ -5,6 +5,9 @@ Harbor's environment interface to a local `runme harbor stdio` process.
 
 Runme Harbor builds on the upstream Harbor Python package.
 
+Task scaffolding is handled by the Go CLI through `runme eval task new`; this
+package stays focused on runtime integration.
+
 ## Install
 
 Install the adapter as an isolated Python CLI tool:

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -51,6 +51,12 @@ type taskTemplateData struct {
 	ContainerWorkdir string
 }
 
+type scaffoldFile struct {
+	template string
+	target   string
+	mode     os.FileMode
+}
+
 var authorPattern = regexp.MustCompile(`^(.+?)\s*<(.+?)>\s*$`)
 
 func NewEvalTaskNewer(opts EvalTaskNewOptions) *EvalTaskNewer {
@@ -109,7 +115,7 @@ func (r *EvalTaskNewer) Run(args []string) error {
 		EvalDatasetPath:  evalDatasetPath,
 		ContainerWorkdir: containerWorkdir,
 	}
-	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution); err != nil {
+	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution, r.opts.Force); err != nil {
 		return err
 	}
 
@@ -163,6 +169,9 @@ func resolveEvalTaskName(name, org string) (string, string, error) {
 		return "", "", errors.New("task name cannot be empty")
 	}
 	if strings.Contains(name, "/") {
+		if org != "" {
+			return "", "", fmt.Errorf("task name %q already includes an organization; do not pass --org", name)
+		}
 		parts := strings.Split(name, "/")
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return "", "", fmt.Errorf("task name must be in org/name format: %s", name)
@@ -265,12 +274,8 @@ func ensureEvalTaskTarget(taskDir string, force bool) error {
 	return err
 }
 
-func writeEvalTaskScaffold(taskDir string, data taskTemplateData, noSolution bool) error {
-	files := []struct {
-		template string
-		target   string
-		mode     os.FileMode
-	}{
+func writeEvalTaskScaffold(taskDir string, data taskTemplateData, noSolution, force bool) error {
+	files := []scaffoldFile{
 		{"README.md.tmpl", "README.md", 0o644},
 		{"task.toml.tmpl", "task.toml", 0o644},
 		{"instruction.md.tmpl", "instruction.md", 0o644},
@@ -279,15 +284,16 @@ func writeEvalTaskScaffold(taskDir string, data taskTemplateData, noSolution boo
 		{"tests/test.sh.tmpl", "tests/test.sh", 0o755},
 	}
 	if !noSolution {
-		files = append(files, struct {
-			template string
-			target   string
-			mode     os.FileMode
-		}{"solution/solve.sh.tmpl", "solution/solve.sh", 0o755})
+		files = append(files, scaffoldFile{"solution/solve.sh.tmpl", "solution/solve.sh", 0o755})
 	}
 
 	for _, file := range files {
 		if err := writeEvalTaskTemplate(taskDir, file.template, file.target, file.mode, data); err != nil {
+			return err
+		}
+	}
+	if noSolution && force {
+		if err := removeEvalTaskSolutionScaffold(taskDir); err != nil {
 			return err
 		}
 	}
@@ -297,6 +303,25 @@ func writeEvalTaskScaffold(taskDir string, data taskTemplateData, noSolution boo
 		return err
 	}
 	return os.WriteFile(workdirKeep, nil, 0o644) // #nosec G306 -- generated scaffold files should be user-readable.
+}
+
+func removeEvalTaskSolutionScaffold(taskDir string) error {
+	solutionDir := filepath.Join(taskDir, "solution")
+	solvePath := filepath.Join(solutionDir, "solve.sh")
+	if err := os.Remove(solvePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	entries, err := os.ReadDir(solutionDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return os.Remove(solutionDir)
+	}
+	return nil
 }
 
 func writeEvalTaskSummary(w io.Writer, taskDir, authorSummary string, noSolution bool) error {

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -1,0 +1,339 @@
+package harbor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+)
+
+type EvalTaskNewOptions struct {
+	TasksDir    string
+	Org         string
+	Description string
+	Authors     []string
+	NoSolution  bool
+	Force       bool
+	GitConfig   GitConfigFunc
+	Stdout      io.Writer
+	Stderr      io.Writer
+}
+
+type GitConfigFunc func(key string) (string, error)
+
+type EvalTaskNewer struct {
+	opts EvalTaskNewOptions
+}
+
+type evalTaskNewPaths struct {
+	tasksDir string
+}
+
+type taskAuthor struct {
+	Name  string
+	Email string
+}
+
+type taskTemplateData struct {
+	FullName      string
+	ShortName     string
+	Description   string
+	Authors       []taskAuthor
+	AuthorSummary string
+}
+
+var authorPattern = regexp.MustCompile(`^(.+?)\s*<(.+?)>\s*$`)
+
+func NewEvalTaskNewer(opts EvalTaskNewOptions) *EvalTaskNewer {
+	if opts.TasksDir == "" {
+		opts.TasksDir = DefaultEvalDatasetPath
+	}
+	if opts.GitConfig == nil {
+		opts.GitConfig = gitConfig
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	return &EvalTaskNewer{opts: opts}
+}
+
+func (r *EvalTaskNewer) Run(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("accepts exactly 1 task name, received %d", len(args))
+	}
+
+	fullName, shortName, err := resolveEvalTaskName(args[0], r.opts.Org)
+	if err != nil {
+		return err
+	}
+	authors, err := r.resolveAuthors()
+	if err != nil {
+		return err
+	}
+	paths, err := resolveEvalTaskNewPaths(r.opts.TasksDir)
+	if err != nil {
+		return err
+	}
+
+	taskDir := filepath.Join(paths.tasksDir, shortName)
+	if err := ensureEvalTaskTarget(taskDir, r.opts.Force); err != nil {
+		return err
+	}
+
+	data := taskTemplateData{
+		FullName:      fullName,
+		ShortName:     shortName,
+		Description:   r.opts.Description,
+		Authors:       authors,
+		AuthorSummary: formatAuthors(authors),
+	}
+	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution); err != nil {
+		return err
+	}
+
+	return writeEvalTaskSummary(r.opts.Stdout, taskDir, data.AuthorSummary, r.opts.NoSolution)
+}
+
+func resolveEvalTaskNewPaths(tasksDir string) (evalTaskNewPaths, error) {
+	invocationCwd, err := os.Getwd()
+	if err != nil {
+		return evalTaskNewPaths{}, err
+	}
+	invocationCwd = cleanExistingPath(invocationCwd)
+	baseDir := defaultEvalBaseDir(invocationCwd)
+
+	if tasksDir == "" {
+		tasksDir = DefaultEvalDatasetPath
+	}
+	if filepath.IsAbs(tasksDir) {
+		return evalTaskNewPaths{tasksDir: cleanExistingPath(tasksDir)}, nil
+	}
+	if tasksDir == DefaultEvalDatasetPath {
+		return evalTaskNewPaths{tasksDir: filepath.Join(baseDir, tasksDir)}, nil
+	}
+	return evalTaskNewPaths{tasksDir: filepath.Clean(filepath.Join(invocationCwd, tasksDir))}, nil
+}
+
+func resolveEvalTaskName(name, org string) (string, string, error) {
+	name = strings.TrimSpace(name)
+	org = strings.TrimSpace(org)
+	if name == "" {
+		return "", "", errors.New("task name cannot be empty")
+	}
+	if strings.Contains(name, "/") {
+		parts := strings.Split(name, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", "", fmt.Errorf("task name must be in org/name format: %s", name)
+		}
+		if err := validateEvalTaskDirName(parts[1]); err != nil {
+			return "", "", err
+		}
+		return name, parts[1], nil
+	}
+	if org == "" {
+		return "", "", fmt.Errorf("task name %q is missing an organization; pass org/name or --org", name)
+	}
+	if strings.Contains(org, "/") {
+		return "", "", fmt.Errorf("organization cannot contain /: %s", org)
+	}
+	if err := validateEvalTaskDirName(name); err != nil {
+		return "", "", err
+	}
+	return org + "/" + name, name, nil
+}
+
+func validateEvalTaskDirName(name string) error {
+	if name == "." || name == ".." || strings.Contains(name, "/") || strings.Contains(name, `\`) {
+		return fmt.Errorf("invalid task directory name: %s", name)
+	}
+	cleaned := filepath.Clean(name)
+	if cleaned != name {
+		return fmt.Errorf("invalid task directory name: %s", name)
+	}
+	return nil
+}
+
+func (r *EvalTaskNewer) resolveAuthors() ([]taskAuthor, error) {
+	if len(r.opts.Authors) > 0 {
+		return parseTaskAuthors(r.opts.Authors)
+	}
+
+	name, nameErr := r.opts.GitConfig("user.name")
+	email, emailErr := r.opts.GitConfig("user.email")
+	name = strings.TrimSpace(name)
+	email = strings.TrimSpace(email)
+
+	if nameErr != nil || name == "" {
+		return nil, nil
+	}
+	if emailErr != nil || email == "" {
+		return []taskAuthor{{Name: name}}, nil
+	}
+	return []taskAuthor{{Name: name, Email: email}}, nil
+}
+
+func parseTaskAuthors(values []string) ([]taskAuthor, error) {
+	authors := make([]taskAuthor, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, errors.New("author cannot be empty")
+		}
+		match := authorPattern.FindStringSubmatch(value)
+		if match != nil {
+			name := strings.TrimSpace(match[1])
+			email := strings.TrimSpace(match[2])
+			if name == "" || email == "" {
+				return nil, fmt.Errorf("invalid author: %s", value)
+			}
+			authors = append(authors, taskAuthor{Name: name, Email: email})
+			continue
+		}
+		authors = append(authors, taskAuthor{Name: value})
+	}
+	return authors, nil
+}
+
+func formatAuthors(authors []taskAuthor) string {
+	parts := make([]string, 0, len(authors))
+	for _, author := range authors {
+		if author.Email != "" {
+			parts = append(parts, fmt.Sprintf("%s <%s>", author.Name, author.Email))
+		} else {
+			parts = append(parts, author.Name)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func ensureEvalTaskTarget(taskDir string, force bool) error {
+	info, err := os.Stat(taskDir)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("eval task path exists and is not a directory: %s", taskDir)
+		}
+		if !force {
+			return fmt.Errorf("eval task already exists: %s; pass --force to overwrite scaffold-owned files", taskDir)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func writeEvalTaskScaffold(taskDir string, data taskTemplateData, noSolution bool) error {
+	files := []struct {
+		template string
+		target   string
+		mode     os.FileMode
+	}{
+		{"README.md.tmpl", "README.md", 0o644},
+		{"task.toml.tmpl", "task.toml", 0o644},
+		{"instruction.md.tmpl", "instruction.md", 0o644},
+		{"environment/Dockerfile.tmpl", "environment/Dockerfile", 0o644},
+		{"workdir/.gitignore.tmpl", "workdir/.gitignore", 0o644},
+		{"tests/test.sh.tmpl", "tests/test.sh", 0o755},
+	}
+	if !noSolution {
+		files = append(files, struct {
+			template string
+			target   string
+			mode     os.FileMode
+		}{"solution/solve.sh.tmpl", "solution/solve.sh", 0o755})
+	}
+
+	for _, file := range files {
+		if err := writeEvalTaskTemplate(taskDir, file.template, file.target, file.mode, data); err != nil {
+			return err
+		}
+	}
+
+	workdirKeep := filepath.Join(taskDir, "workdir", ".gitkeep")
+	if err := os.MkdirAll(filepath.Dir(workdirKeep), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(workdirKeep, nil, 0o644) // #nosec G306 -- generated scaffold files should be user-readable.
+}
+
+func writeEvalTaskSummary(w io.Writer, taskDir, authorSummary string, noSolution bool) error {
+	lines := []string{
+		fmt.Sprintf("Task initialized in %s\n", taskDir),
+	}
+	if authorSummary != "" {
+		lines = append(lines, fmt.Sprintf("Author: %s\n", authorSummary))
+	}
+	lines = append(
+		lines,
+		"Next steps:\n",
+		fmt.Sprintf("- Add your instruction to: %s\n", filepath.Join(taskDir, "instruction.md")),
+		fmt.Sprintf("- Define any task setup in: %s\n", filepath.Join(taskDir, "environment", "Dockerfile")),
+		fmt.Sprintf("- Use the test script to generate a reward: %s\n", filepath.Join(taskDir, "tests", "test.sh")),
+	)
+	if !noSolution {
+		lines = append(lines, fmt.Sprintf("- Fill out the solution: %s\n", filepath.Join(taskDir, "solution", "solve.sh")))
+	}
+	_, err := io.WriteString(w, strings.Join(lines, ""))
+	return err
+}
+
+func writeEvalTaskTemplate(taskDir, templatePath, targetPath string, mode os.FileMode, data taskTemplateData) error {
+	content, err := renderEvalTaskTemplate(templatePath, data)
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(taskDir, targetPath)
+	if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(target, content, mode) // #nosec G306 -- generated scaffold files need their requested modes.
+}
+
+func renderEvalTaskTemplate(path string, data taskTemplateData) ([]byte, error) {
+	source, err := evalTaskNewTemplates.ReadFile(filepath.ToSlash(filepath.Join("eval_task_new_templates", path)))
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New(path).Funcs(template.FuncMap{
+		"tomlString": tomlString,
+	}).Parse(string(source))
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, data); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+func tomlString(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"\"", "\\\"",
+		"\b", "\\b",
+		"\t", "\\t",
+		"\n", "\\n",
+		"\f", "\\f",
+		"\r", "\\r",
+	)
+	return `"` + replacer.Replace(value) + `"`
+}
+
+func gitConfig(key string) (string, error) {
+	output, err := exec.Command("git", "config", key).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -294,7 +294,7 @@ func writeEvalTaskSummary(w io.Writer, taskDir, authorSummary string, noSolution
 		lines,
 		"Next steps:\n",
 		fmt.Sprintf("- Add your instruction to: %s\n", filepath.Join(taskDir, "instruction.md")),
-		fmt.Sprintf("- Define any task setup in: %s\n", filepath.Join(taskDir, "environment", "Dockerfile")),
+		fmt.Sprintf("- Optional Docker setup (--env docker): %s\n", filepath.Join(taskDir, "environment", "Dockerfile")),
 		fmt.Sprintf("- Use the test script to generate a reward: %s\n", filepath.Join(taskDir, "tests", "test.sh")),
 	)
 	if !noSolution {

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -48,6 +48,7 @@ type taskTemplateData struct {
 	Authors          []taskAuthor
 	AuthorSummary    string
 	EvalDatasetPath  string
+	EvalCommand      string
 	ContainerWorkdir string
 }
 
@@ -113,6 +114,7 @@ func (r *EvalTaskNewer) Run(args []string) error {
 		Authors:          authors,
 		AuthorSummary:    formatAuthors(authors),
 		EvalDatasetPath:  evalDatasetPath,
+		EvalCommand:      evalTaskRunCommand(evalDatasetPath, shortName),
 		ContainerWorkdir: containerWorkdir,
 	}
 	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution, r.opts.Force); err != nil {
@@ -160,6 +162,13 @@ func evalTaskDatasetPath(baseDir, tasksDir string) (string, error) {
 		return "", fmt.Errorf("eval tasks directory must be under workspace root %s: %s", baseDir, tasksDir)
 	}
 	return filepath.ToSlash(rel), nil
+}
+
+func evalTaskRunCommand(evalDatasetPath, shortName string) string {
+	if evalDatasetPath == filepath.ToSlash(DefaultEvalDatasetPath) {
+		return fmt.Sprintf("runme eval --task-dir %s --agent claude-code", shortName)
+	}
+	return fmt.Sprintf("runme eval %s --task-dir %s --agent claude-code", evalDatasetPath, shortName)
 }
 
 func resolveEvalTaskName(name, org string) (string, string, error) {

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -47,6 +47,7 @@ type taskTemplateData struct {
 	Description      string
 	Authors          []taskAuthor
 	AuthorSummary    string
+	EvalDatasetPath  string
 	ContainerWorkdir string
 }
 
@@ -94,6 +95,10 @@ func (r *EvalTaskNewer) Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	evalDatasetPath, err := evalTaskDatasetPath(paths.baseDir, paths.tasksDir)
+	if err != nil {
+		return err
+	}
 
 	data := taskTemplateData{
 		FullName:         fullName,
@@ -101,6 +106,7 @@ func (r *EvalTaskNewer) Run(args []string) error {
 		Description:      r.opts.Description,
 		Authors:          authors,
 		AuthorSummary:    formatAuthors(authors),
+		EvalDatasetPath:  evalDatasetPath,
 		ContainerWorkdir: containerWorkdir,
 	}
 	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution); err != nil {
@@ -138,6 +144,16 @@ func evalTaskContainerWorkdir(baseDir, taskDir string) (string, error) {
 		return "", fmt.Errorf("eval task directory must be under workspace root %s to map to /app: %s", baseDir, taskDir)
 	}
 	return "/app/" + filepath.ToSlash(filepath.Join(rel, "workdir")), nil
+}
+
+func evalTaskDatasetPath(baseDir, tasksDir string) (string, error) {
+	baseDir = cleanExistingPath(baseDir)
+	tasksDir = cleanExistingPath(tasksDir)
+	rel := relativePathUnder(baseDir, tasksDir)
+	if rel == "" {
+		return "", fmt.Errorf("eval tasks directory must be under workspace root %s: %s", baseDir, tasksDir)
+	}
+	return filepath.ToSlash(rel), nil
 }
 
 func resolveEvalTaskName(name, org string) (string, string, error) {

--- a/internal/harbor/eval_task_new.go
+++ b/internal/harbor/eval_task_new.go
@@ -33,6 +33,7 @@ type EvalTaskNewer struct {
 
 type evalTaskNewPaths struct {
 	tasksDir string
+	baseDir  string
 }
 
 type taskAuthor struct {
@@ -41,11 +42,12 @@ type taskAuthor struct {
 }
 
 type taskTemplateData struct {
-	FullName      string
-	ShortName     string
-	Description   string
-	Authors       []taskAuthor
-	AuthorSummary string
+	FullName         string
+	ShortName        string
+	Description      string
+	Authors          []taskAuthor
+	AuthorSummary    string
+	ContainerWorkdir string
 }
 
 var authorPattern = regexp.MustCompile(`^(.+?)\s*<(.+?)>\s*$`)
@@ -88,13 +90,18 @@ func (r *EvalTaskNewer) Run(args []string) error {
 	if err := ensureEvalTaskTarget(taskDir, r.opts.Force); err != nil {
 		return err
 	}
+	containerWorkdir, err := evalTaskContainerWorkdir(paths.baseDir, taskDir)
+	if err != nil {
+		return err
+	}
 
 	data := taskTemplateData{
-		FullName:      fullName,
-		ShortName:     shortName,
-		Description:   r.opts.Description,
-		Authors:       authors,
-		AuthorSummary: formatAuthors(authors),
+		FullName:         fullName,
+		ShortName:        shortName,
+		Description:      r.opts.Description,
+		Authors:          authors,
+		AuthorSummary:    formatAuthors(authors),
+		ContainerWorkdir: containerWorkdir,
 	}
 	if err := writeEvalTaskScaffold(taskDir, data, r.opts.NoSolution); err != nil {
 		return err
@@ -115,12 +122,22 @@ func resolveEvalTaskNewPaths(tasksDir string) (evalTaskNewPaths, error) {
 		tasksDir = DefaultEvalDatasetPath
 	}
 	if filepath.IsAbs(tasksDir) {
-		return evalTaskNewPaths{tasksDir: cleanExistingPath(tasksDir)}, nil
+		return evalTaskNewPaths{tasksDir: cleanExistingPath(tasksDir), baseDir: baseDir}, nil
 	}
 	if tasksDir == DefaultEvalDatasetPath {
-		return evalTaskNewPaths{tasksDir: filepath.Join(baseDir, tasksDir)}, nil
+		return evalTaskNewPaths{tasksDir: filepath.Join(baseDir, tasksDir), baseDir: baseDir}, nil
 	}
-	return evalTaskNewPaths{tasksDir: filepath.Clean(filepath.Join(invocationCwd, tasksDir))}, nil
+	return evalTaskNewPaths{tasksDir: filepath.Clean(filepath.Join(invocationCwd, tasksDir)), baseDir: baseDir}, nil
+}
+
+func evalTaskContainerWorkdir(baseDir, taskDir string) (string, error) {
+	baseDir = cleanExistingPath(baseDir)
+	taskDir = cleanExistingPath(taskDir)
+	rel := relativePathUnder(baseDir, taskDir)
+	if rel == "" || rel == "." {
+		return "", fmt.Errorf("eval task directory must be under workspace root %s to map to /app: %s", baseDir, taskDir)
+	}
+	return "/app/" + filepath.ToSlash(filepath.Join(rel, "workdir")), nil
 }
 
 func resolveEvalTaskName(name, org string) (string, string, error) {

--- a/internal/harbor/eval_task_new_templates.go
+++ b/internal/harbor/eval_task_new_templates.go
@@ -1,0 +1,6 @@
+package harbor
+
+import "embed"
+
+//go:embed all:eval_task_new_templates
+var evalTaskNewTemplates embed.FS

--- a/internal/harbor/eval_task_new_templates/README.md.tmpl
+++ b/internal/harbor/eval_task_new_templates/README.md.tmpl
@@ -5,5 +5,5 @@ Runme eval task scaffold.
 Run this task with an agent:
 
 ```sh
-runme eval {{ .EvalDatasetPath }} --task-dir {{ .ShortName }} --agent claude-code
+{{ .EvalCommand }}
 ```

--- a/internal/harbor/eval_task_new_templates/README.md.tmpl
+++ b/internal/harbor/eval_task_new_templates/README.md.tmpl
@@ -1,0 +1,3 @@
+# {{ .FullName }}
+
+Runme eval task scaffold.

--- a/internal/harbor/eval_task_new_templates/README.md.tmpl
+++ b/internal/harbor/eval_task_new_templates/README.md.tmpl
@@ -1,4 +1,4 @@
-# {{ .FullName }}
+# Task {{ .FullName }}
 
 Runme eval task scaffold.
 

--- a/internal/harbor/eval_task_new_templates/README.md.tmpl
+++ b/internal/harbor/eval_task_new_templates/README.md.tmpl
@@ -1,3 +1,9 @@
 # {{ .FullName }}
 
 Runme eval task scaffold.
+
+Run this task with an agent:
+
+```sh
+runme eval {{ .EvalDatasetPath }} --task-dir {{ .ShortName }} --agent claude-code
+```

--- a/internal/harbor/eval_task_new_templates/environment/Dockerfile.tmpl
+++ b/internal/harbor/eval_task_new_templates/environment/Dockerfile.tmpl
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/internal/harbor/eval_task_new_templates/environment/Dockerfile.tmpl
+++ b/internal/harbor/eval_task_new_templates/environment/Dockerfile.tmpl
@@ -1,3 +1,3 @@
 FROM ubuntu:24.04
 
-WORKDIR /app
+WORKDIR {{ .ContainerWorkdir }}

--- a/internal/harbor/eval_task_new_templates/instruction.md.tmpl
+++ b/internal/harbor/eval_task_new_templates/instruction.md.tmpl
@@ -1,0 +1,1 @@
+Describe the task for the agent here.

--- a/internal/harbor/eval_task_new_templates/solution/solve.sh.tmpl
+++ b/internal/harbor/eval_task_new_templates/solution/solve.sh.tmpl
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+# Implement a reference solution for the task here.

--- a/internal/harbor/eval_task_new_templates/task.toml.tmpl
+++ b/internal/harbor/eval_task_new_templates/task.toml.tmpl
@@ -1,0 +1,36 @@
+schema_version = "1.3"
+artifacts = []
+
+[task]
+name = {{ tomlString .FullName }}
+description = {{ tomlString .Description }}
+authors = [
+{{- range .Authors }}
+  { name = {{ tomlString .Name }}{{ if .Email }}, email = {{ tomlString .Email }}{{ end }} },
+{{- end }}
+]
+keywords = ["runme", "harbor", "eval"]
+
+[metadata]
+category = "software_engineering"
+tags = ["runme", "harbor", "eval"]
+
+[verifier]
+timeout_sec = 600.0
+collect = []
+
+[agent]
+timeout_sec = 600.0
+
+[environment]
+network_mode = "public"
+build_timeout_sec = 600.0
+os = "linux"
+workdir = "/app/workdir"
+mcp_servers = []
+
+[environment.env]
+
+[verifier.env]
+
+[solution.env]

--- a/internal/harbor/eval_task_new_templates/task.toml.tmpl
+++ b/internal/harbor/eval_task_new_templates/task.toml.tmpl
@@ -26,7 +26,7 @@ timeout_sec = 600.0
 network_mode = "public"
 build_timeout_sec = 600.0
 os = "linux"
-workdir = "/app/workdir"
+workdir = {{ tomlString .ContainerWorkdir }}
 mcp_servers = []
 
 [environment.env]

--- a/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
+++ b/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
@@ -10,6 +10,7 @@ mkdir -p "$verifier_dir"
 {
   echo "Verifier started for ${RUNME_TASK_NAME:-{{ .ShortName }}}"
   echo "Task workdir: ${RUNME_TASK_WORKDIR:-{{ .ContainerWorkdir }}}"
+  echo
   echo "Checking stub success condition: implement real checks before expecting this task to pass"
 
   # Harbor expects the canonical reward JSON to be a reward-name-to-score map.
@@ -17,5 +18,6 @@ mkdir -p "$verifier_dir"
 
   echo "Reward written to: $reward_path"
   echo "Reward: 0.0"
+  echo
   echo "Verifier completed successfully"
 } | tee "$stdout_path"

--- a/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
+++ b/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-# Write 1 for success or 0 for failure.
-mkdir -p /logs/verifier
-echo 0 > /logs/verifier/reward.txt
+verifier_dir="${RUNME_VERIFIER_DIR:-/logs/verifier}"
+reward_path="${RUNME_REWARD_PATH:-$verifier_dir/reward.json}"
+stdout_path="$verifier_dir/test-stdout.txt"
+
+mkdir -p "$verifier_dir"
+
+{
+  echo "Verifier started for ${RUNME_TASK_NAME:-{{ .ShortName }}}"
+  echo "Task workdir: ${RUNME_TASK_WORKDIR:-{{ .ContainerWorkdir }}}"
+  echo "Checking stub success condition: implement real checks before expecting this task to pass"
+
+  # Harbor expects the canonical reward JSON to be a reward-name-to-score map.
+  printf '{"reward": 0.0}\n' > "$reward_path"
+
+  echo "Reward written to: $reward_path"
+  echo "Reward: 0.0"
+  echo "Verifier completed successfully"
+} | tee "$stdout_path"

--- a/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
+++ b/internal/harbor/eval_task_new_templates/tests/test.sh.tmpl
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# Write 1 for success or 0 for failure.
+mkdir -p /logs/verifier
+echo 0 > /logs/verifier/reward.txt

--- a/internal/harbor/eval_task_new_templates/workdir/.gitignore.tmpl
+++ b/internal/harbor/eval_task_new_templates/workdir/.gitignore.tmpl
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -397,16 +397,19 @@ func TestEvalTaskNewerGeneratedVerifierWritesRewardAndStdout(t *testing.T) {
 	}
 
 	stdout := readFile(t, filepath.Join(verifierDir, "test-stdout.txt"))
-	for _, want := range []string{
+	wantStdout := strings.Join([]string{
 		"Verifier started for my-task",
 		"Task workdir: " + workdir,
+		"",
+		"Checking stub success condition: implement real checks before expecting this task to pass",
 		"Reward written to: " + rewardPath,
 		"Reward: 0.0",
+		"",
 		"Verifier completed successfully",
-	} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("test-stdout.txt missing %q:\n%s", want, stdout)
-		}
+		"",
+	}, "\n")
+	if stdout != wantStdout {
+		t.Fatalf("test-stdout.txt = %q, want %q", stdout, wantStdout)
 	}
 	if string(output) != stdout {
 		t.Fatalf("stdout mirror mismatch\noutput:\n%s\nfile:\n%s", output, stdout)

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -11,9 +11,11 @@ import (
 
 func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
+	tasksDir := filepath.Join(tmp, DefaultEvalDatasetPath)
 	var stdout bytes.Buffer
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
-		TasksDir:    tmp,
+		TasksDir:    tasksDir,
 		Description: "A useful task",
 		Authors:     []string{"Alice <alice@example.com>", "Bob"},
 		GitConfig:   noGitConfig,
@@ -24,7 +26,7 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	taskDir := filepath.Join(tmp, "my-task")
+	taskDir := filepath.Join(tasksDir, "my-task")
 	for _, path := range []string{
 		"README.md",
 		"task.toml",
@@ -47,11 +49,15 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 		`description = "A useful task"`,
 		`{ name = "Alice", email = "alice@example.com" }`,
 		`{ name = "Bob" }`,
-		`workdir = "/app/workdir"`,
+		`workdir = "/app/evals/tasks/my-task/workdir"`,
 	} {
 		if !strings.Contains(taskTOML, want) {
 			t.Fatalf("task.toml missing %q:\n%s", want, taskTOML)
 		}
+	}
+	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))
+	if !strings.Contains(dockerfile, "WORKDIR /app/evals/tasks/my-task/workdir") {
+		t.Fatalf("Dockerfile = %s", dockerfile)
 	}
 	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
 		t.Fatalf("stdout = %q", stdout.String())
@@ -75,10 +81,82 @@ func TestEvalTaskNewerDefaultsTasksDirUnderProjectRoot(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(tmp, DefaultEvalDatasetPath, "my-task", "task.toml")); err != nil {
 		t.Fatal(err)
 	}
+	taskTOML := readFile(t, filepath.Join(tmp, DefaultEvalDatasetPath, "my-task", "task.toml"))
+	if !strings.Contains(taskTOML, `workdir = "/app/evals/tasks/my-task/workdir"`) {
+		t.Fatalf("task.toml = %s", taskTOML)
+	}
+}
+
+func TestEvalTaskNewerUsesRelativeTasksDirForContainerWorkdir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  filepath.Join("examples", "harbor", "datasets", "custom"),
+		Org:       "runmedev",
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	if err := runner.Run([]string{"my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	taskDir := filepath.Join(tmp, "examples", "harbor", "datasets", "custom", "my-task")
+	want := `/app/examples/harbor/datasets/custom/my-task/workdir`
+	taskTOML := readFile(t, filepath.Join(taskDir, "task.toml"))
+	if !strings.Contains(taskTOML, `workdir = "`+want+`"`) {
+		t.Fatalf("task.toml = %s", taskTOML)
+	}
+	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))
+	if !strings.Contains(dockerfile, "WORKDIR "+want) {
+		t.Fatalf("Dockerfile = %s", dockerfile)
+	}
+}
+
+func TestEvalTaskNewerUsesAbsoluteTasksDirInsideWorkspaceForContainerWorkdir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	tasksDir := filepath.Join(tmp, "custom", "tasks")
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tasksDir,
+		Org:       "runmedev",
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	if err := runner.Run([]string{"my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	taskTOML := readFile(t, filepath.Join(tasksDir, "my-task", "task.toml"))
+	if !strings.Contains(taskTOML, `workdir = "/app/custom/tasks/my-task/workdir"`) {
+		t.Fatalf("task.toml = %s", taskTOML)
+	}
+}
+
+func TestEvalTaskNewerRejectsTasksDirOutsideWorkspace(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	externalTasksDir := filepath.Join(t.TempDir(), "tasks")
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  externalTasksDir,
+		Org:       "runmedev",
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	err := runner.Run([]string{"my-task"})
+	if err == nil || !strings.Contains(err.Error(), "must be under workspace root") {
+		t.Fatalf("error = %v", err)
+	}
 }
 
 func TestEvalTaskNewerDefaultsAuthorFromGitConfig(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
 		TasksDir: tmp,
 		GitConfig: func(key string) (string, error) {
@@ -106,6 +184,7 @@ func TestEvalTaskNewerDefaultsAuthorFromGitConfig(t *testing.T) {
 
 func TestEvalTaskNewerExplicitAuthorSkipsGitConfig(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	called := false
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
 		TasksDir: tmp,
@@ -126,8 +205,10 @@ func TestEvalTaskNewerExplicitAuthorSkipsGitConfig(t *testing.T) {
 }
 
 func TestEvalTaskNewerRequiresOrgForBareName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
-		TasksDir:  t.TempDir(),
+		TasksDir:  tmp,
 		GitConfig: noGitConfig,
 		Stdout:    &bytes.Buffer{},
 	})
@@ -146,8 +227,10 @@ func TestEvalTaskNewerRejectsInvalidNames(t *testing.T) {
 		"too/many/slashes",
 	} {
 		t.Run(name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Chdir(tmp)
 			runner := NewEvalTaskNewer(EvalTaskNewOptions{
-				TasksDir:  t.TempDir(),
+				TasksDir:  tmp,
 				GitConfig: noGitConfig,
 				Stdout:    &bytes.Buffer{},
 			})
@@ -160,6 +243,7 @@ func TestEvalTaskNewerRejectsInvalidNames(t *testing.T) {
 
 func TestEvalTaskNewerExistingTargetRequiresForce(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	if err := os.Mkdir(filepath.Join(tmp, "my-task"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -177,6 +261,7 @@ func TestEvalTaskNewerExistingTargetRequiresForce(t *testing.T) {
 
 func TestEvalTaskNewerForceOverwritesOwnedFilesAndKeepsUnknownFiles(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	taskDir := filepath.Join(tmp, "my-task")
 	if err := os.MkdirAll(taskDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -208,6 +293,7 @@ func TestEvalTaskNewerForceOverwritesOwnedFilesAndKeepsUnknownFiles(t *testing.T
 
 func TestEvalTaskNewerNoSolutionSkipsSolution(t *testing.T) {
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
 		TasksDir:   tmp,
 		NoSolution: true,
@@ -228,6 +314,7 @@ func TestEvalTaskNewerScriptsAreExecutable(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
+	t.Chdir(tmp)
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
 		TasksDir:  tmp,
 		GitConfig: noGitConfig,

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -247,6 +247,22 @@ func TestEvalTaskNewerRequiresOrgForBareName(t *testing.T) {
 	}
 }
 
+func TestEvalTaskNewerRejectsOrgFlagWithQualifiedName(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tmp,
+		Org:       "other",
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	err := runner.Run([]string{"runmedev/my-task"})
+	if err == nil || !strings.Contains(err.Error(), "already includes an organization") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestEvalTaskNewerRejectsInvalidNames(t *testing.T) {
 	for _, name := range []string{
 		"runmedev/../bad",
@@ -316,6 +332,40 @@ func TestEvalTaskNewerForceOverwritesOwnedFilesAndKeepsUnknownFiles(t *testing.T
 	}
 	if got := readFile(t, filepath.Join(taskDir, "task.toml")); got == "old" {
 		t.Fatal("task.toml was not overwritten")
+	}
+}
+
+func TestEvalTaskNewerForceNoSolutionRemovesOwnedSolutionFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	taskDir := filepath.Join(tmp, "my-task")
+	solutionDir := filepath.Join(taskDir, "solution")
+	if err := os.MkdirAll(solutionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(solutionDir, "solve.sh"), []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(solutionDir, "notes.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:   tmp,
+		Force:      true,
+		NoSolution: true,
+		GitConfig:  noGitConfig,
+		Stdout:     &bytes.Buffer{},
+	})
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(solutionDir, "solve.sh")); !os.IsNotExist(err) {
+		t.Fatalf("solution/solve.sh exists or stat failed unexpectedly: %v", err)
+	}
+	if got := readFile(t, filepath.Join(solutionDir, "notes.txt")); got != "keep" {
+		t.Fatalf("solution/notes.txt = %q", got)
 	}
 }
 

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -222,6 +223,10 @@ func TestEvalTaskNewerNoSolutionSkipsSolution(t *testing.T) {
 }
 
 func TestEvalTaskNewerScriptsAreExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filesystems do not report Unix executable bits")
+	}
+
 	tmp := t.TempDir()
 	runner := NewEvalTaskNewer(EvalTaskNewOptions{
 		TasksDir:  tmp,

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -81,11 +81,12 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
-	stdoutText := filepath.ToSlash(stdout.String())
-	dockerfilePath := filepath.ToSlash(filepath.Join(taskDir, "environment", "Dockerfile"))
-	if !strings.Contains(stdoutText, "- Optional Docker setup (--env docker): "+dockerfilePath) {
-		t.Fatalf("stdout = %q", stdout.String())
-	}
+	assertSummaryPath(
+		t,
+		stdout.String(),
+		"- Optional Docker setup (--env docker): ",
+		filepath.Join(taskDir, "environment", "Dockerfile"),
+	)
 }
 
 func TestEvalTaskNewerDefaultsTasksDirUnderProjectRoot(t *testing.T) {
@@ -487,4 +488,21 @@ func readFile(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return string(data)
+}
+
+func assertSummaryPath(t *testing.T, stdout, prefix, wantPath string) {
+	t.Helper()
+	for _, line := range strings.Split(stdout, "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		gotPath := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		gotClean := cleanExistingPath(gotPath)
+		wantClean := cleanExistingPath(wantPath)
+		if gotClean != wantClean {
+			t.Fatalf("%s path = %q, want %q\nstdout:\n%s", strings.TrimSpace(prefix), gotPath, wantPath, stdout)
+		}
+		return
+	}
+	t.Fatalf("stdout missing line with prefix %q:\n%s", prefix, stdout)
 }

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -58,7 +58,7 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 		}
 	}
 	readme := readFile(t, filepath.Join(taskDir, "README.md"))
-	if !strings.Contains(readme, `runme eval evals/tasks --task-dir my-task --agent claude-code`) {
+	if !strings.Contains(readme, `runme eval --task-dir my-task --agent claude-code`) {
 		t.Fatalf("README.md = %s", readme)
 	}
 	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -2,7 +2,9 @@ package harbor
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -58,6 +60,19 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))
 	if !strings.Contains(dockerfile, "WORKDIR /app/evals/tasks/my-task/workdir") {
 		t.Fatalf("Dockerfile = %s", dockerfile)
+	}
+	testScript := readFile(t, filepath.Join(taskDir, "tests", "test.sh"))
+	for _, want := range []string{
+		`RUNME_VERIFIER_DIR`,
+		`RUNME_REWARD_PATH`,
+		`test-stdout.txt`,
+		`tee "$stdout_path"`,
+		`{"reward": 0.0}`,
+		`/app/evals/tasks/my-task/workdir`,
+	} {
+		if !strings.Contains(testScript, want) {
+			t.Fatalf("tests/test.sh missing %q:\n%s", want, testScript)
+		}
 	}
 	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
 		t.Fatalf("stdout = %q", stdout.String())
@@ -331,6 +346,67 @@ func TestEvalTaskNewerScriptsAreExecutable(t *testing.T) {
 		if info.Mode()&0o111 == 0 {
 			t.Fatalf("%s is not executable: %s", path, info.Mode())
 		}
+	}
+}
+
+func TestEvalTaskNewerGeneratedVerifierWritesRewardAndStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated verifier script requires a Unix shell")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not found")
+	}
+
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tmp,
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	verifierDir := filepath.Join(tmp, "verifier")
+	rewardPath := filepath.Join(verifierDir, "reward.json")
+	workdir := filepath.Join(tmp, "my-task", "workdir")
+	cmd := exec.Command(bash, filepath.Join(tmp, "my-task", "tests", "test.sh"))
+	cmd.Env = append(
+		os.Environ(),
+		"RUNME_VERIFIER_DIR="+verifierDir,
+		"RUNME_REWARD_PATH="+rewardPath,
+		"RUNME_TASK_NAME=my-task",
+		"RUNME_TASK_WORKDIR="+workdir,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("generated verifier failed: %v\n%s", err, output)
+	}
+
+	var rewards map[string]float64
+	if err := json.Unmarshal([]byte(readFile(t, rewardPath)), &rewards); err != nil {
+		t.Fatal(err)
+	}
+	if got := rewards["reward"]; got != 0.0 {
+		t.Fatalf("reward = %v, want 0.0", got)
+	}
+
+	stdout := readFile(t, filepath.Join(verifierDir, "test-stdout.txt"))
+	for _, want := range []string{
+		"Verifier started for my-task",
+		"Task workdir: " + workdir,
+		"Reward written to: " + rewardPath,
+		"Reward: 0.0",
+		"Verifier completed successfully",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("test-stdout.txt missing %q:\n%s", want, stdout)
+		}
+	}
+	if string(output) != stdout {
+		t.Fatalf("stdout mirror mismatch\noutput:\n%s\nfile:\n%s", output, stdout)
 	}
 }
 

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -1,0 +1,256 @@
+package harbor
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
+	tmp := t.TempDir()
+	var stdout bytes.Buffer
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:    tmp,
+		Description: "A useful task",
+		Authors:     []string{"Alice <alice@example.com>", "Bob"},
+		GitConfig:   noGitConfig,
+		Stdout:      &stdout,
+	})
+
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	taskDir := filepath.Join(tmp, "my-task")
+	for _, path := range []string{
+		"README.md",
+		"task.toml",
+		"instruction.md",
+		"environment/Dockerfile",
+		"workdir/.gitignore",
+		"workdir/.gitkeep",
+		"tests/test.sh",
+		"solution/solve.sh",
+	} {
+		if _, err := os.Stat(filepath.Join(taskDir, path)); err != nil {
+			t.Fatalf("%s missing: %v", path, err)
+		}
+	}
+
+	taskTOML := readFile(t, filepath.Join(taskDir, "task.toml"))
+	for _, want := range []string{
+		`schema_version = "1.3"`,
+		`name = "runmedev/my-task"`,
+		`description = "A useful task"`,
+		`{ name = "Alice", email = "alice@example.com" }`,
+		`{ name = "Bob" }`,
+		`workdir = "/app/workdir"`,
+	} {
+		if !strings.Contains(taskTOML, want) {
+			t.Fatalf("task.toml missing %q:\n%s", want, taskTOML)
+		}
+	}
+	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestEvalTaskNewerDefaultsTasksDirUnderProjectRoot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		Org:       "runmedev",
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	if err := runner.Run([]string{"my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, DefaultEvalDatasetPath, "my-task", "task.toml")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEvalTaskNewerDefaultsAuthorFromGitConfig(t *testing.T) {
+	tmp := t.TempDir()
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir: tmp,
+		GitConfig: func(key string) (string, error) {
+			switch key {
+			case "user.name":
+				return "Sebastian", nil
+			case "user.email":
+				return "sebastian@example.com", nil
+			default:
+				return "", os.ErrNotExist
+			}
+		},
+		Stdout: &bytes.Buffer{},
+	})
+
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	taskTOML := readFile(t, filepath.Join(tmp, "my-task", "task.toml"))
+	if !strings.Contains(taskTOML, `{ name = "Sebastian", email = "sebastian@example.com" }`) {
+		t.Fatalf("task.toml = %s", taskTOML)
+	}
+}
+
+func TestEvalTaskNewerExplicitAuthorSkipsGitConfig(t *testing.T) {
+	tmp := t.TempDir()
+	called := false
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir: tmp,
+		Authors:  []string{"Alice"},
+		GitConfig: func(string) (string, error) {
+			called = true
+			return "", nil
+		},
+		Stdout: &bytes.Buffer{},
+	})
+
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("GitConfig was called")
+	}
+}
+
+func TestEvalTaskNewerRequiresOrgForBareName(t *testing.T) {
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  t.TempDir(),
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	err := runner.Run([]string{"my-task"})
+	if err == nil || !strings.Contains(err.Error(), "missing an organization") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEvalTaskNewerRejectsInvalidNames(t *testing.T) {
+	for _, name := range []string{
+		"runmedev/../bad",
+		"runmedev/",
+		"/bad",
+		"too/many/slashes",
+	} {
+		t.Run(name, func(t *testing.T) {
+			runner := NewEvalTaskNewer(EvalTaskNewOptions{
+				TasksDir:  t.TempDir(),
+				GitConfig: noGitConfig,
+				Stdout:    &bytes.Buffer{},
+			})
+			if err := runner.Run([]string{name}); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestEvalTaskNewerExistingTargetRequiresForce(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmp, "my-task"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tmp,
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+
+	err := runner.Run([]string{"runmedev/my-task"})
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEvalTaskNewerForceOverwritesOwnedFilesAndKeepsUnknownFiles(t *testing.T) {
+	tmp := t.TempDir()
+	taskDir := filepath.Join(tmp, "my-task")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "task.toml"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "notes.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tmp,
+		Force:     true,
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := readFile(t, filepath.Join(taskDir, "notes.txt")); got != "keep" {
+		t.Fatalf("notes.txt = %q", got)
+	}
+	if got := readFile(t, filepath.Join(taskDir, "task.toml")); got == "old" {
+		t.Fatal("task.toml was not overwritten")
+	}
+}
+
+func TestEvalTaskNewerNoSolutionSkipsSolution(t *testing.T) {
+	tmp := t.TempDir()
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:   tmp,
+		NoSolution: true,
+		GitConfig:  noGitConfig,
+		Stdout:     &bytes.Buffer{},
+	})
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "my-task", "solution", "solve.sh")); !os.IsNotExist(err) {
+		t.Fatalf("solution exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestEvalTaskNewerScriptsAreExecutable(t *testing.T) {
+	tmp := t.TempDir()
+	runner := NewEvalTaskNewer(EvalTaskNewOptions{
+		TasksDir:  tmp,
+		GitConfig: noGitConfig,
+		Stdout:    &bytes.Buffer{},
+	})
+	if err := runner.Run([]string{"runmedev/my-task"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"tests/test.sh", "solution/solve.sh"} {
+		info, err := os.Stat(filepath.Join(tmp, "my-task", path))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode()&0o111 == 0 {
+			t.Fatalf("%s is not executable: %s", path, info.Mode())
+		}
+	}
+}
+
+func noGitConfig(string) (string, error) {
+	return "", os.ErrNotExist
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -77,7 +77,9 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "- Optional Docker setup (--env docker): "+filepath.Join(taskDir, "environment", "Dockerfile")) {
+	stdoutText := filepath.ToSlash(stdout.String())
+	dockerfilePath := filepath.ToSlash(filepath.Join(taskDir, "environment", "Dockerfile"))
+	if !strings.Contains(stdoutText, "- Optional Docker setup (--env docker): "+dockerfilePath) {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
 }

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -57,6 +57,10 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 			t.Fatalf("task.toml missing %q:\n%s", want, taskTOML)
 		}
 	}
+	readme := readFile(t, filepath.Join(taskDir, "README.md"))
+	if !strings.Contains(readme, `runme eval evals/tasks --task-dir my-task --agent claude-code`) {
+		t.Fatalf("README.md = %s", readme)
+	}
 	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))
 	if !strings.Contains(dockerfile, "WORKDIR /app/evals/tasks/my-task/workdir") {
 		t.Fatalf("Dockerfile = %s", dockerfile)
@@ -131,6 +135,10 @@ func TestEvalTaskNewerUsesRelativeTasksDirForContainerWorkdir(t *testing.T) {
 	dockerfile := readFile(t, filepath.Join(taskDir, "environment", "Dockerfile"))
 	if !strings.Contains(dockerfile, "WORKDIR "+want) {
 		t.Fatalf("Dockerfile = %s", dockerfile)
+	}
+	readme := readFile(t, filepath.Join(taskDir, "README.md"))
+	if !strings.Contains(readme, `runme eval examples/harbor/datasets/custom --task-dir my-task --agent claude-code`) {
+		t.Fatalf("README.md = %s", readme)
 	}
 }
 

--- a/internal/harbor/eval_task_new_test.go
+++ b/internal/harbor/eval_task_new_test.go
@@ -77,6 +77,9 @@ func TestEvalTaskNewerCreatesExpectedScaffold(t *testing.T) {
 	if !strings.Contains(stdout.String(), "Author: Alice <alice@example.com>, Bob") {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "- Optional Docker setup (--env docker): "+filepath.Join(taskDir, "environment", "Dockerfile")) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
 }
 
 func TestEvalTaskNewerDefaultsTasksDirUnderProjectRoot(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `runme eval task new <org/name>` as a native Go scaffold command
- generate a minimal Runme-shaped Harbor task with embedded templates
- default authors from `git config user.name` / `user.email` when `--author` is omitted
- document the new scaffold command in Harbor examples/integration docs

## Tests

- `go test ./cmd ./internal/harbor`
- `go run . eval task new runmedev/manual-smoke --tasks-dir /tmp/runme-eval-task-new-smoke --description 'Manual smoke task' --author 'Manual Tester <manual@example.com>' --force`
- `make lint`
- `runme run test`
