### PR TITLE
test: detach runner service test logger

### DIFF
--- a/internal/testutils/runnerservice/runner_service.go
+++ b/internal/testutils/runnerservice/runner_service.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -16,7 +16,7 @@ import (
 func New(t *testing.T) (_ *bufconn.Listener, stop func()) {
 	t.Helper()
 
-	logger := zaptest.NewLogger(t)
+	logger := zap.NewNop()
 	factory := command.NewFactory(command.WithLogger(logger))
 
 	runnerService, err := runnerv2service.NewRunnerService(factory, logger)


### PR DESCRIPTION
## Summary
- use a detached no-op logger in the runner service test helper
- prevent async service goroutines from logging to testing.T after a test has completed

## Tests
- go test -count=50 ./runnerv2client
- runme run test