### PR TITLE
feat(eval): export reusable command constructors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Key packages:
 
 ## Development Notes
 
-**IMPORTANT: You MUST always run `runme run lint test` after making changes.**
+**IMPORTANT: You MUST always run the full `runme run check test` suite before committing changes.**
 
 - Tests require `TZ=UTC` environment variable
 - Protocol buffers managed with buf CLI; TypeScript definitions published to buf.build registry

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -39,7 +39,40 @@ var newEvalRunner = func(opts harbor.EvalOptions) evalRunner {
 	return harbor.NewEvalRunner(opts)
 }
 
+// NewEvalCmd returns the full runme eval command group.
+func NewEvalCmd() *cobra.Command {
+	cmd := newEvalRunCmd(
+		"eval [dataset-path] [flags] [-- harbor-flags...]",
+		"Run Harbor eval tasks with Runme",
+		fmt.Sprintf(`Run Harbor eval tasks with Runme.
+
+When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetPath),
+	)
+
+	cmd.AddCommand(NewEvalViewCmd())
+	cmd.AddCommand(evalPromoteCmd())
+	cmd.AddCommand(evalCompareCmd())
+	cmd.AddCommand(NewEvalTaskCmd())
+
+	return cmd
+}
+
+// NewEvalRunCmd returns the standalone eval runner command for reuse as an alias.
+func NewEvalRunCmd() *cobra.Command {
+	return newEvalRunCmd(
+		"run [dataset-path] [flags] [-- harbor-flags...]",
+		"Run Harbor eval tasks with Runme",
+		fmt.Sprintf(`Run Harbor eval tasks with Runme.
+
+When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetPath),
+	)
+}
+
 func evalCmd() *cobra.Command {
+	return NewEvalCmd()
+}
+
+func newEvalRunCmd(use, short, long string) *cobra.Command {
 	opts := evalOptions{
 		agent:   "oracle",
 		jobsDir: harbor.DefaultEvalJobsDir,
@@ -48,12 +81,10 @@ func evalCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "eval [dataset-path] [flags] [-- harbor-flags...]",
-		Short: "Run Harbor eval tasks with Runme",
-		Long: fmt.Sprintf(`Run Harbor eval tasks with Runme.
-
-When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetPath),
-		Args: validateEvalArgs,
+		Use:   use,
+		Short: short,
+		Long:  long,
+		Args:  validateEvalArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.stdout = cmd.OutOrStdout()
 			opts.stderr = cmd.ErrOrStderr()
@@ -85,11 +116,6 @@ When dataset-path is omitted, runme eval uses ./%s.`, harbor.DefaultEvalDatasetP
 	flags.StringArrayVar(&opts.runmeArgs, "runme-arg", nil, "Additional Runme argument used by the Harbor environment")
 	flags.StringVar(&opts.runmeHarbor, "runme-harbor-bin", "", "runme-harbor executable")
 	flags.BoolVar(&opts.debug, "debug", false, "Print delegated commands")
-
-	cmd.AddCommand(evalViewCmd())
-	cmd.AddCommand(evalPromoteCmd())
-	cmd.AddCommand(evalCompareCmd())
-	cmd.AddCommand(evalTaskCmd())
 
 	return cmd
 }

--- a/cmd/eval_task.go
+++ b/cmd/eval_task.go
@@ -28,18 +28,20 @@ type evalTaskNewOptions struct {
 	stderr      io.Writer
 }
 
-func evalTaskCmd() *cobra.Command {
+// NewEvalTaskCmd returns the eval task command group.
+func NewEvalTaskCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "task",
 		Short: "Manage Harbor eval tasks",
 	}
 
-	cmd.AddCommand(evalTaskNewCmd())
+	cmd.AddCommand(NewEvalTaskNewCmd())
 
 	return cmd
 }
 
-func evalTaskNewCmd() *cobra.Command {
+// NewEvalTaskNewCmd returns the eval task scaffold command.
+func NewEvalTaskNewCmd() *cobra.Command {
 	opts := evalTaskNewOptions{
 		tasksDir: harbor.DefaultEvalDatasetPath,
 		stdout:   os.Stdout,

--- a/cmd/eval_test.go
+++ b/cmd/eval_test.go
@@ -176,6 +176,44 @@ func TestEvalCmdHelpIncludesDefaultDatasetPath(t *testing.T) {
 	}
 }
 
+func TestExportedEvalConstructorsReturnFreshCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func() commandNamer
+		want string
+	}{
+		{name: "eval", new: func() commandNamer { return NewEvalCmd() }, want: "eval"},
+		{name: "run", new: func() commandNamer { return NewEvalRunCmd() }, want: "run"},
+		{name: "view", new: func() commandNamer { return NewEvalViewCmd() }, want: "view"},
+		{name: "task", new: func() commandNamer { return NewEvalTaskCmd() }, want: "task"},
+		{name: "task new", new: func() commandNamer { return NewEvalTaskNewCmd() }, want: "new"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := tt.new()
+			second := tt.new()
+			if first == second {
+				t.Fatal("constructor returned the same command instance twice")
+			}
+			if first.Name() != tt.want {
+				t.Fatalf("Name() = %q, want %q", first.Name(), tt.want)
+			}
+			if second.Name() != tt.want {
+				t.Fatalf("second Name() = %q, want %q", second.Name(), tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalRunCmdDoesNotExposeNestedEvalCommands(t *testing.T) {
+	cmd := NewEvalRunCmd()
+
+	if len(cmd.Commands()) != 0 {
+		t.Fatalf("eval run alias should not expose subcommands: got %v", cmd.Commands())
+	}
+}
+
 func TestEvalCmdRejectsMultipleDatasetPaths(t *testing.T) {
 	cmd := evalCmd()
 	cmd.SetArgs([]string{"first", "second"})
@@ -224,6 +262,10 @@ type evalRunnerFunc func([]string) error
 
 func (f evalRunnerFunc) Run(args []string) error {
 	return f(args)
+}
+
+type commandNamer interface {
+	Name() string
 }
 
 func restoreEvalRunner(t *testing.T, fn func(harbor.EvalOptions) evalRunner) {

--- a/cmd/eval_view.go
+++ b/cmd/eval_view.go
@@ -29,7 +29,8 @@ type evalViewOptions struct {
 	stderr      io.Writer
 }
 
-func evalViewCmd() *cobra.Command {
+// NewEvalViewCmd returns the eval jobs dashboard command.
+func NewEvalViewCmd() *cobra.Command {
 	opts := evalViewOptions{
 		stdout: os.Stdout,
 		stderr: os.Stderr,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ func Root() *cobra.Command {
 
 	cmd.AddCommand(codeServerCmd())
 	cmd.AddCommand(environmentCmd())
-	cmd.AddCommand(evalCmd())
+	cmd.AddCommand(NewEvalCmd())
 	cmd.AddCommand(fmtCmd())
 	cmd.AddCommand(harborCmd())
 	cmd.AddCommand(listCmd())


### PR DESCRIPTION
## Summary

- export reusable eval Cobra constructors from the existing `cmd` package
- factor the eval runner command so it can be mounted as a standalone `run` alias
- keep `compare` and `promote` private while exposing `eval`, `run`, `view`, `task`, and `task new` constructors
- add coverage that exported constructors return fresh command instances and that the standalone run alias does not expose nested eval subcommands

## Validation

```sh
go test ./cmd ./internal/harbor
```

Passed.

Also tried:

```sh
go test ./...
```

This hit existing local environment/version fixture failures outside the touched packages (`document`, `document/editor`, `document/editor/editorservice`): UTC timestamp expectations rendered in local `-08:00`, plus version fixture expectations (`v0`/version regex) differing from local output.
