### PR TITLE
fix: isolate Antigravity evals and forward models

### DIFF
--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -83,7 +83,7 @@ class RunmeAntigravityCli(AntigravityCli):
                 environment,
                 command=(
                     'export PATH="$HOME/.local/bin:$PATH"\n'
-                    f"agy --dangerously-skip-permissions {extra_flags}"
+                    f"agy --new-project --dangerously-skip-permissions {extra_flags}"
                     f"--prompt={escaped_instruction} "
                     "2>&1 </dev/null | stdbuf -oL tee /logs/agent/antigravity-cli.txt"
                 ),

--- a/integrations/harbor/src/runme_harbor/runme_agents.py
+++ b/integrations/harbor/src/runme_harbor/runme_agents.py
@@ -78,12 +78,16 @@ class RunmeAntigravityCli(AntigravityCli):
 
         cli_flags = self.build_cli_flags()
         extra_flags = (cli_flags + " ") if cli_flags else ""
+        # The agy Go CLI selects its model from the --model flag; the ~/.agy
+        # settings.json written above is read only by the legacy CLI, so pass
+        # an explicitly configured model through to the current CLI.
+        model_flag = f"--model {shlex.quote(model)} " if model else ""
         try:
             await self.exec_as_agent(
                 environment,
                 command=(
                     'export PATH="$HOME/.local/bin:$PATH"\n'
-                    f"agy --new-project --dangerously-skip-permissions {extra_flags}"
+                    f"agy --new-project --dangerously-skip-permissions {model_flag}{extra_flags}"
                     f"--prompt={escaped_instruction} "
                     "2>&1 </dev/null | stdbuf -oL tee /logs/agent/antigravity-cli.txt"
                 ),

--- a/integrations/harbor/tests/test_runme_antigravity_cli.py
+++ b/integrations/harbor/tests/test_runme_antigravity_cli.py
@@ -63,7 +63,7 @@ def test_runme_antigravity_cli_uses_ambient_user_auth(
     assert len(calls) == 3
     assert "settings.json" in calls[0][0]
     assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
-    assert "\nagy --dangerously-skip-permissions " in calls[1][0]
+    assert "\nagy --new-project --dangerously-skip-permissions " in calls[1][0]
     assert "--prompt='write result.txt'" in calls[1][0]
     assert "/logs/agent/antigravity-cli.txt" in calls[1][0]
     assert "find ~/.agy/antigravity-cli/tmp" in calls[2][0]
@@ -95,7 +95,7 @@ def test_runme_antigravity_cli_can_use_local_default_model(tmp_path: Path) -> No
     asyncio.run(agent.run("write result.txt", environment, object()))
 
     assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
-    assert "\nagy --dangerously-skip-permissions " in calls[1][0]
+    assert "\nagy --new-project --dangerously-skip-permissions " in calls[1][0]
     assert "defaultModel" not in calls[0][0]
     assert "--prompt='write result.txt'" in calls[1][0]
 

--- a/integrations/harbor/tests/test_runme_antigravity_cli.py
+++ b/integrations/harbor/tests/test_runme_antigravity_cli.py
@@ -64,6 +64,7 @@ def test_runme_antigravity_cli_uses_ambient_user_auth(
     assert "settings.json" in calls[0][0]
     assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
     assert "\nagy --new-project --dangerously-skip-permissions " in calls[1][0]
+    assert "--model gemini-3-pro-preview " in calls[1][0]
     assert "--prompt='write result.txt'" in calls[1][0]
     assert "/logs/agent/antigravity-cli.txt" in calls[1][0]
     assert "find ~/.agy/antigravity-cli/tmp" in calls[2][0]
@@ -97,6 +98,7 @@ def test_runme_antigravity_cli_can_use_local_default_model(tmp_path: Path) -> No
     assert 'export PATH="$HOME/.local/bin:$PATH"' in calls[1][0]
     assert "\nagy --new-project --dangerously-skip-permissions " in calls[1][0]
     assert "defaultModel" not in calls[0][0]
+    assert "--model " not in calls[1][0]
     assert "--prompt='write result.txt'" in calls[1][0]
 
 


### PR DESCRIPTION
## What changed

- Start each Runme Antigravity eval with `agy --new-project`.
- Forward an explicitly configured Harbor model through `agy --model`.
- Preserve Antigravity's configured default when `runme eval` omits `--model`.
- Add regression assertions for isolated projects, explicit model forwarding, and default-model behavior.

## Why

The Antigravity CLI attached new eval conversations to its persisted `default-cli-project`. Agents therefore wrote into `~/.gemini/antigravity-cli/scratch` instead of the Harbor trial workdir, producing successful-looking runs with zero correctness and structure scores and allowing state to leak across trials.

The current Go-based `agy` CLI also selects explicit models from its `--model` flag. Writing `defaultModel` to the legacy `~/.agy` settings alone caused requested models to be silently ignored.

With project isolation enabled, the rewardkit smoke eval writes into the correct trial workdir and reaches 1.0 correctness and 1.0 structure.

## Validation

- `uv run pytest tests/test_runme_antigravity_cli.py` (6 passed)
- `runme run lint test`
- `git diff --check origin/main..HEAD`