### PR TITLE
ci: disable fail-fast on Go matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
     # Don't use make here as this job needs to be cross-platform.
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     name: Build and test with Go on ${{ matrix.os }}


### PR DESCRIPTION
Disable matrix fail-fast for the Go build/test job so Ubuntu and Windows complete independently in CI.