### PR TITLE
chore: allow Harbor 0.20

### DIFF
--- a/integrations/harbor/pyproject.toml
+++ b/integrations/harbor/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Topic :: System :: Shells",
 ]
 dependencies = [
-  "harbor>=0.16,<0.18",
+  "harbor>=0.16,<0.21",
   "protobuf>=7.35.1",
 ]
 license-files = ["LICENSE", "NOTICE"]

--- a/integrations/harbor/src/runme_harbor/cli.py
+++ b/integrations/harbor/src/runme_harbor/cli.py
@@ -16,7 +16,7 @@ from urllib.request import url2pathname
 
 PACKAGE_NAME = "runme-harbor"
 MIN_HARBOR_VERSION = (0, 16, 0)
-MAX_HARBOR_VERSION = (0, 18, 0)
+MAX_HARBOR_VERSION = (0, 21, 0)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -199,7 +199,7 @@ def _preflight_harbor_package() -> None:
 
     version = _version_tuple(importlib.metadata.version("harbor"))
     if version < MIN_HARBOR_VERSION or version >= MAX_HARBOR_VERSION:
-        raise SystemExit("Runme Harbor requires harbor>=0.16,<0.18.")
+        raise SystemExit("Runme Harbor requires harbor>=0.16,<0.21.")
 
 
 def _version_tuple(value: str) -> tuple[int, int, int]:

--- a/integrations/harbor/tests/test_cli.py
+++ b/integrations/harbor/tests/test_cli.py
@@ -177,7 +177,11 @@ def test_run_command_is_not_exposed(capsys: pytest.CaptureFixture[str]) -> None:
         ("0.16.9", True),
         ("0.17.0", True),
         ("0.17.1", True),
-        ("0.18.0", False),
+        ("0.18.0", True),
+        ("0.19.0", True),
+        ("0.20.0", True),
+        ("0.20.99", True),
+        ("0.21.0", False),
     ],
 )
 def test_preflight_harbor_version_range(
@@ -191,7 +195,7 @@ def test_preflight_harbor_version_range(
     if supported:
         cli._preflight_harbor_package()
     else:
-        with pytest.raises(SystemExit, match="harbor>=0.16,<0.18"):
+        with pytest.raises(SystemExit, match="harbor>=0.16,<0.21"):
             cli._preflight_harbor_package()
 
 

--- a/integrations/harbor/uv.lock
+++ b/integrations/harbor/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.17.1"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dirhash" },
@@ -619,6 +619,7 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -630,9 +631,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/2f/6ae61b6c03ca20966a5003b204abdfed75918792866c2c0a1feddadca088/harbor-0.17.1.tar.gz", hash = "sha256:ec796576b856090bdcc4d759b94c9b205bd0f9bb4334632ef33d27e5af10c86e", size = 1429228, upload-time = "2026-07-03T23:08:57.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/da/5a26998c6e7d9455321ab39bc8e9122993892ece13c3ad4f2b0de986aaf6/harbor-0.20.0.tar.gz", hash = "sha256:e2e5e88f772690fd121553ca34fd5d6dd6b4aaa51c8fae635abc84b112303112", size = 1590870, upload-time = "2026-07-18T21:25:22.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/fd/a7a311c0c1b2cf08947c68c8a743c1212ea65b0081a5264887baf12c3eac/harbor-0.17.1-py3-none-any.whl", hash = "sha256:70ec59ecb4af254bf74f1825e34fc8e06e13e4b3a50baca316907cea4344e155", size = 1625462, upload-time = "2026-07-03T23:08:55.504Z" },
+    { url = "https://files.pythonhosted.org/packages/76/03/b6617f32385295729f3af0ae0d512cf87ba4793b9ce462ea020d776a9025/harbor-0.20.0-py3-none-any.whl", hash = "sha256:4b7e48223aea2384cdb8c9eff35eaebd482fc9b1ec09f8193a121c47356ff19a", size = 1792416, upload-time = "2026-07-18T21:25:19.206Z" },
 ]
 
 [[package]]
@@ -1753,7 +1754,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "harbor", specifier = ">=0.16,<0.18" },
+    { name = "harbor", specifier = ">=0.16,<0.21" },
     { name = "protobuf", specifier = ">=7.35.1" },
 ]
 


### PR DESCRIPTION
## Summary
- widen the runme-harbor dependency/preflight range from `harbor>=0.16,<0.18` to `harbor>=0.16,<0.21`
- refresh the integration lockfile to Harbor `0.20.0`
- update version-boundary coverage so 0.18, 0.19, and 0.20 are accepted while 0.21 remains blocked

## Release-note review
Reviewed Harbor releases/tags from the previous allowed ceiling through latest stable `0.20.0`:
- `v0.18.0`: Hub auth switched from GoTrue sessions to personal API keys; viewer/Hub/allowlist improvements. No adapter imports or environment protocol breaks found.
- `v0.19.0`: no GitHub release entry, so reviewed the tag compare/changelog. Breaking-ish changes are legacy `harbor leaderboard` removal and Harbor auth module/API migration; Runme Harbor does not use those surfaces.
- `v0.20.0`: JSON output is now plain JSON, upload failures exit non-zero, OpenClaw/OpenHands fixes, `harbor exec --agent-timeout`. No break found for Runme's environment adapter or installed-agent wrappers.

Compatibility smoke: the integration test suite passes with Harbor `0.20.0` installed from the refreshed lockfile.

Release links:
- https://github.com/harbor-framework/harbor/releases/tag/v0.18.0
- https://github.com/harbor-framework/harbor/compare/v0.18.0...v0.19.0
- https://github.com/harbor-framework/harbor/releases/tag/v0.20.0

## Tests
- `cd integrations/harbor && uv run pytest`
- `runme run test`