### PR TITLE
Add CLI Scarf telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test/execute: TAGS ?= "" # e.g. TAGS="docker_enabled"
 # It depends on the build target because the runme binary
 # is used for tests, for example, "runme env dump".
 test/execute: build
-	TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=60s -race=$(RACE) $(PKGS)
+	DO_NOT_TRACK=true SCARF_NO_ANALYTICS=true TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=60s -race=$(RACE) $(PKGS)
 
 .PHONY: test/coverage
 test/coverage: PKGS ?= "./..."
@@ -45,7 +45,7 @@ test/coverage: TAGS ?= "" # e.g. TAGS="docker_enabled"
 # It depends on the build target because the runme binary
 # is used for tests, for example, "runme env dump".
 test/coverage: build
-	TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=180s -covermode=atomic -coverprofile=cover.out -coverpkg=./... $(PKGS)
+	DO_NOT_TRACK=true SCARF_NO_ANALYTICS=true TZ=UTC go test -ldflags="$(LDTESTFLAGS)" -run="$(RUN)" -tags="$(TAGS)" -timeout=180s -covermode=atomic -coverprofile=cover.out -coverpkg=./... $(PKGS)
 
 .PHONY: test
 test: test/execute
@@ -69,7 +69,9 @@ test-docker/cleanup:
 .PHONY: test-docker/run
 test-docker/run:
 	docker run --rm \
+		-e DO_NOT_TRACK=true \
 		-e RUNME_TEST_ENV=docker \
+		-e SCARF_NO_ANALYTICS=true \
 		-e GOTOOLCHAIN=auto \
 		-v $(shell pwd):/workspace \
 		-v dev.runme.test-env-gocache:/root/.cache/go-build \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/runmedev/runme/v3/internal/cmd/beta"
 	"github.com/runmedev/runme/v3/internal/extension"
 	agent "github.com/runmedev/runme/v3/pkg/agent/cmd"
+	"github.com/runmedev/runme/v3/telemetry"
 )
 
 var (
@@ -131,6 +132,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(agent.NewAgentCmd("runme-agent"))
 
 	cmd.SetUsageTemplate(getUsageTemplate(cmd))
+	telemetry.InstrumentCommandTree(&cmd)
 
 	return &cmd
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -101,7 +101,7 @@ The kernel is used to run long running processes like shells and interacting wit
 				return err
 			}
 
-			_ = telemetry.ReportUnlessNoTracking(logger)
+			_ = telemetry.ReportKernelStartup(logger)
 
 			logger.Info("started listening", zap.String("addr", lis.Addr().String()))
 

--- a/internal/cmd/beta/server/server_start_cmd.go
+++ b/internal/cmd/beta/server/server_start_cmd.go
@@ -26,7 +26,7 @@ func serverStartCmd() *cobra.Command {
 				) error {
 					defer logger.Sync()
 
-					_ = telemetry.ReportUnlessNoTracking(logger)
+					_ = telemetry.ReportKernelStartup(logger)
 
 					// When using a unix socket, we want to create a file with server's PID.
 					if path := pidFileNameFromAddr(cfg.Server.Address); path != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -23,16 +23,29 @@ import (
 var realHome = os.Getenv("HOME")
 
 func TestMain(m *testing.M) {
+	setNoTelemetryEnv()
+
 	os.Exit(testscript.RunMain(m, map[string]func() int{
 		"runme": root,
 	}))
+}
+
+func setNoTelemetryEnv() {
+	_ = os.Setenv("DO_NOT_TRACK", "true")
+	_ = os.Setenv("SCARF_NO_ANALYTICS", "true")
+}
+
+func setupNoTelemetry(env *testscript.Env) error {
+	env.Setenv("DO_NOT_TRACK", "true")
+	env.Setenv("SCARF_NO_ANALYTICS", "true")
+	return nil
 }
 
 // setupWithRealHome provides a Setup function that preserves the real HOME.
 // This is needed for tools like asdf/nvm that use shims requiring $HOME.
 func setupWithRealHome(env *testscript.Env) error {
 	env.Setenv("HOME", realHome)
-	return nil
+	return setupNoTelemetry(env)
 }
 
 // TestRunme tests runme end-to-end using testscript.
@@ -51,6 +64,7 @@ func TestRunmeFlags(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata/flags",
 		ContinueOnError: true,
+		Setup:           setupNoTelemetry,
 	})
 }
 
@@ -58,6 +72,7 @@ func TestRunmeTags(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata/tags",
 		ContinueOnError: true,
+		Setup:           setupNoTelemetry,
 	})
 }
 
@@ -65,6 +80,7 @@ func TestRunmeRunAll(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata/runall",
 		ContinueOnError: true,
+		Setup:           setupNoTelemetry,
 	})
 }
 
@@ -72,6 +88,7 @@ func TestRunmeBeta(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata/beta",
 		ContinueOnError: true,
+		Setup:           setupNoTelemetry,
 	})
 }
 
@@ -83,6 +100,7 @@ func TestRunmeFilePermissions(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:             "testdata/permissions",
 		ContinueOnError: true,
+		Setup:           setupNoTelemetry,
 	})
 }
 
@@ -92,6 +110,7 @@ func TestSkipPromptsWithinAPty(t *testing.T) {
 	defer os.Unsetenv("RUNME_VERBOSE")
 
 	cmd := exec.Command("go", "run", ".", "run", "skip-prompts-sample", "--chdir", "./examples/frontmatter/skipPrompts")
+	cmd.Env = append(os.Environ(), "DO_NOT_TRACK=true", "SCARF_NO_ANALYTICS=true")
 	ptmx, err := pty.StartWithAttrs(cmd, &pty.Winsize{Rows: 25, Cols: 80}, &syscall.SysProcAttr{})
 	require.NoError(t, err)
 	defer ptmx.Close()

--- a/telemetry/cli.go
+++ b/telemetry/cli.go
@@ -1,0 +1,95 @@
+package telemetry
+
+import (
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+
+	"github.com/runmedev/runme/v3/internal/version"
+)
+
+const cliInvocationEvent = "cli_invocation"
+
+type cliInvocation struct {
+	command        string
+	commandPath    string
+	version        string
+	goos           string
+	arch           string
+	installChannel string
+}
+
+func reportCLIInvocationDefault(cmd *cobra.Command) bool {
+	invocation := newCLIInvocation(cmd)
+	if !invocation.shouldReport() {
+		return false
+	}
+
+	return newReporter(zap.NewNop()).report(invocation.event())
+}
+
+func newCLIInvocation(cmd *cobra.Command) cliInvocation {
+	if cmd == nil {
+		return cliInvocation{}
+	}
+
+	path := cmd.CommandPath()
+
+	return cliInvocation{
+		command:        topLevelCommand(path),
+		commandPath:    coarseCommandPath(path),
+		version:        version.BuildVersion,
+		goos:           runtime.GOOS,
+		arch:           runtime.GOARCH,
+		installChannel: installChannel(),
+	}
+}
+
+func (i cliInvocation) shouldReport() bool {
+	switch i.commandPath {
+	case "", "server", "beta server start", "harbor stdio":
+		return false
+	default:
+		return true
+	}
+}
+
+func (i cliInvocation) event() event {
+	props := map[string]string{
+		"component":       "cli",
+		"version":         i.version,
+		"os":              i.goos,
+		"arch":            i.arch,
+		"command":         i.command,
+		"command_path":    i.commandPath,
+		"install_channel": i.installChannel,
+	}
+
+	return event{
+		client:  clientCLI,
+		name:    cliInvocationEvent,
+		props:   props,
+		timeout: 2 * time.Second,
+	}
+}
+
+func topLevelCommand(commandPath string) string {
+	parts := strings.Fields(commandPath)
+	if len(parts) < 2 {
+		return "tui"
+	}
+
+	return parts[1]
+}
+
+func coarseCommandPath(commandPath string) string {
+	parts := strings.Fields(commandPath)
+	if len(parts) <= 1 {
+		return "runme"
+	}
+
+	return strings.Join(parts[1:], " ")
+}

--- a/telemetry/cli_test.go
+++ b/telemetry/cli_test.go
@@ -1,0 +1,127 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCLIInvocation(t *testing.T) {
+	cmd := &cobra.Command{Use: "run"}
+	root := &cobra.Command{Use: "runme"}
+	root.AddCommand(cmd)
+
+	invocation := newCLIInvocation(cmd)
+	require.Equal(t, "run", invocation.command)
+	require.Equal(t, "run", invocation.commandPath)
+	require.NotEmpty(t, invocation.version)
+	require.NotEmpty(t, invocation.goos)
+	require.NotEmpty(t, invocation.arch)
+	require.NotEmpty(t, invocation.installChannel)
+
+	event := invocation.event()
+	require.Equal(t, clientCLI, event.client)
+	require.Equal(t, cliInvocationEvent, event.name)
+	require.Equal(t, "cli", event.props["component"])
+	require.Equal(t, "run", event.props["command"])
+	require.Equal(t, "run", event.props["command_path"])
+	require.NotEmpty(t, event.props["version"])
+	require.NotEmpty(t, event.props["os"])
+	require.NotEmpty(t, event.props["arch"])
+	require.NotEmpty(t, event.props["install_channel"])
+}
+
+func TestCLIInvocationShouldReport(t *testing.T) {
+	t.Run("RegularCommand", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "run"}
+		root := &cobra.Command{Use: "runme"}
+		root.AddCommand(cmd)
+
+		require.True(t, newCLIInvocation(cmd).shouldReport())
+	})
+
+	t.Run("KernelServer", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "server"}
+		root := &cobra.Command{Use: "runme"}
+		root.AddCommand(cmd)
+
+		require.False(t, newCLIInvocation(cmd).shouldReport())
+	})
+
+	t.Run("BetaKernelServerStart", func(t *testing.T) {
+		start := &cobra.Command{Use: "start"}
+		server := &cobra.Command{Use: "server"}
+		beta := &cobra.Command{Use: "beta"}
+		root := &cobra.Command{Use: "runme"}
+		server.AddCommand(start)
+		beta.AddCommand(server)
+		root.AddCommand(beta)
+
+		require.False(t, newCLIInvocation(start).shouldReport())
+	})
+
+	t.Run("HarborStdio", func(t *testing.T) {
+		stdio := &cobra.Command{Use: "stdio"}
+		harbor := &cobra.Command{Use: "harbor"}
+		root := &cobra.Command{Use: "runme"}
+		harbor.AddCommand(stdio)
+		root.AddCommand(harbor)
+
+		require.False(t, newCLIInvocation(stdio).shouldReport())
+	})
+
+	t.Run("NilCommand", func(t *testing.T) {
+		require.False(t, newCLIInvocation(nil).shouldReport())
+	})
+}
+
+func TestInstallChannelFromPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "HomebrewAppleSilicon",
+			path: "/opt/homebrew/Cellar/runme/3.9.0/bin/runme",
+			want: installChannelHomebrew,
+		},
+		{
+			name: "HomebrewIntel",
+			path: "/usr/local/Cellar/runme/3.9.0/bin/runme",
+			want: installChannelHomebrew,
+		},
+		{
+			name: "NPMGlobal",
+			path: "/usr/local/lib/node_modules/runme/.bin/runme",
+			want: installChannelNPM,
+		},
+		{
+			name: "NPMNpxCache",
+			path: "/Users/person/.npm/_npx/abc123/node_modules/runme/.bin/runme",
+			want: installChannelNPM,
+		},
+		{
+			name: "GoInstall",
+			path: "/Users/person/go/bin/runme",
+			want: installChannelGoInstall,
+		},
+		{
+			name: "LinuxPackage",
+			path: "/usr/bin/runme",
+			want: installChannelLinuxPackage,
+		},
+		{
+			name: "Unknown",
+			path: "/tmp/random/runme",
+			want: installChannelUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, installChannelFromPath(tt.path))
+		})
+	}
+}

--- a/telemetry/cobra.go
+++ b/telemetry/cobra.go
@@ -1,0 +1,49 @@
+package telemetry
+
+import (
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+var reportCLIInvocation = reportCLIInvocationDefault
+
+func InstrumentCommandTree(root *cobra.Command) {
+	var once sync.Once
+	instrumentCommandTree(root, root, &once)
+}
+
+func instrumentCommandTree(root, cmd *cobra.Command, once *sync.Once) {
+	if cmd == nil {
+		return
+	}
+
+	if cmd == root || cmd.PersistentPreRun != nil || cmd.PersistentPreRunE != nil {
+		wrapPersistentPreRun(cmd, once)
+	}
+
+	for _, child := range cmd.Commands() {
+		instrumentCommandTree(root, child, once)
+	}
+}
+
+func wrapPersistentPreRun(cmd *cobra.Command, once *sync.Once) {
+	oldRun := cmd.PersistentPreRun
+	oldRunE := cmd.PersistentPreRunE
+
+	cmd.PersistentPreRun = nil
+	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		once.Do(func() {
+			reportCLIInvocation(cmd)
+		})
+
+		if oldRunE != nil {
+			return oldRunE(cmd, args)
+		}
+		if oldRun != nil {
+			oldRun(cmd, args)
+		}
+
+		return nil
+	}
+}

--- a/telemetry/cobra_test.go
+++ b/telemetry/cobra_test.go
@@ -1,0 +1,154 @@
+package telemetry
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrumentCommandTreePreservesRootPersistentPreRun(t *testing.T) {
+	var reportedPath string
+	var rootRan bool
+
+	withReportCLIInvocation(t, func(cmd *cobra.Command) bool {
+		reportedPath = cmd.CommandPath()
+		return true
+	})
+
+	root := &cobra.Command{
+		Use: "runme",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			rootRan = true
+		},
+	}
+	child := &cobra.Command{
+		Use: "run",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(child)
+	InstrumentCommandTree(root)
+	root.SetArgs([]string{"run"})
+
+	require.NoError(t, root.Execute())
+	require.True(t, rootRan)
+	require.Equal(t, "runme run", reportedPath)
+}
+
+func TestInstrumentCommandTreePreservesPersistentPreRunEError(t *testing.T) {
+	wantErr := errors.New("boom")
+	var reported bool
+
+	withReportCLIInvocation(t, func(cmd *cobra.Command) bool {
+		reported = true
+		return true
+	})
+
+	root := &cobra.Command{Use: "runme"}
+	beta := &cobra.Command{
+		Use: "beta",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return wantErr
+		},
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(beta)
+	InstrumentCommandTree(root)
+	root.SetArgs([]string{"beta"})
+
+	err := root.Execute()
+	require.ErrorIs(t, err, wantErr)
+	require.True(t, reported)
+}
+
+func TestInstrumentCommandTreeCoversNestedPersistentPreRunE(t *testing.T) {
+	var reportedPath string
+	var serverRan bool
+
+	withReportCLIInvocation(t, func(cmd *cobra.Command) bool {
+		reportedPath = cmd.CommandPath()
+		return true
+	})
+
+	root := &cobra.Command{Use: "runme"}
+	beta := &cobra.Command{Use: "beta"}
+	server := &cobra.Command{
+		Use: "server",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			serverRan = true
+			return nil
+		},
+	}
+	list := &cobra.Command{
+		Use: "list",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	server.AddCommand(list)
+	beta.AddCommand(server)
+	root.AddCommand(beta)
+	InstrumentCommandTree(root)
+	root.SetArgs([]string{"beta", "server", "list"})
+
+	require.NoError(t, root.Execute())
+	require.True(t, serverRan)
+	require.Equal(t, "runme beta server list", reportedPath)
+}
+
+func TestInstrumentCommandTreeReportsOnce(t *testing.T) {
+	var reportCount int
+
+	withReportCLIInvocation(t, func(cmd *cobra.Command) bool {
+		reportCount++
+		return true
+	})
+
+	root := &cobra.Command{
+		Use:              "runme",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	}
+	child := &cobra.Command{
+		Use:              "run",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+		Run:              func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(child)
+	InstrumentCommandTree(root)
+	root.SetArgs([]string{"run"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, 1, reportCount)
+}
+
+func TestInstrumentCommandTreeSkipsKernelServer(t *testing.T) {
+	var reportCount int
+
+	withReportCLIInvocation(t, func(cmd *cobra.Command) bool {
+		if newCLIInvocation(cmd).shouldReport() {
+			reportCount++
+		}
+		return true
+	})
+
+	root := &cobra.Command{Use: "runme"}
+	server := &cobra.Command{
+		Use: "server",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(server)
+	InstrumentCommandTree(root)
+	root.SetArgs([]string{"server"})
+
+	require.NoError(t, root.Execute())
+	require.Equal(t, 0, reportCount)
+}
+
+func withReportCLIInvocation(t *testing.T, fn func(*cobra.Command) bool) {
+	t.Helper()
+
+	previous := reportCLIInvocation
+	reportCLIInvocation = fn
+	t.Cleanup(func() {
+		reportCLIInvocation = previous
+	})
+}

--- a/telemetry/env.go
+++ b/telemetry/env.go
@@ -1,0 +1,10 @@
+package telemetry
+
+import "os"
+
+type lookupEnvFunc func(key string) (string, bool)
+
+var (
+	getenv    = os.Getenv
+	lookupEnv = os.LookupEnv
+)

--- a/telemetry/install_channel.go
+++ b/telemetry/install_channel.go
@@ -1,0 +1,76 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	installChannelHomebrew     = "homebrew"
+	installChannelNPM          = "npm"
+	installChannelGoInstall    = "go_install"
+	installChannelLinuxPackage = "linux_package"
+	installChannelDocker       = "docker"
+	installChannelSource       = "source"
+	installChannelUnknown      = "unknown"
+)
+
+func installChannel() string {
+	if runningInContainer() {
+		return installChannelDocker
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return installChannelUnknown
+	}
+
+	resolved, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		resolved = executable
+	}
+
+	return installChannelFromPath(resolved)
+}
+
+func installChannelFromPath(path string) string {
+	normalized := filepath.ToSlash(strings.ToLower(path))
+
+	switch {
+	case strings.Contains(normalized, "/cellar/runme/"),
+		strings.Contains(normalized, "/homebrew/"),
+		strings.Contains(normalized, "/linuxbrew/"):
+		return installChannelHomebrew
+	case strings.Contains(normalized, "/node_modules/"),
+		strings.Contains(normalized, "/npm/"):
+		return installChannelNPM
+	case strings.HasSuffix(normalized, "/go/bin/runme"),
+		strings.Contains(normalized, "/go/bin/runme"):
+		return installChannelGoInstall
+	case normalized == "/usr/bin/runme",
+		normalized == "/bin/runme",
+		strings.HasPrefix(normalized, "/usr/lib/runme/"),
+		strings.HasPrefix(normalized, "/usr/share/runme/"):
+		return installChannelLinuxPackage
+	case strings.Contains(normalized, "/runme/") && strings.HasSuffix(normalized, "/runme"):
+		return installChannelSource
+	default:
+		return installChannelUnknown
+	}
+}
+
+func runningInContainer() bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+
+	for _, path := range []string{"/.dockerenv", "/run/.containerenv"} {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+
+	return false
+}

--- a/telemetry/kernel.go
+++ b/telemetry/kernel.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func ReportKernelStartup(logger *zap.Logger) bool {
+	return newReporter(logger).report(kernelStartupEventFromEnv(lookupEnv))
+}
+
+func kernelStartupEventFromEnv(lookup lookupEnvFunc) event {
+	props := map[string]string{}
+	for _, prop := range []string{
+		"extname",
+		"extversion",
+		"remotename",
+		"appname",
+		"product",
+		"platform",
+		"uikind",
+	} {
+		addEnvProp(lookup, props, prop)
+	}
+
+	return event{
+		client:  clientKernel,
+		props:   props,
+		timeout: 30 * time.Second,
+	}
+}
+
+func addEnvProp(lookup lookupEnvFunc, props map[string]string, prop string) {
+	if v, ok := lookup(fmt.Sprintf("TELEMETRY_%s", strings.ToUpper(prop))); ok {
+		props[strings.ToLower(prop)] = v
+	}
+}

--- a/telemetry/scarf.go
+++ b/telemetry/scarf.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,47 +13,91 @@ import (
 )
 
 const (
-	base   = "https://home.runme.dev/"
-	client = "Kernel"
+	baseURL = "https://home.runme.dev/"
+
+	envDoNotTrack       = "DO_NOT_TRACK"
+	envScarfNoAnalytics = "SCARF_NO_ANALYTICS"
 )
 
-type (
-	reporterFunc  func() error
-	lookupEnvFunc func(key string) (string, bool)
+type client string
+
+const (
+	clientKernel client = "Kernel"
+	clientCLI    client = "CLI"
 )
 
-var reporter reporterFunc
-
-func init() {
-	reporter = liveReporter
+type event struct {
+	client  client
+	name    string
+	props   map[string]string
+	timeout time.Duration
 }
 
-// Returns true if telemetry reporting is enabled, false otherwise.
-func ReportUnlessNoTracking(logger *zap.Logger) bool {
-	disablers := []string{"DO_NOT_TRACK", "SCARF_NO_ANALYTICS"}
+type reporter interface {
+	report(event event) bool
+}
 
-	for _, key := range disablers {
-		disabled, err := trackingDisabledForEnv(key)
-		if err == nil && disabled {
-			logger.Info(fmt.Sprintf("Telemetry reporting is disabled with %s", key))
-			return false
+type scarfReporter struct {
+	logger *zap.Logger
+	client *http.Client
+}
+
+type noopReporter struct{}
+
+func newReporter(logger *zap.Logger) reporter {
+	if TelemetryDisabledByUserOptOut() {
+		if logger != nil {
+			logger.Info("Telemetry reporting is disabled by user opt-out")
 		}
+		return noopReporter{}
 	}
 
-	logger.Info("Telemetry reporting is enabled")
+	return newScarfReporter(logger, http.DefaultClient)
+}
+
+func newScarfReporter(logger *zap.Logger, client *http.Client) reporter {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	return &scarfReporter{
+		logger: logger,
+		client: client,
+	}
+}
+
+func (r *scarfReporter) report(event event) bool {
+	r.logger.Info("Telemetry reporting is enabled")
 
 	go func() {
-		err := reporter()
-		if err != nil {
-			logger.Warn("Error reporting telemetry", zap.Error(err))
+		if err := r.send(event); err != nil {
+			r.logger.Warn("Error reporting telemetry", zap.Error(err))
 		}
 	}()
 
 	return true
 }
 
+func (noopReporter) report(event) bool {
+	return false
+}
+
+func TelemetryDisabledByUserOptOut() bool {
+	for _, key := range []string{envDoNotTrack, envScarfNoAnalytics} {
+		disabled, err := trackingDisabledForEnv(key)
+		if err == nil && disabled {
+			return true
+		}
+	}
+
+	return false
+}
+
 func trackingDisabledForEnv(key string) (bool, error) {
-	val, err := strconv.ParseBool(os.Getenv(key))
+	val, err := strconv.ParseBool(getenv(key))
 	if err != nil {
 		return false, err
 	}
@@ -63,21 +105,26 @@ func trackingDisabledForEnv(key string) (bool, error) {
 	return val, nil
 }
 
-func liveReporter() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	encodedURL, err := buildURL(os.LookupEnv, client)
-	if err != nil {
-		return errors.Wrapf(err, "Error building telemtry URL")
+func (r *scarfReporter) send(event event) error {
+	timeout := event.timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", encodedURL.String(), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	encodedURL, err := buildURL(baseURL, event)
+	if err != nil {
+		return errors.Wrapf(err, "Error building telemetry URL")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, encodedURL.String(), nil)
 	if err != nil {
 		return errors.Wrapf(err, "Error creating telemetry request")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "Error sending telemetry request")
 	}
@@ -90,40 +137,32 @@ func liveReporter() error {
 	return nil
 }
 
-func buildURL(lookup lookupEnvFunc, client string) (*url.URL, error) {
-	baseAndClient := base + client
+func buildURL(base string, event event) (*url.URL, error) {
+	if event.client == "" {
+		return nil, fmt.Errorf("telemetry client is required")
+	}
 
-	props := []string{
-		"extname",
-		"extversion",
-		"remotename",
-		"appname",
-		"product",
-		"platform",
-		"uikind",
+	dst, err := url.Parse(base + string(event.client))
+	if err != nil {
+		return nil, err
 	}
 
 	params := url.Values{}
-	for _, p := range props {
-		addValue(lookup, &params, p)
+	if event.name != "" {
+		params.Add("event", event.name)
+	}
+	for key, value := range event.props {
+		if value != "" {
+			params.Add(key, value)
+		}
 	}
 
-	// until we have a non-extension-bundled reporting strategy, lets error
+	// Until we have a non-extension-bundled reporting strategy, let's error.
 	if len(params) == 0 {
 		return nil, fmt.Errorf("no telemetry properties provided")
 	}
 
-	dst, err := url.Parse(baseAndClient)
-	if err != nil {
-		return nil, err
-	}
 	dst.RawQuery = params.Encode()
 
 	return dst, nil
-}
-
-func addValue(lookup lookupEnvFunc, params *url.Values, prop string) {
-	if v, ok := lookup(fmt.Sprintf("TELEMETRY_%s", strings.ToUpper(prop))); ok {
-		params.Add(strings.ToLower(prop), v)
-	}
 }

--- a/telemetry/scarf_test.go
+++ b/telemetry/scarf_test.go
@@ -1,43 +1,73 @@
 package telemetry
 
 import (
-	"os"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
-func TestReportUnlessNoTracking(t *testing.T) {
-	// don't send telemetry in tests
-	reporter = func() error {
-		return nil
-	}
+func TestNewReporter(t *testing.T) {
+	t.Run("Scarf", func(t *testing.T) {
+		t.Setenv(envDoNotTrack, "false")
+		t.Setenv(envScarfNoAnalytics, "false")
 
-	t.Run("Track", func(t *testing.T) {
-		logger := zap.NewNop()
-		require.True(t, ReportUnlessNoTracking(logger))
+		reporter := newReporter(zap.NewNop())
+		require.IsType(t, &scarfReporter{}, reporter)
 	})
 
 	t.Run("DO_NOT_TRACK", func(t *testing.T) {
-		logger := zap.NewNop()
-		t.Setenv("DO_NOT_TRACK", "true")
-		require.False(t, ReportUnlessNoTracking(logger))
+		t.Setenv(envDoNotTrack, "true")
+		reporter := newReporter(zap.NewNop())
+		require.IsType(t, noopReporter{}, reporter)
 	})
 
 	t.Run("SCARF_NO_ANALYTICS", func(t *testing.T) {
-		logger := zap.NewNop()
-		t.Setenv("SCARF_NO_ANALYTICS", "true")
-		defer os.Unsetenv("SCARF_NO_ANALYTICS")
-		require.False(t, ReportUnlessNoTracking(logger))
+		t.Setenv(envScarfNoAnalytics, "true")
+		reporter := newReporter(zap.NewNop())
+		require.IsType(t, noopReporter{}, reporter)
 	})
 }
 
-func TestUrlBuilder(t *testing.T) {
+func TestNoopReporter(t *testing.T) {
+	reporter := noopReporter{}
+	require.False(t, reporter.report(event{client: clientCLI, name: cliInvocationEvent}))
+}
+
+func TestScarfReporter(t *testing.T) {
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "https", req.URL.Scheme)
+		require.Equal(t, "home.runme.dev", req.URL.Host)
+		require.Equal(t, "/CLI", req.URL.Path)
+		require.Equal(t, cliInvocationEvent, req.URL.Query().Get("event"))
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		}, nil
+	})
+
+	reporter := &scarfReporter{
+		logger: zap.NewNop(),
+		client: &http.Client{Transport: transport},
+	}
+
+	err := reporter.send(event{
+		client: clientCLI,
+		name:   cliInvocationEvent,
+		props:  map[string]string{"component": "cli"},
+	})
+	require.NoError(t, err)
+}
+
+func TestBuildURL(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Full", func(t *testing.T) {
-		lookupEnv := createLookup(map[string]string{
+	t.Run("KernelFull", func(t *testing.T) {
+		t.Parallel()
+
+		event := kernelStartupEventFromEnv(createLookup(map[string]string{
 			"TELEMETRY_EXTNAME":    "stateful.runme",
 			"TELEMETRY_EXTVERSION": "3.7.7-dev.10",
 			"TELEMETRY_REMOTENAME": "none",
@@ -45,26 +75,51 @@ func TestUrlBuilder(t *testing.T) {
 			"TELEMETRY_PRODUCT":    "desktop",
 			"TELEMETRY_PLATFORM":   "darwin_arm64",
 			"TELEMETRY_UIKIND":     "desktop",
-		})
-		dst, err := buildURL(lookupEnv, "Kernel")
+		}))
+		dst, err := buildURL(baseURL, event)
 		require.NoError(t, err)
 		require.Equal(t, "https://home.runme.dev/Kernel?appname=Visual+Studio+Code&extname=stateful.runme&extversion=3.7.7-dev.10&platform=darwin_arm64&product=desktop&remotename=none&uikind=desktop", dst.String())
 	})
 
-	t.Run("Partial", func(t *testing.T) {
-		lookupEnv := createLookup(map[string]string{
+	t.Run("KernelPartial", func(t *testing.T) {
+		t.Parallel()
+
+		event := kernelStartupEventFromEnv(createLookup(map[string]string{
 			"TELEMETRY_EXTNAME":  "stateful.runme",
 			"TELEMETRY_PLATFORM": "linux_x64",
-		})
-		dst, err := buildURL(lookupEnv, "Kernel")
+		}))
+		dst, err := buildURL(baseURL, event)
 		require.NoError(t, err)
 		require.Equal(t, "https://home.runme.dev/Kernel?extname=stateful.runme&platform=linux_x64", dst.String())
 	})
 
-	t.Run("Empty", func(t *testing.T) {
-		lookupEnv := createLookup(map[string]string{})
-		_, err := buildURL(lookupEnv, "Kernel")
-		require.Error(t, err, "no telemetry properties provided")
+	t.Run("KernelEmpty", func(t *testing.T) {
+		t.Parallel()
+
+		event := kernelStartupEventFromEnv(createLookup(map[string]string{}))
+		_, err := buildURL(baseURL, event)
+		require.ErrorContains(t, err, "no telemetry properties provided")
+	})
+
+	t.Run("CLI", func(t *testing.T) {
+		t.Parallel()
+
+		dst, err := buildURL(baseURL, event{
+			client: clientCLI,
+			name:   cliInvocationEvent,
+			props: map[string]string{
+				"component":       "cli",
+				"version":         "1.2.3",
+				"os":              "darwin",
+				"arch":            "arm64",
+				"command":         "run",
+				"command_path":    "run",
+				"install_channel": "homebrew",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "https://home.runme.dev/CLI?arch=arm64&command=run&command_path=run&component=cli&event=cli_invocation&install_channel=homebrew&os=darwin&version=1.2.3", dst.String())
+		require.NotContains(t, dst.String(), "/opt/homebrew")
 	})
 }
 
@@ -73,4 +128,10 @@ func createLookup(fixture map[string]string) func(string) (string, bool) {
 		value, ok := fixture[key]
 		return value, ok
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }


### PR DESCRIPTION
## Summary

- refactor Scarf telemetry behind a `Reporter` interface with Scarf and noop implementations
- add CLI invocation telemetry on `home.runme.dev/CLI` with coarse command, platform, version, and best-effort install channel fields
- instrument the built Cobra command tree so commands with their own `PersistentPreRun(E)` remain covered without rewriting command constructors
- keep Kernel startup telemetry separate from CLI usage telemetry

## Docs follow-up

Docs should be updated out of band to reflect the new telemetry behavior:

- Runme now sends anonymous, coarse CLI invocation telemetry to `home.runme.dev/CLI`.
- Existing Kernel/server startup telemetry remains separate on `home.runme.dev/Kernel`.
- CLI telemetry includes only low-cardinality fields: event name, component, Runme version, OS, architecture, coarse command, coarse command path, and best-effort install channel.
- CLI telemetry must not be described as collecting command contents, raw args, notebook contents, file paths, working directories, environment values, repository remotes, usernames, hostnames, or executable paths.
- Users can opt out with either `DO_NOT_TRACK=true` or `SCARF_NO_ANALYTICS=true`.

## Testing

- `go test ./telemetry ./cmd ./internal/cmd/beta/...`
- `runme run test`

Note: the first full-suite run hit a flaky `command/Test_envCollectorFifo/Diff` failure (`invalid data read: env var format is incorrect`). Rerunning that package passed, and the subsequent full `runme run test` passed.
