### PR TITLE
feat: add version subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/runmedev/runme/v3/internal/cmd/beta"
 	"github.com/runmedev/runme/v3/internal/extension"
+	"github.com/runmedev/runme/v3/internal/version"
 	agent "github.com/runmedev/runme/v3/pkg/agent/cmd"
 	"github.com/runmedev/runme/v3/telemetry"
 )
@@ -38,6 +39,7 @@ func Root() *cobra.Command {
 		Use:           "runme",
 		Short:         "Execute commands directly from a README",
 		Long:          "Runme executes commands inside your runbooks, docs, and READMEs. Parses commands\ndirectly from markdown files to make them executable.",
+		Version:       version.BaseVersionInfo(),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -129,6 +131,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(shellCmd())
 	cmd.AddCommand(tokenCmd())
 	cmd.AddCommand(tuiCmd)
+	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(agent.NewAgentCmd("runme-agent"))
 
 	cmd.SetUsageTemplate(getUsageTemplate(cmd))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func versionCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "version",
+		Short: "Print the version",
+		Args:  cobra.NoArgs,
+		// Avoid root's terminal-title PersistentPreRun so output matches --version.
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		},
+		Run: func(cmd *cobra.Command, _ []string) {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s version %s\n", cmd.Root().Name(), cmd.Root().Version)
+		},
+	}
+
+	setDefaultFlags(&cmd)
+
+	return &cmd
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionCommandMatchesVersionFlag(t *testing.T) {
+	flagStdout, flagStderr := executeRootCommand(t, "--version")
+	commandStdout, commandStderr := executeRootCommand(t, "version")
+
+	require.Empty(t, flagStderr)
+	require.Empty(t, commandStderr)
+	require.Equal(t, flagStdout, commandStdout)
+}
+
+func executeRootCommand(t *testing.T, args ...string) (string, string) {
+	t.Helper()
+
+	cmd := Root()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(args)
+
+	require.NoError(t, cmd.Execute())
+
+	return stdout.String(), stderr.String()
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"runtime/pprof"
 
 	"github.com/runmedev/runme/v3/cmd"
-	"github.com/runmedev/runme/v3/internal/version"
 )
 
 func main() {
@@ -17,7 +16,6 @@ func main() {
 
 func root() (status int) {
 	root := cmd.Root()
-	root.Version = version.BaseVersionInfo()
 
 	rootWithCPUProfile(func() {
 		if err := root.Execute(); err != nil {

--- a/testdata/script/version.txtar
+++ b/testdata/script/version.txtar
@@ -1,3 +1,7 @@
 exec runme --version
-stdout '^runme version (?:[3-9]\d*|2\.\d+\.\d+|2\.0\.\d+|2\.0\.0)'
+stdout '^runme version (?:0\.0\.0|[3-9]\d*|2\.\d+\.\d+|2\.0\.\d+|2\.0\.0)'
+! stderr .
+
+exec runme version
+stdout '^runme version (?:0\.0\.0|[3-9]\d*|2\.\d+\.\d+|2\.0\.\d+|2\.0\.0)'
 ! stderr .


### PR DESCRIPTION
## Summary

- add `runme version` as a root subcommand matching `runme --version`
- move root version metadata into `cmd.Root()` so flag and subcommand share the same value
- cover exact output parity with a unit test and extend the existing version txtar fixture

## Tests

- `go test ./cmd`
- `go test -tags test_with_txtar . -run 'TestRunme/version$'`
- `./runme --version && ./runme version`

## Notes

- `runme run test` was attempted locally and failed in the existing `TestRunme/daggershell` fixture because Docker's Linux socket is unavailable: `dial unix /Users/sourishkrout/.docker/run/docker.sock: connect: no such file or directory`.
