### PR TITLE
eval: gate text stats reward on lint validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,12 @@ jobs:
           go-version-file: go.mod
       - name: Install dependencies
         run: make install/dev
-      # It duplicates running linter from pre-commit
-      # but as revive is set up differently, we want
-      # to make sure that `make lint` also works.
-      - name: Run lint from Makefile
-        run: make lint
+      - name: Run checks from Makefile
+        run: make check
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: lint
 
   harbor-python:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ Use `runme list` to see all available named commands. Key development commands:
 ```bash
 runme run build         # Build CLI binary to ./runme
 runme run setup         # Install dev tools (gofumpt, revive, etc.)
-runme run lint          # Run full linting suite
+runme run lint          # Run formatting and routine lint checks
+runme run check         # Run the complete lint and analysis suite
 runme run test          # Run all tests (unsets env vars, clears cache, builds first)
 runme run test-docker   # Run tests in Docker (for integration tests with Python/Node)
 runme run server-dev    # Run server in dev mode on 127.0.0.1:9999

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,14 +126,20 @@ python3 -m pip install pre-commit
 
 ## Linting
 
-Like many complex go projects, this project uses a variety of linting tools to ensure code quality and prevent regressions! The main linter (revive) can be run with:
+Like many complex Go projects, this project uses a variety of linting tools to ensure code quality and prevent regressions. Run the formatting and routine lint checks with:
 
 ```sh {"id":"01HF7BT3HEQBTBM9SSTKQENPT3","interactive":"false","name":"lint"}
 make lint
 make fmt
 ```
 
-The rest of the project's linting suite can be run with:
+The slower static-analysis, vet, lock, and security checks can be run separately with `make analyze`. Run the complete non-test quality suite with:
+
+```sh {"name":"check"}
+make check
+```
+
+The project's pre-commit hooks can be run with:
 
 ```sh {"id":"01HF7BT3HEQBTBM9SSTPGWHF1K"}
 pre-commit run --files */**

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 
+GO_FILES := git ls-files -z --cached --others --exclude-standard -- '*.go'
 GO_ROOT := $(shell go env GOROOT)
 GIT_SHA := $(shell git rev-parse HEAD)
 GIT_SHA_SHORT := $(shell git rev-parse --short HEAD)
@@ -107,8 +108,8 @@ install/dev:
 
 .PHONY: fmt
 fmt:
-	@go tool gofumpt -w .
-	@go tool goimports -local="github.com/runmedev/runme" -w -l .
+	@$(GO_FILES) | xargs -0 go tool gofumpt -w
+	@$(GO_FILES) | xargs -0 go tool goimports -local="github.com/runmedev/runme" -w -l
 
 .PHONY: generate
 generate: _generate fmt
@@ -119,10 +120,10 @@ _generate:
 
 .PHONY: lint
 lint:
-	@# "gofumpt -d ." does not return non-zero exit code if there are changes
-	test -z "$$(git ls-files '*.go' | xargs go tool gofumpt -d)"
-	@# "goimports -d ." does not return non-zero exit code if there are changes
-	test -z $(shell go tool goimports -local="github.com/runmedev/runme" -l .)
+	@# "gofumpt -d" does not return non-zero exit code if there are changes
+	test -z "$$($(GO_FILES) | xargs -0 go tool gofumpt -d)"
+	@# "goimports -d" does not return non-zero exit code if there are changes
+	test -z "$$($(GO_FILES) | xargs -0 go tool goimports -local="github.com/runmedev/runme" -l)"
 	go tool revive \
 		-config revive.toml \
 		-formatter friendly \

--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,16 @@ lint:
 		-formatter friendly \
 		-exclude pkg/agent/... \
 		./...
+
+.PHONY: analyze
+analyze:
 	go tool staticcheck ./...
-	go tool gosec -quiet -exclude=G110,G115,G204,G304,G404 -exclude-dir=pkg/agent -exclude-generated ./...
 	go vet -stdmethods=false ./...
 	go vet -vettool=$(shell go env GOPATH)/bin/checklocks $(shell go list ./... | grep -v '^github.com/runmedev/runme/v3/pkg/agent')
+	go tool gosec -quiet -exclude=G110,G115,G204,G304,G404 -exclude-dir=pkg/agent -exclude-generated ./...
+
+.PHONY: check
+check: lint analyze
 
 .PHONY: pre-commit
 pre-commit: build wasm test lint

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
@@ -25,3 +25,15 @@ Create a script that:
 ```
 
 The `sample.txt` file is already present in the working directory.
+
+## Validation
+
+This is an isolated example task, so do not run the repository's full test suite.
+After creating the files and generating `results.json`, run:
+
+```sh
+runme run lint
+```
+
+Allow the command to finish and do not suppress its output. `runme run test` is
+not required for this task.

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/instruction.md
@@ -35,5 +35,7 @@ After creating the files and generating `results.json`, run:
 runme run lint
 ```
 
-Allow the command to finish and do not suppress its output. `runme run test` is
-not required for this task.
+Run the command in the foreground with a timeout of 480 seconds, wait for it to
+finish, and do not suppress its output. If the environment moves it to the
+background, wait for that exact background task's completion notification
+before proceeding. `runme run test` is not required for this task.

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/solution/solve.sh
@@ -38,3 +38,4 @@ Path("results.json").write_text(json.dumps(results, indent=2))
 PY
 
 python analyze.py
+runme run lint

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
@@ -2,10 +2,19 @@
 
 import importlib.util
 import json
+import os
+import re
 import subprocess
 from pathlib import Path
 
 from rewardkit import criterion
+
+_DEFAULT_AGENT_TRAJECTORY = Path("/logs/agent/trajectory.json")
+_LINT_COMMAND_PATTERN = re.compile(
+    r"(?:^|&&|\|\||;|\n|[\"']cmd[\"']\s*:\s*[\"'])"
+    r"\s*runme\s+run\s+lint(?=\s|[\"'`;|&)]|$)"
+)
+_LINT_SUCCESS_PATTERN = re.compile(r"Task lint exited with code 0")
 
 
 def _load_module(workspace: Path, name: str):
@@ -99,6 +108,60 @@ def _structure_score(workspace: Path) -> float:
     ) / 3
 
 
+def _agent_trajectory_path() -> Path:
+    configured = os.environ.get("RUNME_AGENT_TRAJECTORY")
+    return Path(configured) if configured else _DEFAULT_AGENT_TRAJECTORY
+
+
+def _strings(value: object):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for nested in value.values():
+            yield from _strings(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from _strings(nested)
+
+
+def _lint_validation_score(workspace: Path) -> float:
+    del workspace
+
+    try:
+        trajectory = json.loads(_agent_trajectory_path().read_text())
+    except (OSError, ValueError):
+        return 0.0
+    if not isinstance(trajectory, dict):
+        return 0.0
+
+    command_seen = False
+    success_seen = False
+    for step in trajectory.get("steps", []):
+        if not isinstance(step, dict) or step.get("source") != "agent":
+            continue
+
+        tool_calls = step.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                if not isinstance(tool_call, dict):
+                    continue
+                arguments = tool_call.get("arguments")
+                if any(_LINT_COMMAND_PATTERN.search(text) for text in _strings(arguments)):
+                    command_seen = True
+
+        observation = step.get("observation")
+        if any(_LINT_SUCCESS_PATTERN.search(text) for text in _strings(observation)):
+            success_seen = True
+
+    return float(command_seen and success_seen)
+
+
+def _gated_reward_score(workspace: Path) -> float:
+    if _lint_validation_score(workspace) == 0.0:
+        return 0.0
+    return (_correctness_score(workspace) + _structure_score(workspace)) / 2
+
+
 @criterion(shared=True)
 def word_count_correct(workspace: Path) -> float:
     try:
@@ -123,3 +186,13 @@ def correctness(workspace: Path) -> float:
 @criterion(shared=True)
 def structure(workspace: Path) -> float:
     return _structure_score(workspace)
+
+
+@criterion(shared=True)
+def lint_validation(workspace: Path) -> float:
+    return _lint_validation_score(workspace)
+
+
+@criterion(shared=True)
+def gated_reward(workspace: Path) -> float:
+    return _gated_reward_score(workspace)

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
@@ -11,18 +11,38 @@ from rewardkit import criterion
 
 _DEFAULT_AGENT_TRAJECTORY = Path("/logs/agent/trajectory.json")
 _LINT_COMMAND_PATTERN = re.compile(
-    r"(?:^|&&|\|\||;|\n|[\"']cmd[\"']\s*:\s*[\"'])"
+    r"(?:^|&&|\|\||;|\n|[\"']?cmd[\"']?\s*:\s*[\"'])"
     r"\s*runme\s+run\s+lint(?=\s|[\"'`;|&)]|$)"
 )
 _TERMINAL_STATUS_PATTERNS = (
     re.compile(r"\bTask lint exited with code (-?\d+)\b", re.IGNORECASE),
     re.compile(r"\b(?:Process|Command) exited with code (-?\d+)\b", re.IGNORECASE),
     re.compile(r"\bExit code:\s*(-?\d+)\b", re.IGNORECASE),
+    re.compile(r"""["']exit_code["']\s*:\s*(-?\d+)""", re.IGNORECASE),
 )
-_RUNNING_SESSION_PATTERN = re.compile(
-    r"\b(?:Process|Script) running with (?:session|cell) ID ([\w.-]+)\b",
+_RUNNING_SESSION_PATTERNS = (
+    re.compile(
+        r"\b(?:Process|Script) running with (?:session|cell) ID ([\w.-]+)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"""["']session_id["']\s*:\s*["']?([\w.-]+)["']?""",
+        re.IGNORECASE,
+    ),
+)
+_SCRIPT_COMPLETED_PATTERN = re.compile(r"\bScript completed\b", re.IGNORECASE)
+_MOVED_TO_BACKGROUND_PATTERN = re.compile(
+    r"\bmoved to the background\b", re.IGNORECASE
+)
+_TASK_NOTIFICATION_PATTERN = re.compile(
+    r"<task-notification>(.*?)</task-notification>",
+    re.DOTALL,
+)
+_TASK_NOTIFICATION_EXIT_PATTERN = re.compile(
+    r"\bexit code\s+(-?\d+)\b",
     re.IGNORECASE,
 )
+_TERMINAL_TASK_STATUSES = frozenset({"completed", "failed", "canceled", "cancelled"})
 _SHELL_ARGUMENT_KEYS = frozenset({"cmd", "command", "script"})
 
 
@@ -147,13 +167,18 @@ def _running_sessions(value: object) -> set[str]:
     return {
         match.group(1)
         for text in _strings(value)
-        for match in _RUNNING_SESSION_PATTERN.finditer(text)
+        for pattern in _RUNNING_SESSION_PATTERNS
+        for match in pattern.finditer(text)
     }
 
 
 def _references_session(value: object, sessions: set[str]) -> bool:
     if isinstance(value, (str, int)):
-        return str(value) in sessions
+        text = str(value)
+        return any(
+            re.search(rf"(?<![\w.-]){re.escape(session)}(?![\w.-])", text)
+            for session in sessions
+        )
     if isinstance(value, dict):
         return any(_references_session(nested, sessions) for nested in value.values())
     if isinstance(value, list):
@@ -186,6 +211,66 @@ def _linked_results(step: dict[str, object], call_id: object) -> list[dict[str, 
     ]
 
 
+def _synchronous_success(results: list[dict[str, object]]) -> bool:
+    for result in results:
+        extra = result.get("extra")
+        if not isinstance(extra, dict) or extra.get("tool_result_is_error") is not False:
+            continue
+        if any(
+            _MOVED_TO_BACKGROUND_PATTERN.search(text) for text in _strings(result)
+        ):
+            continue
+
+        metadata = extra.get("tool_result_metadata")
+        if not isinstance(metadata, dict):
+            continue
+        tool_result = metadata.get("tool_use_result")
+        if isinstance(tool_result, dict) and (
+            tool_result.get("interrupted") is True
+            or "backgroundTaskId" in tool_result
+            or "timedOutAfterMs" in tool_result
+        ):
+            continue
+
+        return True
+
+    return False
+
+
+def _background_task_id(results: list[dict[str, object]]) -> str | None:
+    for result in results:
+        extra = result.get("extra")
+        if not isinstance(extra, dict) or extra.get("tool_result_is_error") is not False:
+            continue
+        metadata = extra.get("tool_result_metadata")
+        if not isinstance(metadata, dict):
+            continue
+        tool_result = metadata.get("tool_use_result")
+        if not isinstance(tool_result, dict):
+            continue
+        task_id = tool_result.get("backgroundTaskId")
+        if isinstance(task_id, str) and task_id:
+            return task_id
+    return None
+
+
+def _task_notification(message: object) -> dict[str, str] | None:
+    if not isinstance(message, str):
+        return None
+    notification = _TASK_NOTIFICATION_PATTERN.search(message)
+    if notification is None:
+        return None
+
+    fields: dict[str, str] = {}
+    body = notification.group(1)
+    for tag in ("task-id", "tool-use-id", "status", "summary"):
+        match = re.search(rf"<{tag}>\s*(.*?)\s*</{tag}>", body, re.DOTALL)
+        if match is None:
+            return None
+        fields[tag] = match.group(1)
+    return fields
+
+
 def _lint_validation_score(workspace: Path) -> float:
     del workspace
 
@@ -197,10 +282,41 @@ def _lint_validation_score(workspace: Path) -> float:
         return 0.0
 
     active_sessions: set[str] = set()
+    pending_background: tuple[str, str] | None = None
     for step in trajectory.get("steps", []):
-        if not isinstance(step, dict) or step.get("source") != "agent":
+        if not isinstance(step, dict):
             continue
 
+        if step.get("source") == "user" and pending_background is not None:
+            notification = _task_notification(step.get("message"))
+            if notification is None:
+                continue
+
+            task_id, tool_call_id = pending_background
+            if (
+                notification["task-id"] != task_id
+                or notification["tool-use-id"] != tool_call_id
+            ):
+                continue
+
+            status = notification["status"].strip().lower()
+            exit_match = _TASK_NOTIFICATION_EXIT_PATTERN.search(
+                notification["summary"]
+            )
+            if (
+                status == "completed"
+                and exit_match is not None
+                and int(exit_match.group(1)) == 0
+            ):
+                return 1.0
+            if status in _TERMINAL_TASK_STATUSES or (
+                exit_match is not None and int(exit_match.group(1)) != 0
+            ):
+                pending_background = None
+            continue
+
+        if step.get("source") != "agent":
+            continue
         tool_calls = step.get("tool_calls")
         if not isinstance(tool_calls, list):
             continue
@@ -217,12 +333,25 @@ def _lint_validation_score(workspace: Path) -> float:
 
             if runs_lint:
                 active_sessions.clear()
+                pending_background = None
                 status = _terminal_status(results)
                 if status is not None:
                     if status == 0:
                         return 1.0
                     continue
-                active_sessions.update(_running_sessions(results))
+                running_sessions = _running_sessions(results)
+                active_sessions.update(running_sessions)
+                background_task_id = _background_task_id(results)
+                tool_call_id = tool_call.get("tool_call_id")
+                if background_task_id is not None and isinstance(tool_call_id, str):
+                    pending_background = (background_task_id, tool_call_id)
+                if not running_sessions and _synchronous_success(results):
+                    return 1.0
+                if not running_sessions and any(
+                    _SCRIPT_COMPLETED_PATTERN.search(text)
+                    for text in _strings(results)
+                ):
+                    return 1.0
                 continue
 
             if active_sessions and _starts_shell_command(arguments):
@@ -236,7 +365,13 @@ def _lint_validation_score(workspace: Path) -> float:
                         return 1.0
                     active_sessions.clear()
                     continue
-                active_sessions.update(_running_sessions(results))
+                running_sessions = _running_sessions(results)
+                active_sessions.update(running_sessions)
+                if not running_sessions and any(
+                    _SCRIPT_COMPLETED_PATTERN.search(text)
+                    for text in _strings(results)
+                ):
+                    return 1.0
 
     return 0.0
 

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py
@@ -14,7 +14,16 @@ _LINT_COMMAND_PATTERN = re.compile(
     r"(?:^|&&|\|\||;|\n|[\"']cmd[\"']\s*:\s*[\"'])"
     r"\s*runme\s+run\s+lint(?=\s|[\"'`;|&)]|$)"
 )
-_LINT_SUCCESS_PATTERN = re.compile(r"Task lint exited with code 0")
+_TERMINAL_STATUS_PATTERNS = (
+    re.compile(r"\bTask lint exited with code (-?\d+)\b", re.IGNORECASE),
+    re.compile(r"\b(?:Process|Command) exited with code (-?\d+)\b", re.IGNORECASE),
+    re.compile(r"\bExit code:\s*(-?\d+)\b", re.IGNORECASE),
+)
+_RUNNING_SESSION_PATTERN = re.compile(
+    r"\b(?:Process|Script) running with (?:session|cell) ID ([\w.-]+)\b",
+    re.IGNORECASE,
+)
+_SHELL_ARGUMENT_KEYS = frozenset({"cmd", "command", "script"})
 
 
 def _load_module(workspace: Path, name: str):
@@ -124,6 +133,59 @@ def _strings(value: object):
             yield from _strings(nested)
 
 
+def _terminal_status(value: object) -> int | None:
+    statuses = [
+        int(match.group(1))
+        for text in _strings(value)
+        for pattern in _TERMINAL_STATUS_PATTERNS
+        for match in pattern.finditer(text)
+    ]
+    return statuses[-1] if statuses else None
+
+
+def _running_sessions(value: object) -> set[str]:
+    return {
+        match.group(1)
+        for text in _strings(value)
+        for match in _RUNNING_SESSION_PATTERN.finditer(text)
+    }
+
+
+def _references_session(value: object, sessions: set[str]) -> bool:
+    if isinstance(value, (str, int)):
+        return str(value) in sessions
+    if isinstance(value, dict):
+        return any(_references_session(nested, sessions) for nested in value.values())
+    if isinstance(value, list):
+        return any(_references_session(nested, sessions) for nested in value)
+    return False
+
+
+def _starts_shell_command(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    for key, nested in value.items():
+        if key in _SHELL_ARGUMENT_KEYS and isinstance(nested, str):
+            return True
+        if _starts_shell_command(nested):
+            return True
+    return False
+
+
+def _linked_results(step: dict[str, object], call_id: object) -> list[dict[str, object]]:
+    observation = step.get("observation")
+    if not isinstance(observation, dict):
+        return []
+    results = observation.get("results")
+    if not isinstance(results, list):
+        return []
+    return [
+        result
+        for result in results
+        if isinstance(result, dict) and result.get("source_call_id") == call_id
+    ]
+
+
 def _lint_validation_score(workspace: Path) -> float:
     del workspace
 
@@ -134,26 +196,49 @@ def _lint_validation_score(workspace: Path) -> float:
     if not isinstance(trajectory, dict):
         return 0.0
 
-    command_seen = False
-    success_seen = False
+    active_sessions: set[str] = set()
     for step in trajectory.get("steps", []):
         if not isinstance(step, dict) or step.get("source") != "agent":
             continue
 
         tool_calls = step.get("tool_calls")
-        if isinstance(tool_calls, list):
-            for tool_call in tool_calls:
-                if not isinstance(tool_call, dict):
+        if not isinstance(tool_calls, list):
+            continue
+
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+
+            arguments = tool_call.get("arguments")
+            results = _linked_results(step, tool_call.get("tool_call_id"))
+            runs_lint = any(
+                _LINT_COMMAND_PATTERN.search(text) for text in _strings(arguments)
+            )
+
+            if runs_lint:
+                active_sessions.clear()
+                status = _terminal_status(results)
+                if status is not None:
+                    if status == 0:
+                        return 1.0
                     continue
-                arguments = tool_call.get("arguments")
-                if any(_LINT_COMMAND_PATTERN.search(text) for text in _strings(arguments)):
-                    command_seen = True
+                active_sessions.update(_running_sessions(results))
+                continue
 
-        observation = step.get("observation")
-        if any(_LINT_SUCCESS_PATTERN.search(text) for text in _strings(observation)):
-            success_seen = True
+            if active_sessions and _starts_shell_command(arguments):
+                active_sessions.clear()
+                continue
 
-    return float(command_seen and success_seen)
+            if active_sessions and _references_session(arguments, active_sessions):
+                status = _terminal_status(results)
+                if status is not None:
+                    if status == 0:
+                        return 1.0
+                    active_sessions.clear()
+                    continue
+                active_sessions.update(_running_sessions(results))
+
+    return 0.0
 
 
 def _gated_reward_score(workspace: Path) -> float:

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/reward/rollup.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/reward/rollup.py
@@ -2,5 +2,4 @@
 
 from rewardkit import criteria
 
-criteria.correctness(weight=1.0)
-criteria.structure(weight=1.0)
+criteria.gated_reward(weight=1.0)

--- a/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/lint_validation.py
+++ b/examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/workflow/lint_validation.py
@@ -1,0 +1,5 @@
+"""Require evidence that the agent ran the lint task successfully."""
+
+from rewardkit import criteria
+
+criteria.lint_validation(weight=1.0)

--- a/integrations/harbor/tests/test_text_stats_reward_criteria.py
+++ b/integrations/harbor/tests/test_text_stats_reward_criteria.py
@@ -1,0 +1,198 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+CRITERIA_PATH = (
+    Path(__file__).parents[3]
+    / "examples/harbor/datasets/runme-rewardkit/text-stats-reward/tests/criteria.py"
+)
+
+
+@pytest.fixture
+def criteria(monkeypatch):
+    rewardkit = types.ModuleType("rewardkit")
+    rewardkit.criterion = lambda **_kwargs: lambda function: function
+    monkeypatch.setitem(sys.modules, "rewardkit", rewardkit)
+
+    spec = importlib.util.spec_from_file_location("text_stats_criteria", CRITERIA_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _step(
+    step_id: int,
+    function_name: str,
+    arguments: dict[str, object],
+    content: str,
+) -> dict[str, object]:
+    call_id = f"call-{step_id}"
+    return {
+        "step_id": step_id,
+        "source": "agent",
+        "tool_calls": [
+            {
+                "tool_call_id": call_id,
+                "function_name": function_name,
+                "arguments": arguments,
+            }
+        ],
+        "observation": {
+            "results": [{"source_call_id": call_id, "content": content}]
+        },
+    }
+
+
+def _score(criteria, monkeypatch, tmp_path: Path, steps: list[dict[str, object]]) -> float:
+    trajectory = tmp_path / "trajectory.json"
+    trajectory.write_text(json.dumps({"schema_version": "ATIF-v1.7", "steps": steps}))
+    monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
+    return criteria._lint_validation_score(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        "Task lint exited with code 0",
+        "Process exited with code 0",
+        "Command exited with code 0",
+        "Exit code: 0",
+    ],
+)
+def test_lint_validation_accepts_tty_and_non_tty_success(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+    terminal_status: str,
+) -> None:
+    steps = [_step(1, "arbitrary-shell-tool", {"command": "runme run lint"}, terminal_status)]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+def test_lint_validation_follows_async_session(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "exec_command",
+            {"cmd": "runme run lint"},
+            "Process running with session ID 63887",
+        ),
+        _step(
+            2,
+            "write_stdin",
+            {"session_id": 63887, "chars": ""},
+            "Process exited with code 0",
+        ),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+@pytest.mark.parametrize("status", ["Process exited with code 1", "Exit code: 2"])
+def test_lint_validation_rejects_failure(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+    status: str,
+) -> None:
+    steps = [_step(1, "shell", {"cmd": "runme run lint"}, status)]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_incomplete_session(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "shell",
+            {"cmd": "runme run lint"},
+            "Process running with session ID lint-session",
+        )
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_unrelated_command_success(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "shell",
+            {"cmd": "runme run lint"},
+            "Process running with session ID lint-session",
+        ),
+        _step(
+            2,
+            "shell",
+            {"command": "echo unrelated"},
+            "Process exited with code 0",
+        ),
+        _step(
+            3,
+            "poll",
+            {"session_id": "lint-session"},
+            "Process exited with code 0",
+        ),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_accepts_successful_retry(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(1, "shell", {"cmd": "runme run lint"}, "Process exited with code 1"),
+        _step(2, "shell", {"cmd": "runme run lint"}, "Process exited with code 0"),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+def test_lint_validation_ignores_agent_claims(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        {
+            "step_id": 1,
+            "source": "agent",
+            "message": "runme run lint completed. Process exited with code 0",
+        }
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_malformed_trajectory(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    trajectory = tmp_path / "trajectory.json"
+    trajectory.write_text("[]")
+    monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
+
+    assert criteria._lint_validation_score(tmp_path) == 0.0

--- a/integrations/harbor/tests/test_text_stats_reward_criteria.py
+++ b/integrations/harbor/tests/test_text_stats_reward_criteria.py
@@ -31,8 +31,12 @@ def _step(
     function_name: str,
     arguments: dict[str, object],
     content: str,
+    result_extra: dict[str, object] | None = None,
 ) -> dict[str, object]:
     call_id = f"call-{step_id}"
+    result = {"source_call_id": call_id, "content": content}
+    if result_extra is not None:
+        result["extra"] = result_extra
     return {
         "step_id": step_id,
         "source": "agent",
@@ -44,7 +48,7 @@ def _step(
             }
         ],
         "observation": {
-            "results": [{"source_call_id": call_id, "content": content}]
+            "results": [result]
         },
     }
 
@@ -54,6 +58,56 @@ def _score(criteria, monkeypatch, tmp_path: Path, steps: list[dict[str, object]]
     trajectory.write_text(json.dumps({"schema_version": "ATIF-v1.7", "steps": steps}))
     monkeypatch.setenv("RUNME_AGENT_TRAJECTORY", str(trajectory))
     return criteria._lint_validation_score(tmp_path)
+
+
+def _background_lint_step(
+    step_id: int = 1,
+    task_id: str = "lint-task",
+) -> dict[str, object]:
+    return _step(
+        step_id,
+        "Bash",
+        {"command": "runme run lint", "timeout": 120000},
+        (
+            "Command did not complete within its 120s timeout and was moved "
+            f"to the background (ID: {task_id})."
+        ),
+        {
+            "tool_result_metadata": {
+                "tool_use_result": {
+                    "interrupted": False,
+                    "backgroundTaskId": task_id,
+                    "timedOutAfterMs": 120000,
+                },
+                "raw_tool_result": {"is_error": False},
+            },
+            "tool_result_is_error": False,
+        },
+    )
+
+
+def _task_notification_step(
+    step_id: int = 2,
+    task_id: str = "lint-task",
+    tool_use_id: str = "call-1",
+    status: str = "completed",
+    exit_code: int | None = 0,
+    source: str = "user",
+) -> dict[str, object]:
+    exit_summary = "" if exit_code is None else f" (exit code {exit_code})"
+    return {
+        "step_id": step_id,
+        "source": source,
+        "message": (
+            "<task-notification>\n"
+            f"<task-id>{task_id}</task-id>\n"
+            f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
+            f"<status>{status}</status>\n"
+            f'<summary>Background command "runme run lint" '
+            f"{status}{exit_summary}</summary>\n"
+            "</task-notification>"
+        ),
+    }
 
 
 @pytest.mark.parametrize(
@@ -99,6 +153,101 @@ def test_lint_validation_follows_async_session(
     assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
 
 
+def test_lint_validation_accepts_terra_cell_completion(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "exec",
+            {
+                "input": (
+                    'const r = await tools.exec_command({"cmd":"runme run lint"}); '
+                    "text(r.output);"
+                )
+            },
+            "Script running with cell ID 4\nWall time 11.0 seconds\nOutput:\n",
+        ),
+        _step(
+            2,
+            "wait",
+            {"cell_id": "4", "yield_time_ms": 30000},
+            "Script completed\nWall time 17.4 seconds\nOutput:\n",
+        ),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+def test_lint_validation_accepts_luna_structured_status(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "exec",
+            {
+                "input": (
+                    'const r = await tools.exec_command({cmd:"runme run lint"}); '
+                    "text(JSON.stringify(r));"
+                )
+            },
+            (
+                "Script completed\nWall time 1.2 seconds\nOutput:\n"
+                '\'{"session_id":38781,"output":"gofumpt"}\''
+            ),
+        ),
+        _step(
+            2,
+            "exec",
+            {
+                "input": (
+                    "const r = await tools.write_stdin({session_id:38781}); "
+                    "text(JSON.stringify(r));"
+                )
+            },
+            (
+                "Script completed\nWall time 8.0 seconds\nOutput:\n"
+                '\'{"exit_code":0,"output":""}\''
+            ),
+        ),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+def test_lint_validation_accepts_sonnet_synchronous_success(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "Bash",
+            {"command": "runme run lint", "timeout": 300000},
+            "gofumpt\ngoimports\nrevive",
+            {
+                "tool_result_metadata": {
+                    "tool_use_result": {
+                        "stdout": "gofumpt\ngoimports\nrevive",
+                        "stderr": "",
+                        "interrupted": False,
+                    },
+                    "raw_tool_result": {"is_error": False},
+                },
+                "tool_result_is_error": False,
+            },
+        )
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
 @pytest.mark.parametrize("status", ["Process exited with code 1", "Exit code: 2"])
 def test_lint_validation_rejects_failure(
     criteria,
@@ -107,6 +256,204 @@ def test_lint_validation_rejects_failure(
     status: str,
 ) -> None:
     steps = [_step(1, "shell", {"cmd": "runme run lint"}, status)]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_haiku_background_launch(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [_background_lint_step()]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_accepts_correlated_background_completion(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [_background_lint_step(), _task_notification_step()]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 1.0
+
+
+@pytest.mark.parametrize(
+    ("task_id", "tool_use_id"),
+    [
+        ("other-task", "call-1"),
+        ("lint-task", "other-call"),
+    ],
+)
+def test_lint_validation_ignores_uncorrelated_background_completion(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+    task_id: str,
+    tool_use_id: str,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        _task_notification_step(task_id=task_id, tool_use_id=tool_use_id),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("status", "exit_code"),
+    [
+        ("completed", 1),
+        ("completed", None),
+        ("failed", 0),
+        ("cancelled", 0),
+        ("canceled", 0),
+    ],
+)
+def test_lint_validation_rejects_unsuccessful_background_completion(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+    status: str,
+    exit_code: int | None,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        _task_notification_step(status=status, exit_code=exit_code),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_clears_correlated_background_failure(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        _task_notification_step(status="failed", exit_code=1),
+        _task_notification_step(step_id=3),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_ignores_agent_background_completion_spoof(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        _task_notification_step(source="agent"),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_ignores_ordinary_user_completion_claim(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        {
+            "step_id": 2,
+            "source": "user",
+            "message": "The lint task completed with exit code 0.",
+        },
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_clears_background_attempt_on_new_lint_run(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _background_lint_step(),
+        _step(2, "Bash", {"command": "runme run lint"}, "Process exited with code 1"),
+        _task_notification_step(step_id=3),
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("is_error", "interrupted"),
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+def test_lint_validation_rejects_failed_or_interrupted_tool_result(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+    is_error: bool,
+    interrupted: bool,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "Bash",
+            {"command": "runme run lint"},
+            "lint output",
+            {
+                "tool_result_metadata": {
+                    "tool_use_result": {"interrupted": interrupted},
+                    "raw_tool_result": {"is_error": is_error},
+                },
+                "tool_result_is_error": is_error,
+            },
+        )
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_structured_failure_despite_completion(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "exec",
+            {"input": 'tools.exec_command({cmd:"runme run lint"})'},
+            (
+                "Script completed\nWall time 1.0 seconds\nOutput:\n"
+                '\'{"exit_code":1,"output":"lint failed"}\''
+            ),
+        )
+    ]
+
+    assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
+
+
+def test_lint_validation_rejects_completion_while_session_is_running(
+    criteria,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    steps = [
+        _step(
+            1,
+            "exec",
+            {"input": 'tools.exec_command({cmd:"runme run lint"})'},
+            (
+                "Script completed\nWall time 1.0 seconds\nOutput:\n"
+                '\'{"session_id":38781,"output":"gofumpt"}\''
+            ),
+        )
+    ]
 
     assert _score(criteria, monkeypatch, tmp_path, steps) == 0.0
 


### PR DESCRIPTION
## Summary

- require the isolated text-stats task to run `runme run lint` in the foreground with the task's 480-second timeout
- gate reward on successful lint evidence, including correlated Claude Code background-task completion
- reject incomplete, failed, mismatched, or agent-spoofed completion while preserving existing synchronous/session handling

## Validation

- focused and full Harbor tests
- `runme run lint test`
- live Claude Code Sonnet and Haiku trials: `1.0`