### PR TITLE
feat(harbor): export hidden command group

### DIFF
--- a/cmd/harbor.go
+++ b/cmd/harbor.go
@@ -8,7 +8,8 @@ import (
 	"github.com/runmedev/runme/v3/internal/harbor"
 )
 
-func harborCmd() *cobra.Command {
+// NewHarborCmd returns the hidden Harbor command group.
+func NewHarborCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "harbor",
 		Hidden: true,

--- a/cmd/harbor_test.go
+++ b/cmd/harbor_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 func TestHarborCommandShape(t *testing.T) {
 	root := Root()
@@ -27,5 +31,32 @@ func TestHarborCommandShape(t *testing.T) {
 	}
 	if stdio.Use != "stdio" {
 		t.Fatalf("stdio Use = %q, want stdio", stdio.Use)
+	}
+}
+
+func TestNewHarborCmdReturnsFreshHiddenCommand(t *testing.T) {
+	first := NewHarborCmd()
+	second := NewHarborCmd()
+
+	if first == second {
+		t.Fatal("constructor returned the same command instance twice")
+	}
+	for _, cmd := range []*cobra.Command{first, second} {
+		if cmd.Name() != "harbor" {
+			t.Fatalf("Name() = %q, want harbor", cmd.Name())
+		}
+		if !cmd.Hidden {
+			t.Fatal("harbor command is visible, want hidden")
+		}
+		stdio, _, err := cmd.Find([]string{"stdio"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stdio == nil {
+			t.Fatal("stdio command not found")
+		}
+		if !stdio.Hidden {
+			t.Fatal("stdio command is visible, want hidden")
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,7 +119,7 @@ func Root() *cobra.Command {
 	cmd.AddCommand(environmentCmd())
 	cmd.AddCommand(NewEvalCmd())
 	cmd.AddCommand(fmtCmd())
-	cmd.AddCommand(harborCmd())
+	cmd.AddCommand(NewHarborCmd())
 	cmd.AddCommand(listCmd())
 	cmd.AddCommand(loginCmd())
 	cmd.AddCommand(logoutCmd())


### PR DESCRIPTION
## Summary

- export the existing hidden Harbor command group as `NewHarborCmd()` for downstream CLIs
- keep `runme harbor` and `runme harbor stdio` hidden and behaviorally unchanged
- keep Runme root registration on the same hidden Harbor command group

## Why

Downstream CLIs that reuse Runme eval commands need to register the same hidden `harbor stdio` plumbing command, because Runme eval preflight shells the active binary with `harbor stdio`.

## Validation

```sh
go test ./cmd
runme run test
```

`go test ./cmd` passed. Local `runme run test` reached the Dagger shell script tests and failed because Docker is not reachable at `unix:///Users/sourishkrout/.docker/run/docker.sock`; package output before that showed the touched cmd package passing. GitHub CI covers the Docker-backed path.
