### PR TITLE
Scope eval concurrency default to Runme

### DIFF
--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -62,11 +62,12 @@ a task directory inside the dataset, such as `simple-agent` or
 
 `runme eval` delegates to `runme-harbor`, so these examples remain compatible
 with the underlying `harbor run` workflow. The adapter supports `oracle`,
-`antigravity-cli`, `codex`, `claude-code`, `cursor-cli`, and `openclaw` agents
-and runs local agent CLIs through `runme harbor stdio` by default. The default
-environment is `runme`; pass `--env runme` to select it explicitly. Passing a
-non-Runme Harbor environment, such as `--env docker`, delegates the selected
-environment and agent to Harbor without the Runme-specific agent wrappers.
+`nop`, `antigravity-cli`, `codex`, `claude-code`, `cursor-cli`, and `openclaw`
+agents and runs local agent CLIs through `runme harbor stdio` by default. The
+default environment is `runme`; pass `--env runme` to select it explicitly.
+Passing a non-Runme Harbor environment, such as `--env docker`, delegates the
+selected environment and agent to Harbor without the Runme-specific agent
+wrappers.
 Runme environments default to one concurrent trial because they share the host
 workspace. Other environments use Harbor's concurrency default. Override either
 behavior with passthrough arguments such as `-- --n-concurrent 4`.

--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -67,6 +67,9 @@ and runs local agent CLIs through `runme harbor stdio` by default. The default
 environment is `runme`; pass `--env runme` to select it explicitly. Passing a
 non-Runme Harbor environment, such as `--env docker`, delegates the selected
 environment and agent to Harbor without the Runme-specific agent wrappers.
+Runme environments default to one concurrent trial because they share the host
+workspace. Other environments use Harbor's concurrency default. Override either
+behavior with passthrough arguments such as `-- --n-concurrent 4`.
 
 Set `--runme-bin` to use a specific Runme binary. Set `--runme-arg` one or more
 times to pass global Runme flags before `harbor stdio`.

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -60,7 +60,7 @@ func (b harborRunArgsBuilder) Build() ([]string, error) {
 	}
 
 	extraArgs := b.extraArgs()
-	if !concurrencyHarborFlag.Present(extraArgs) {
+	if usesRunmeEnvironment(b.opts.Env) && !concurrencyHarborFlag.Present(extraArgs) {
 		args = append(args, "--n-concurrent", "1")
 	}
 	args = append(args, extraArgs...)

--- a/internal/harbor/eval_harbor_args.go
+++ b/internal/harbor/eval_harbor_args.go
@@ -13,6 +13,7 @@ const (
 
 var runmeAgentSpecs = []runmeAgentSpec{
 	{name: "oracle"},
+	{name: "nop"},
 	{name: "antigravity-cli", importPath: "runme_harbor.runme_agents:RunmeAntigravityCli"},
 	{name: "codex", importPath: "runme_harbor.runme_agents:RunmeCodex"},
 	{name: "claude-code", importPath: "runme_harbor.runme_agents:RunmeClaudeCode"},

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -817,13 +817,61 @@ func TestRunEvalDelegatesNonRunmeEnvWithoutPreflight(t *testing.T) {
 		"--env", "docker",
 		"--agent", "codex",
 		"-y",
-		"--n-concurrent", "1",
 	}
 	if len(calls) != 2 {
 		t.Fatalf("calls = %#v, want delegate and metadata sync", calls)
 	}
 	if !reflect.DeepEqual(calls[0].args, want) {
 		t.Fatalf("args = %#v, want %#v", calls[0].args, want)
+	}
+}
+
+func TestRunEvalPreservesPassthroughConcurrency(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		env          string
+		delegatedEnv string
+		passthrough  []string
+		delegateCall int
+	}{
+		{
+			name:         "runme long flag",
+			delegatedEnv: runmeEnvironmentImportPath,
+			passthrough:  []string{"--n-concurrent", "3"},
+			delegateCall: 1,
+		},
+		{
+			name:         "docker short flag",
+			env:          "docker",
+			delegatedEnv: "docker",
+			passthrough:  []string{"-n", "3"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := t.TempDir()
+			var calls []recordedCommand
+			opts := testEvalOptions(t, &calls, io.Discard)
+			opts.Env = tt.env
+
+			err := NewEvalRunner(opts).Run(append([]string{path}, tt.passthrough...))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := []string{
+				"run",
+				"--path",
+				mustAbs(t, path),
+				"--jobs-dir", defaultJobsDir(t),
+				"--env", tt.delegatedEnv,
+				"--agent", "oracle",
+				"-y",
+			}
+			want = append(want, tt.passthrough...)
+			if !reflect.DeepEqual(calls[tt.delegateCall].args, want) {
+				t.Fatalf("args = %#v, want %#v", calls[tt.delegateCall].args, want)
+			}
+		})
 	}
 }
 

--- a/internal/harbor/eval_test.go
+++ b/internal/harbor/eval_test.go
@@ -124,6 +124,32 @@ func TestRunEvalDelegatesAntigravityCli(t *testing.T) {
 	}
 }
 
+func TestRunEvalDelegatesNop(t *testing.T) {
+	path := t.TempDir()
+	var calls []recordedCommand
+	opts := testEvalOptions(t, &calls, io.Discard)
+	opts.Agent = "nop"
+
+	err := NewEvalRunner(opts).Run([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"run",
+		"--path",
+		mustAbs(t, path),
+		"--jobs-dir", defaultJobsDir(t),
+		"--env", runmeEnvironmentImportPath,
+		"--agent", "nop",
+		"-y",
+		"--n-concurrent", "1",
+	}
+	if !reflect.DeepEqual(calls[1].args, want) {
+		t.Fatalf("args = %#v, want %#v", calls[1].args, want)
+	}
+}
+
 func TestRunEvalDefaultsDatasetPath(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)


### PR DESCRIPTION
## Summary

- default Runme-backed evals to one concurrent trial
- let Docker and other sandboxed Harbor environments use Harbor's concurrency default
- preserve explicit `--n-concurrent` and `-n` passthrough overrides
- support Harbor's native `nop` agent in the Runme environment
- document the environment-specific concurrency and supported-agent behavior

## Why

Runme's default environment shares the host workspace and should remain serial. Docker and other Harbor environments are hermetic or sandboxed, so forcing them to one concurrent trial unnecessarily disables Harbor's safe parallelism.

The Runme environment validates agents against a curated allowlist. Harbor's `nop` agent is environment-agnostic and compatible with `RunmeEnvironment`, but was missing from that allowlist. Supporting it enables no-op tasks that verify environment behavior without requiring an agent or solution script.

## Documentation

`runme eval` uses concurrency 1 only for the Runme environment, including when `--env` is omitted or explicitly set to `--env runme`. Other environments, such as `--env docker`, do not receive this serial default and instead use Harbor's configured or default concurrency. Users can override concurrency for any environment with Harbor passthrough arguments, for example `-- --n-concurrent 4`.

The Runme environment's supported agent list now includes `nop` alongside `oracle`, `antigravity-cli`, `codex`, `claude-code`, `cursor-cli`, and `openclaw`.

## Validation

- `go test ./internal/harbor`
- `runme run lint test`