### PR TITLE
fix: render unresolved owl env snapshots

### DIFF
--- a/cmd/environment_store.go
+++ b/cmd/environment_store.go
@@ -347,18 +347,35 @@ func (c *runmeOwlStoreClient) sessionID(ctx context.Context, runnerClient runner
 func snapshotEnvsFromProto(envs []*runnerv1.MonitorEnvStoreResponseSnapshot_SnapshotEnv) []owlcmd.SnapshotEnv {
 	result := make([]owlcmd.SnapshotEnv, 0, len(envs))
 	for _, env := range envs {
+		visibility := snapshotVisibilityFromProto(env.GetStatus())
 		result = append(result, owlcmd.SnapshotEnv{
 			Name:        env.GetName(),
-			Value:       env.GetResolvedValue(),
+			Value:       snapshotValueFromProto(env.GetResolvedValue(), visibility),
 			Description: env.GetDescription(),
 			Type:        env.GetSpec(),
 			Source:      env.GetOrigin(),
 			Explicit:    snapshotExplicitFromProto(env),
-			Visibility:  snapshotVisibilityFromProto(env.GetStatus()),
+			Visibility:  visibility,
 			Diagnostics: snapshotDiagnosticsFromProto(env.GetErrors()),
 		})
 	}
 	return result
+}
+
+func snapshotValueFromProto(value string, visibility string) string {
+	if value != "" {
+		return value
+	}
+	switch visibility {
+	case "unresolved":
+		return "[unset]"
+	case "masked":
+		return "[masked]"
+	case "hidden":
+		return "[hidden]"
+	default:
+		return value
+	}
 }
 
 func snapshotExplicitFromProto(env *runnerv1.MonitorEnvStoreResponseSnapshot_SnapshotEnv) bool {
@@ -378,7 +395,7 @@ func snapshotVisibilityFromProto(status runnerv1.MonitorEnvStoreResponseSnapshot
 	case runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_LITERAL:
 		return "literal"
 	default:
-		return "unspecified"
+		return "unresolved"
 	}
 }
 

--- a/cmd/environment_store_test.go
+++ b/cmd/environment_store_test.go
@@ -36,6 +36,49 @@ func TestSnapshotEnvsFromProtoMarksExplicitRows(t *testing.T) {
 	assert.False(t, byName["HOME"])
 }
 
+func TestSnapshotEnvsFromProtoMapsVisibilityAndDisplayValue(t *testing.T) {
+	t.Parallel()
+
+	envs := snapshotEnvsFromProto([]*runnerv1.MonitorEnvStoreResponseSnapshot_SnapshotEnv{
+		{
+			Name:   "RUNME_TEST_TOKEN",
+			Spec:   "https://owl.runme.dev/v1/types/core/secret",
+			Status: runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_UNSPECIFIED,
+		},
+		{
+			Name:          "GITHUB_TOKEN",
+			Spec:          "https://owl.runme.dev/v1/types/core/secret",
+			ResolvedValue: "[masked]",
+			Status:        runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_MASKED,
+		},
+		{
+			Name:          "API_URL",
+			Spec:          "https://owl.runme.dev/v1/types/core/plain",
+			ResolvedValue: "https://api.example.com",
+			Status:        runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_LITERAL,
+		},
+		{
+			Name:   "DATABASE_URL",
+			Spec:   "https://owl.runme.dev/v1/types/core/opaque",
+			Status: runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_HIDDEN,
+		},
+	})
+
+	byName := make(map[string]owlcmd.SnapshotEnv, len(envs))
+	for _, env := range envs {
+		byName[env.Name] = env
+	}
+
+	assert.Equal(t, "[unset]", byName["RUNME_TEST_TOKEN"].Value)
+	assert.Equal(t, "unresolved", byName["RUNME_TEST_TOKEN"].Visibility)
+	assert.Equal(t, "[masked]", byName["GITHUB_TOKEN"].Value)
+	assert.Equal(t, "masked", byName["GITHUB_TOKEN"].Visibility)
+	assert.Equal(t, "https://api.example.com", byName["API_URL"].Value)
+	assert.Equal(t, "literal", byName["API_URL"].Visibility)
+	assert.Equal(t, "[hidden]", byName["DATABASE_URL"].Value)
+	assert.Equal(t, "hidden", byName["DATABASE_URL"].Visibility)
+}
+
 func TestSnapshotTypeProposalHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/redpanda-data/protoc-gen-go-mcp v0.0.0-20260709214304-372b2d56e470
 	github.com/rogpeppe/go-internal v1.15.0
 	github.com/rs/cors v1.11.1
-	github.com/runmedev/owl v1.0.2-0.20260725013433-c47cf16291e8
+	github.com/runmedev/owl v1.0.2-0.20260727162135-283c5346932d
 	github.com/spf13/viper v1.21.0
 	github.com/stateful/godotenv v0.0.0-20240309032207-c7bc0b812915
 	github.com/vektah/gqlparser/v2 v2.5.36

--- a/go.sum
+++ b/go.sum
@@ -431,14 +431,8 @@ github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY
 github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/runmedev/owl v1.0.2-0.20260725005903-15f6c331a32e h1:KzZ2Va/gBOzuQ55TElEceAriaHfcNRLL9FdvE4KVwpU=
-github.com/runmedev/owl v1.0.2-0.20260725005903-15f6c331a32e/go.mod h1:j9dHba3PZdEasw/CqycYvRyysO/gwfoWOq4p2jMfvNY=
-github.com/runmedev/owl v1.0.2-0.20260725011006-a58d17cfbb4d h1:ksUlhtc/3MfDGekVTTpJkYqQgqqQNPK4JSYAxPO25ps=
-github.com/runmedev/owl v1.0.2-0.20260725011006-a58d17cfbb4d/go.mod h1:j9dHba3PZdEasw/CqycYvRyysO/gwfoWOq4p2jMfvNY=
-github.com/runmedev/owl v1.0.2-0.20260725011605-eb5fab79e5a1 h1:DIBH1bRS+Nt7l/dl1nuGcbFsYMOxbKDpKJ1E2vR/hXE=
-github.com/runmedev/owl v1.0.2-0.20260725011605-eb5fab79e5a1/go.mod h1:j9dHba3PZdEasw/CqycYvRyysO/gwfoWOq4p2jMfvNY=
-github.com/runmedev/owl v1.0.2-0.20260725013433-c47cf16291e8 h1:653zga0vc905aVPSKcqH2TaCaIXmsJcHhzkf7wTBwQY=
-github.com/runmedev/owl v1.0.2-0.20260725013433-c47cf16291e8/go.mod h1:j9dHba3PZdEasw/CqycYvRyysO/gwfoWOq4p2jMfvNY=
+github.com/runmedev/owl v1.0.2-0.20260727162135-283c5346932d h1:fZzd8YA+bTR/N87YCcQrRVRw9hTrSi7m8YP3MDmGcnE=
+github.com/runmedev/owl v1.0.2-0.20260727162135-283c5346932d/go.mod h1:j9dHba3PZdEasw/CqycYvRyysO/gwfoWOq4p2jMfvNY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=

--- a/runner/service.go
+++ b/runner/service.go
@@ -958,6 +958,9 @@ func monitorEnvStoreStatusFromVisibility(visibility owl.Visibility) runnerv1.Mon
 	case owl.VisibilityHidden:
 		return runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_HIDDEN
 	case owl.VisibilityUnresolved:
+		// Legacy monitor snapshots have no explicit unresolved/unset status.
+		// Keep using UNSPECIFIED as the wire value and let clients render it as
+		// unresolved rather than exposing the proto default name.
 		return runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_UNSPECIFIED
 	default:
 		return runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_UNSPECIFIED

--- a/runner/service_test.go
+++ b/runner/service_test.go
@@ -1352,5 +1352,6 @@ func Test_convertToMonitorEnvStoreResponse_doesNotUseSnapshotOriginAsSource(t *t
 	envs := msg.GetSnapshot().GetEnvs()
 	require.Len(t, envs, 1)
 	assert.Empty(t, envs[0].Origin)
+	assert.Equal(t, "[unset]", envs[0].ResolvedValue)
 	assert.Equal(t, runnerv1.MonitorEnvStoreResponseSnapshot_STATUS_UNSPECIFIED, envs[0].Status)
 }


### PR DESCRIPTION
## Summary

- Render legacy monitor `STATUS_UNSPECIFIED` rows as Owl `unresolved` visibility instead of exposing `unspecified`
- Normalize empty unresolved, masked, and hidden snapshot values to stable display sentinels
- Document that unresolved Owl visibility still travels over the legacy monitor proto as `STATUS_UNSPECIFIED`
- Bump Owl for the snapshot table header rename from `VISIBILITY` back to `STATUS`

## Dependency

- Requires Owl PR: https://github.com/runmedev/owl/pull/11

## Tests

```bash
go test ./cmd ./runner
runme run test
```
